### PR TITLE
Add security documentation for interpluginclient permission responsibilities

### DIFF
--- a/interpluginclient/README.md
+++ b/interpluginclient/README.md
@@ -50,6 +50,16 @@ if err != nil {
 }
 ```
 
+## Security Notice
+
+**Important**: The AI plugin's inter-plugin API endpoints do not perform permission checks. The calling plugin is responsible for:
+- Verifying that the user specified in `RequesterUserID` has permission to use the AI features
+- Ensuring the user has access to any data being sent to the AI model
+- Implementing appropriate rate limiting or usage restrictions
+- Validating that the request is authorized for the intended purpose
+
+The AI plugin will process requests on behalf of any user ID provided by the calling plugin, so proper authorization checks are critical.
+
 ## API Documentation
 
 ### Types

--- a/interpluginclient/client.go
+++ b/interpluginclient/client.go
@@ -3,6 +3,10 @@
 
 // Package interpluginclient provides a client for interacting with the Mattermost AI plugin
 // from other Mattermost plugins.
+//
+// Security Notice: The AI plugin's inter-plugin API does not perform permission checks.
+// The calling plugin is responsible for verifying that the user has appropriate permissions
+// before making requests on their behalf.
 package interpluginclient
 
 import (
@@ -70,7 +74,9 @@ type SimpleCompletionResponse struct {
 	Response string `json:"response"`
 }
 
-// CompletionWithContext sends a prompt to the AI plugin with context and returns the generated response
+// SimpleCompletionWithContext sends a prompt to the AI plugin with context and returns the generated response.
+// The calling plugin must ensure that the user specified in RequesterUserID has permission to use AI features
+// and access any data being sent to the AI model.
 func (c *Client) SimpleCompletionWithContext(ctx context.Context, req SimpleCompletionRequest) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -108,7 +114,9 @@ func (c *Client) SimpleCompletionWithContext(ctx context.Context, req SimpleComp
 	return completionResp.Response, nil
 }
 
-// Completion sends a prompt to the AI plugin and returns the generated response (with default timeout)
+// SimpleCompletion sends a prompt to the AI plugin and returns the generated response (with default timeout).
+// The calling plugin must ensure that the user specified in RequesterUserID has permission to use AI features
+// and access any data being sent to the AI model.
 func (c *Client) SimpleCompletion(req SimpleCompletionRequest) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Added security notice to interpluginclient README explaining that calling plugins are responsible for permission checks
- Updated package and method documentation in client.go to reinforce this security requirement
- Makes it clear that the AI plugin's inter-plugin API does not perform authorization checks