### PR TITLE
[MM-64686] Log LLM token usage tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ server/manifest.go
 evals.jsonl
 go.work
 go.work.sum
+*.log
 
 .claude/settings.local.json
 
@@ -23,3 +24,6 @@ go.work.sum
 
 # notice
 .notice-work
+
+# Emacs/Vi
+*~

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -245,6 +245,16 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 		}
 	}
 
+	// Extract and send token usage data
+	usage := llm.TokenUsage{
+		InputTokens:  int(message.Usage.InputTokens),
+		OutputTokens: int(message.Usage.OutputTokens),
+	}
+	state.output <- llm.TextStreamEvent{
+		Type:  llm.EventTypeUsage,
+		Value: usage,
+	}
+
 	// Send end event
 	state.output <- llm.TextStreamEvent{
 		Type:  llm.EventTypeEnd,

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -159,13 +159,17 @@ func (b *MMBots) UpdateBotsCache(cfgBots []llm.BotConfig) error {
 	}
 
 	for _, bot := range b.bots {
-		bot.llm = b.getLLM(bot.cfg.Service)
+		var err error
+		bot.llm, err = b.getLLM(bot.cfg.Service, bot.cfg.Name)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig) llm.LanguageModel {
+func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig, botName string) (llm.LanguageModel, error) {
 	// Create the correct model
 	var result llm.LanguageModel
 	switch serviceConfig.Type {
@@ -188,13 +192,18 @@ func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig) llm.LanguageModel {
 
 	// Truncation Support
 	result = llm.NewLLMTruncationWrapper(result)
+	var err error
+	result, err = llm.NewTokenLoggingWrapper(result, botName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Logging
 	if b.config.EnableLLMLogging() {
 		result = llm.NewLanguageModelLogWrapper(b.pluginAPI.Log, result)
 	}
 
-	return result
+	return result, nil
 }
 
 // TODO: This really doesn't belong here. Figure out where to put this.

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -17,7 +17,15 @@ const (
 	EventTypeError
 	// EventTypeToolCalls represents a tool call event
 	EventTypeToolCalls
+	// EventTypeUsage represents token usage data
+	EventTypeUsage
 )
+
+// TokenUsage represents token usage statistics for an LLM request
+type TokenUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
 
 // TextStreamEvent represents an event in the text stream
 type TextStreamEvent struct {

--- a/llm/token_tracking.go
+++ b/llm/token_tracking.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package llm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// TokenTrackingWrapper wraps a LanguageModel to track token usage in the database
+type TokenTrackingWrapper struct {
+	wrapped     LanguageModel
+	botUsername string
+	tokenLogger *mlog.Logger
+}
+
+// NewTokenLoggingWrapper creates a new wrapper that tracks token usage
+func NewTokenLoggingWrapper(wrapped LanguageModel, botUsername string) (*TokenTrackingWrapper, error) {
+	tokenLogger, err := createTokenLogger()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token tracking wrapper: %w", err)
+	}
+	return &TokenTrackingWrapper{
+		wrapped:     wrapped,
+		botUsername: botUsername,
+		tokenLogger: tokenLogger,
+	}, nil
+}
+
+// createTokenLogger creates a dedicated logger for token usage metrics
+func createTokenLogger() (*mlog.Logger, error) {
+	logger, err := mlog.NewLogger()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token logger: %w", err)
+	}
+
+	jsonTargetCfg := mlog.TargetCfg{
+		Type:   "file",
+		Format: "json",
+		Levels: []mlog.Level{mlog.LvlInfo, mlog.LvlDebug},
+	}
+	jsonFileOptions := map[string]interface{}{
+		"filename": "token_usage.log",
+	}
+	jsonOptions, err := json.Marshal(jsonFileOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal json file options: %w", err)
+	}
+	jsonTargetCfg.Options = json.RawMessage(jsonOptions)
+
+	err = logger.ConfigureTargets(map[string]mlog.TargetCfg{
+		"token_usage": jsonTargetCfg,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure token logger targets: %w", err)
+	}
+
+	return logger, nil
+}
+
+// ChatCompletion intercepts the streaming response to extract and track token usage
+func (w *TokenTrackingWrapper) ChatCompletion(request CompletionRequest, opts ...LanguageModelOption) (*TextStreamResult, error) {
+	result, err := w.wrapped.ChatCompletion(request, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if w.tokenLogger == nil {
+		return nil, errors.New("token logger is nil")
+	}
+
+	interceptedStream := make(chan TextStreamEvent)
+
+	go func() {
+		defer close(interceptedStream)
+
+		for event := range result.Stream {
+			if event.Type != EventTypeUsage {
+				interceptedStream <- event
+				continue
+			}
+
+			usage, ok := event.Value.(TokenUsage)
+			if !ok {
+				continue
+			}
+
+			userID := "unknown"
+			teamID := "unknown"
+			if request.Context != nil {
+				if request.Context.RequestingUser != nil {
+					userID = request.Context.RequestingUser.Id
+				}
+				if request.Context.Team != nil {
+					teamID = request.Context.Team.Id
+				}
+			}
+
+			w.tokenLogger.Info("Token Usage",
+				mlog.String("user_id", userID),
+				mlog.String("team_id", teamID),
+				mlog.String("bot_username", w.botUsername),
+				mlog.Int("input_tokens", usage.InputTokens),
+				mlog.Int("output_tokens", usage.OutputTokens),
+				mlog.Int("total_tokens", usage.InputTokens+usage.OutputTokens),
+			)
+		}
+	}()
+
+	return &TextStreamResult{Stream: interceptedStream}, nil
+}
+
+// ChatCompletionNoStream uses the streaming method internally, so token tracking
+// happens automatically when ReadAll() processes the intercepted stream
+func (w *TokenTrackingWrapper) ChatCompletionNoStream(request CompletionRequest, opts ...LanguageModelOption) (string, error) {
+	result, err := w.ChatCompletion(request, opts...)
+	if err != nil {
+		return "", err
+	}
+	return result.ReadAll()
+}
+
+// CountTokens delegates to the wrapped model
+func (w *TokenTrackingWrapper) CountTokens(text string) int {
+	return w.wrapped.CountTokens(text)
+}
+
+// InputTokenLimit delegates to the wrapped model
+func (w *TokenTrackingWrapper) InputTokenLimit() int {
+	return w.wrapped.InputTokenLimit()
+}

--- a/llm/token_tracking_test.go
+++ b/llm/token_tracking_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package llm
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// MockLanguageModel is a mock implementation of the LanguageModel interface
+type MockLanguageModel struct {
+	mock.Mock
+}
+
+func (m *MockLanguageModel) ChatCompletion(request CompletionRequest, opts ...LanguageModelOption) (*TextStreamResult, error) {
+	args := m.Called(request, opts)
+	return args.Get(0).(*TextStreamResult), args.Error(1)
+}
+
+func (m *MockLanguageModel) ChatCompletionNoStream(request CompletionRequest, opts ...LanguageModelOption) (string, error) {
+	args := m.Called(request, opts)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockLanguageModel) CountTokens(text string) int {
+	args := m.Called(text)
+	return args.Int(0)
+}
+
+func (m *MockLanguageModel) InputTokenLimit() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+func TestTokenTrackingWrapper_ChatCompletion(t *testing.T) {
+	t.Run("filters usage events from stream", func(t *testing.T) {
+		mockLLM := &MockLanguageModel{}
+		wrapper, _ := NewTokenLoggingWrapper(mockLLM, "test-bot")
+
+		// Create a mock stream with usage event
+		mockStream := make(chan TextStreamEvent, 3)
+		mockStream <- TextStreamEvent{Type: EventTypeText, Value: "Hello"}
+		mockStream <- TextStreamEvent{Type: EventTypeUsage, Value: TokenUsage{InputTokens: 10, OutputTokens: 5}}
+		mockStream <- TextStreamEvent{Type: EventTypeEnd, Value: nil}
+		close(mockStream)
+
+		mockResult := &TextStreamResult{Stream: mockStream}
+		mockLLM.On("ChatCompletion", mock.Anything, mock.Anything).Return(mockResult, nil)
+
+		request := CompletionRequest{
+			Context: &Context{
+				RequestingUser: &model.User{Id: "user123"},
+				Team:           &model.Team{Id: "team456"},
+			},
+		}
+
+		result, err := wrapper.ChatCompletion(request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Read all events from the intercepted stream
+		var events []TextStreamEvent
+		for event := range result.Stream {
+			events = append(events, event)
+		}
+
+		// Should have forwarded text and end events, but not usage event
+		require.Len(t, events, 2)
+		assert.Equal(t, EventTypeText, events[0].Type)
+		assert.Equal(t, "Hello", events[0].Value)
+		assert.Equal(t, EventTypeEnd, events[1].Type)
+
+		mockLLM.AssertExpectations(t)
+	})
+
+	t.Run("handles nil context gracefully", func(t *testing.T) {
+		mockLLM := &MockLanguageModel{}
+		wrapper, _ := NewTokenLoggingWrapper(mockLLM, "test-bot")
+
+		mockStream := make(chan TextStreamEvent, 2)
+		mockStream <- TextStreamEvent{Type: EventTypeUsage, Value: TokenUsage{InputTokens: 10, OutputTokens: 5}}
+		mockStream <- TextStreamEvent{Type: EventTypeEnd, Value: nil}
+		close(mockStream)
+
+		mockResult := &TextStreamResult{Stream: mockStream}
+		mockLLM.On("ChatCompletion", mock.Anything, mock.Anything).Return(mockResult, nil)
+
+		request := CompletionRequest{Context: &Context{}}
+		result, err := wrapper.ChatCompletion(request)
+		require.NoError(t, err)
+
+		// Should complete without panic even with nil context
+		var events []TextStreamEvent
+		for event := range result.Stream {
+			events = append(events, event)
+		}
+
+		assert.Len(t, events, 1) // Only end event forwarded
+		assert.Equal(t, EventTypeEnd, events[0].Type)
+
+		mockLLM.AssertExpectations(t)
+	})
+
+	t.Run("handles invalid usage event value", func(t *testing.T) {
+		mockLLM := &MockLanguageModel{}
+		wrapper, _ := NewTokenLoggingWrapper(mockLLM, "test-bot")
+
+		mockStream := make(chan TextStreamEvent, 2)
+		mockStream <- TextStreamEvent{Type: EventTypeUsage, Value: "invalid_value"}
+		mockStream <- TextStreamEvent{Type: EventTypeEnd, Value: nil}
+		close(mockStream)
+
+		mockResult := &TextStreamResult{Stream: mockStream}
+		mockLLM.On("ChatCompletion", mock.Anything, mock.Anything).Return(mockResult, nil)
+
+		request := CompletionRequest{Context: &Context{}}
+		result, err := wrapper.ChatCompletion(request)
+		require.NoError(t, err)
+
+		// Should complete without calling metrics (invalid value ignored)
+		var events []TextStreamEvent
+		for event := range result.Stream {
+			events = append(events, event)
+		}
+
+		assert.Len(t, events, 1) // Only end event forwarded
+		mockLLM.AssertExpectations(t)
+	})
+}
+
+func TestTokenTrackingWrapper_ChatCompletionNoStream(t *testing.T) {
+	t.Run("delegates to streaming method", func(t *testing.T) {
+		mockLLM := &MockLanguageModel{}
+		wrapper, _ := NewTokenLoggingWrapper(mockLLM, "test-bot")
+
+		mockStream := make(chan TextStreamEvent, 3)
+		mockStream <- TextStreamEvent{Type: EventTypeText, Value: "Hello world"}
+		mockStream <- TextStreamEvent{Type: EventTypeUsage, Value: TokenUsage{InputTokens: 5, OutputTokens: 10}}
+		mockStream <- TextStreamEvent{Type: EventTypeEnd, Value: nil}
+		close(mockStream)
+
+		mockResult := &TextStreamResult{Stream: mockStream}
+		mockLLM.On("ChatCompletion", mock.Anything, mock.Anything).Return(mockResult, nil)
+
+		request := CompletionRequest{Context: &Context{}}
+		result, err := wrapper.ChatCompletionNoStream(request)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello world", result)
+
+		mockLLM.AssertExpectations(t)
+	})
+}
+
+func TestTokenTrackingWrapper_DelegatedMethods(t *testing.T) {
+	mockLLM := &MockLanguageModel{}
+	wrapper, _ := NewTokenLoggingWrapper(mockLLM, "test-llm")
+
+	t.Run("CountTokens delegates to wrapped model", func(t *testing.T) {
+		mockLLM.On("CountTokens", "test text").Return(42)
+
+		result := wrapper.CountTokens("test text")
+		assert.Equal(t, 42, result)
+
+		mockLLM.AssertExpectations(t)
+	})
+
+	t.Run("InputTokenLimit delegates to wrapped model", func(t *testing.T) {
+		mockLLM.On("InputTokenLimit").Return(4096)
+
+		result := wrapper.InputTokenLimit()
+		assert.Equal(t, 4096, result)
+
+		mockLLM.AssertExpectations(t)
+	})
+}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -244,6 +244,10 @@ type ToolBufferElement struct {
 
 func (s *OpenAI) streamResultToChannels(request openaiClient.ChatCompletionRequest, llmContext *llm.Context, output chan<- llm.TextStreamEvent) {
 	request.Stream = true
+	// Enable usage tracking in streaming
+	request.StreamOptions = &openaiClient.StreamOptions{
+		IncludeUsage: true,
+	}
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
@@ -316,6 +320,18 @@ func (s *OpenAI) streamResultToChannels(request openaiClient.ChatCompletionReque
 		// Ping the watchdog when we receive a response
 		watchdog <- struct{}{}
 
+		// Check for usage data and emit usage event if available
+		if response.Usage != nil {
+			usage := llm.TokenUsage{
+				InputTokens:  response.Usage.PromptTokens,
+				OutputTokens: response.Usage.CompletionTokens,
+			}
+			output <- llm.TextStreamEvent{
+				Type:  llm.EventTypeUsage,
+				Value: usage,
+			}
+		}
+
 		if len(response.Choices) == 0 {
 			continue
 		}
@@ -347,11 +363,9 @@ func (s *OpenAI) streamResultToChannels(request openaiClient.ChatCompletionReque
 		case "":
 			// Not done yet, keep going
 		case openaiClient.FinishReasonStop:
-			output <- llm.TextStreamEvent{
-				Type:  llm.EventTypeEnd,
-				Value: nil,
-			}
-			return
+			// Continue processing to get usage data, but don't send more text
+			// The EventTypeEnd will be sent when we get EOF
+			continue
 		case openaiClient.FinishReasonToolCalls:
 			// Verify OpenAI functions are not recursing too deep.
 			numFunctionCalls := 0


### PR DESCRIPTION
#### Summary
The changes in this branch implement LLM token usage tracking that can be used to track the costs of AI interactions within the Mattermost agents plugin. This addresses the need to monitor and measure resource consumption across different language models. The implementation captures detailed token usage metrics including input tokens, output tokens, model types, and associated bot identities.

The structured logging format allows organizations to import these logs into their existing reporting and aggregation tools for comprehensive cost analysis and budget management.

#### Supported Providers
This change only supports Anthropic and OpenAI backends.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64686

#### Output Details
Token usage is logged to `token_usage.log` with content like the following:
```
{"timestamp":"2025-09-17 16:16:45.479 -04:00","level":"info","msg":"Token Usage","user_id":"iac1dy16n7bi7ycwhg5wfg4dac","team_id":"6y8ixw7tr3yztjgk3hip87bjuh","bot_username":"matty","input_tokens":416,"output_tokens":3,"total_tokens":419}
{"timestamp":"2025-09-17 16:16:48.957 -04:00","level":"info","msg":"Token Usage","user_id":"iac1dy16n7bi7ycwhg5wfg4dac","team_id":"6y8ixw7tr3yztjgk3hip87bjuh","bot_username":"matty","input_tokens":34,"output_tokens":5,"total_tokens":39}
```