### PR TITLE
WIP: [MM-65973] Reasoning support for Anthropic

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	anthropicSDK "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -33,10 +34,11 @@ type messageState struct {
 }
 
 type Anthropic struct {
-	client           anthropicSDK.Client
-	defaultModel     string
-	inputTokenLimit  int
-	outputTokenLimit int
+	client             anthropicSDK.Client
+	defaultModel       string
+	inputTokenLimit    int
+	outputTokenLimit   int
+	enabledNativeTools []string
 }
 
 func New(llmService llm.ServiceConfig, httpClient *http.Client) *Anthropic {
@@ -46,10 +48,11 @@ func New(llmService llm.ServiceConfig, httpClient *http.Client) *Anthropic {
 	)
 
 	return &Anthropic{
-		client:           client,
-		defaultModel:     llmService.DefaultModel,
-		inputTokenLimit:  llmService.InputTokenLimit,
-		outputTokenLimit: llmService.OutputTokenLimit,
+		client:             client,
+		defaultModel:       llmService.DefaultModel,
+		inputTokenLimit:    llmService.InputTokenLimit,
+		outputTokenLimit:   llmService.OutputTokenLimit,
+		enabledNativeTools: llmService.EnabledNativeTools,
 	}
 }
 
@@ -190,9 +193,42 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 		}},
 		Tools: convertTools(state.tools),
 	}
+
+	// Add native tools if enabled
+	if a.isNativeToolEnabled("web_search") {
+		// Add web search as a native tool
+		webSearchTool := anthropicSDK.WebSearchTool20250305Param{
+			Name: "web_search",
+			Type: "web_search_20250305",
+		}
+		params.Tools = append(params.Tools, anthropicSDK.ToolUnionParam{
+			OfWebSearchTool20250305: &webSearchTool,
+		})
+	}
+
+	// Enable thinking/reasoning for models that support it
+	// We'll allocate a reasonable budget for thinking tokens (1/4 of max tokens, capped at 8192)
+	thinkingBudget := int64(state.config.MaxGeneratedTokens / 4)
+	if thinkingBudget > 8192 {
+		thinkingBudget = 8192
+	}
+	if thinkingBudget < 1024 {
+		thinkingBudget = 1024
+	}
+
+	params.Thinking = anthropicSDK.ThinkingConfigParamUnion{
+		OfEnabled: &anthropicSDK.ThinkingConfigEnabledParam{
+			Type:         "enabled",
+			BudgetTokens: thinkingBudget,
+		},
+	}
+
 	stream := a.client.Messages.NewStreaming(context.Background(), params)
 
 	message := anthropicSDK.Message{}
+	var thinkingBuffer strings.Builder
+	var isThinkingComplete bool
+
 	for stream.Next() {
 		event := stream.Current()
 		if err := message.Accumulate(event); err != nil {
@@ -203,7 +239,7 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 			return
 		}
 
-		// Stream text content immediately
+		// Stream text and thinking content immediately
 		switch eventVariant := event.AsAny().(type) { //nolint:gocritic
 		case anthropicSDK.ContentBlockDeltaEvent:
 			switch deltaVariant := eventVariant.Delta.AsAny().(type) { //nolint:gocritic
@@ -212,6 +248,25 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 					Type:  llm.EventTypeText,
 					Value: deltaVariant.Text,
 				}
+			case anthropicSDK.ThinkingDelta:
+				// Accumulate thinking text
+				thinkingBuffer.WriteString(deltaVariant.Thinking)
+				// Stream thinking chunks as they arrive
+				state.output <- llm.TextStreamEvent{
+					Type:  llm.EventTypeReasoning,
+					Value: deltaVariant.Thinking,
+				}
+			}
+
+		case anthropicSDK.ContentBlockStopEvent:
+			// Check if this is the end of a thinking block
+			if thinkingBuffer.Len() > 0 && !isThinkingComplete {
+				// Send the complete thinking/reasoning
+				state.output <- llm.TextStreamEvent{
+					Type:  llm.EventTypeReasoningEnd,
+					Value: thinkingBuffer.String(),
+				}
+				isThinkingComplete = true
 			}
 		}
 	}
