### PR TITLE
Reduce excess notifications the user gets.

### DIFF
--- a/webapp/src/components/rhs/rhs.tsx
+++ b/webapp/src/components/rhs/rhs.tsx
@@ -129,6 +129,7 @@ export default function RHS() {
                 rootPostId={selectedPostId}
                 useRelativeTimestamp={false}
                 isThreadView={false}
+                forceClearNewMessages={true}
             />
         );
     } else if (currentTab === 'threads') {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -146,6 +146,17 @@ export default class Plugin {
         if (registry.registerNewMessagesSeparatorActionComponent) {
             registry.registerNewMessagesSeparatorActionComponent(UnreadsSummarize);
         }
+
+        if (registry.registerDesktopNotificationHook) {
+            registry.registerDesktopNotificationHook((post: { type: string }) => {
+                // Stop all notifications for custom_llmbot posts
+                if (post.type === 'custom_llmbot') {
+                    return {};
+                }
+
+                return null;
+            });
+        }
     }
 }
 


### PR DESCRIPTION
## Description

In a lot of cases the user will get exessive notifications rom the AI bot. The aim of this and the accompanying webapp PR is to reduce those instances.

1. Block ALL notifications client side from AI posts
2. Enable a flag in the thread viewer to automaticly mark AI threads as viewed. 
