### PR TITLE
Fix MCP config conditional rendering and prop naming

### DIFF
--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -96,6 +96,7 @@ const defaultConfig = {
     mcp: {
         enabled: false,
         servers: {},
+        idleTimeout: 30,
     },
 };
 
@@ -160,6 +161,9 @@ const Config = (props: Props) => {
             </ConfigContainer>
         );
     }
+
+    // Initialize with default empty config if not provided
+    const mcpConfig = value.mcp || defaultConfig.mcp;
 
     return (
         <ConfigContainer>
@@ -234,28 +238,30 @@ const Config = (props: Props) => {
                     props.setSaveNeeded();
                 }}
             />
-            <Panel
-                title={
-                    <Horizontal>
-                        <FormattedMessage defaultMessage='Model Context Protocol (MCP)'/>
-                        <Pill><FormattedMessage defaultMessage='EXPERIMENTAL'/></Pill>
-                    </Horizontal>
-                }
-                subtitle={intl.formatMessage({defaultMessage: 'Configure MCP servers to enable AI tools.'})}
-            >
-                <MCPServers
-                    value={value.mcp || defaultConfig.mcp}
-                    onChange={(config) => {
-                        // Ensure we're creating a valid structure for the server configuration
-                        const updatedConfig = {
-                            ...config,
-                            servers: config.servers || {},
-                        };
-                        props.onChange(props.id, {...value, mcp: updatedConfig});
-                        props.setSaveNeeded();
-                    }}
-                />
-            </Panel>
+            {mcpConfig.enabled &&
+                <Panel
+                    title={
+                        <Horizontal>
+                            <FormattedMessage defaultMessage='Model Context Protocol (MCP)'/>
+                            <Pill><FormattedMessage defaultMessage='EXPERIMENTAL'/></Pill>
+                        </Horizontal>
+                    }
+                    subtitle={intl.formatMessage({defaultMessage: 'Configure MCP servers to enable AI tools.'})}
+                >
+                    <MCPServers
+                        mcpConfig={mcpConfig}
+                        onChange={(config) => {
+                            // Ensure we're creating a valid structure for the server configuration
+                            const updatedConfig = {
+                                ...config,
+                                servers: config.servers || {},
+                            };
+                            props.onChange(props.id, {...value, mcp: updatedConfig});
+                            props.setSaveNeeded();
+                        }}
+                    />
+                </Panel>
+            }
         </ConfigContainer>
     );
 };

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -22,7 +22,7 @@ export type MCPConfig = {
 };
 
 type Props = {
-    value: MCPConfig;
+    mcpConfig: MCPConfig;
     onChange: (config: MCPConfig) => void;
 };
 
@@ -198,11 +198,8 @@ const MCPServer = ({
 };
 
 // Main component for MCP servers configuration
-const MCPServers = ({value, onChange}: Props) => {
+const MCPServers = ({mcpConfig, onChange}: Props) => {
     const intl = useIntl();
-
-    // Initialize with default empty config if not provided
-    const mcpConfig = value ? {...value} : {enabled: false, servers: {}, idleTimeout: 30};
 
     // Ensure servers object is initialized
     if (!mcpConfig.servers) {


### PR DESCRIPTION
## Summary
- Only render MCP panel when MCP is enabled
- Fix prop name from `value` to `mcpConfig` for consistency
- Add default idleTimeout value to defaultConfig