@@ -222,6 +277,15 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 			Value: fmt.Errorf("error from anthropic stream: %w", err),
 		}
 		return
+	}
+
+	// If we haven't sent the complete thinking yet, send it now before processing tool calls
+	if !isThinkingComplete && thinkingBuffer.Len() > 0 {
+		state.output <- llm.TextStreamEvent{
+			Type:  llm.EventTypeReasoningEnd,
+			Value: thinkingBuffer.String(),
+		}
+		isThinkingComplete = true
 	}
 
 	// Check for tool usage in the message
@@ -314,4 +378,14 @@ func (a *Anthropic) InputTokenLimit() int {
 		return a.inputTokenLimit
 	}
 	return 100000
+}
+
+// isNativeToolEnabled checks if a specific native tool is enabled in the configuration
+func (a *Anthropic) isNativeToolEnabled(toolName string) bool {
+	for _, enabledTool := range a.enabledNativeTools {
+		if enabledTool == toolName {
+			return true
+		}
+	}
+	return false
 }

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -229,16 +229,20 @@ const Horizontal = styled.div`
 type NativeToolsItemProps = {
     enabledTools: string[]
     onChange: (tools: string[]) => void
+    provider?: 'openai' | 'anthropic'
 }
 
 const NativeToolsItem = (props: NativeToolsItemProps) => {
     const intl = useIntl();
+    const provider = props.provider || 'openai';
 
     const availableNativeTools = [
         {
             id: 'web_search',
             label: intl.formatMessage({defaultMessage: 'Web Search'}),
-            helpText: intl.formatMessage({defaultMessage: 'Enable OpenAI\'s built-in web search capability'}),
+            helpText: provider === 'anthropic' ?
+                intl.formatMessage({defaultMessage: 'Enable Claude\'s built-in web search capability'}) :
+                intl.formatMessage({defaultMessage: 'Enable OpenAI\'s built-in web search capability'}),
         },
 
     ];
@@ -252,11 +256,15 @@ const NativeToolsItem = (props: NativeToolsItemProps) => {
         }
     };
 
+    const titleMessage = provider === 'anthropic' ?
+        intl.formatMessage({defaultMessage: 'Native Claude Tools'}) :
+        intl.formatMessage({defaultMessage: 'Native OpenAI Tools'});
+
     return (
         <>
             <ItemLabel>
                 <Horizontal>
-                    <FormattedMessage defaultMessage='Native OpenAI Tools'/>
+                    {titleMessage}
                     <Pill><FormattedMessage defaultMessage='EXPERIMENTAL'/></Pill>
                 </Horizontal>
             </ItemLabel>
@@ -341,11 +349,19 @@ const ServiceItem = (props: ServiceItemProps) => {
                                 <NativeToolsItem
                                     enabledTools={props.service.enabledNativeTools || []}
                                     onChange={(tools: string[]) => props.onChange({...props.service, enabledNativeTools: tools})}
+                                    provider='openai'
                                 />
                             )}
                         </>
                     )}
                 </>
+            )}
+            {type === 'anthropic' && (
+                <NativeToolsItem
+                    enabledTools={props.service.enabledNativeTools || []}
+                    onChange={(tools: string[]) => props.onChange({...props.service, enabledNativeTools: tools})}
+                    provider='anthropic'
+                />
             )}
             <TextItem
                 label={intl.formatMessage({defaultMessage: 'Default model'})}


### PR DESCRIPTION

#### Summary
This PR is pointing at the branch here: https://github.com/mattermost/mattermost-plugin-agents/pull/387 which initially introduced general reasoning support for OpenAI and OpenAI compatible API's. 

This PR introduces the same support, but for Anthropic. It does not change the front-end other than to also add support for the web search native tool. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65973
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Support for reasoning models in Anthropic
Support for Web Search native tool in Anthropic
```
