### PR TITLE
Fix panic when checking empty choices slice in OpenAI streaming

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -316,6 +316,10 @@ func (s *OpenAI) streamResultToChannels(request openaiClient.ChatCompletionReque
 		// Ping the watchdog when we receive a response
 		watchdog <- struct{}{}
 
+		if len(response.Choices) == 0 {
+			continue
+		}
+
 		delta := response.Choices[0].Delta
 		numTools := len(delta.ToolCalls)
 
@@ -336,10 +340,6 @@ func (s *OpenAI) streamResultToChannels(request openaiClient.ChatCompletionReque
 				toolsBuffer[toolIndex].args.WriteString(toolCall.Function.Arguments)
 				toolsBuffer[toolIndex].id.WriteString(toolCall.ID)
 			}
-		}
-
-		if len(response.Choices) == 0 {
-			continue
 		}
 
 		// Check finishing conditions


### PR DESCRIPTION
## Summary
- Fixed a bug where `response.Choices[0]` was accessed before checking if the choices slice is empty
- Moved the length check before any access to the choices slice to prevent panic