### PR TITLE
[MM-65734] Fix MCP Header entry

### DIFF
--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -103,7 +103,7 @@ const MCPServer = ({
         const headers = {...(config.headers || {})};
 
         // If the key has changed, remove the old one
-        if (oldKey !== newKey && oldKey !== '') {
+        if (oldKey !== newKey) {
             delete headers[oldKey];
         }
 
@@ -194,8 +194,8 @@ const MCPServer = ({
                 </HeadersSectionTitle>
 
                 <HeadersList>
-                    {Object.entries(config.headers || {}).map(([key, value]) => (
-                        <HeaderRow key={key}>
+                    {Object.entries(config.headers || {}).map(([key, value], index) => (
+                        <HeaderRow key={index}>
                             <HeaderInput
                                 placeholder={intl.formatMessage({defaultMessage: 'Header name'})}
                                 value={key}


### PR DESCRIPTION
#### Summary
When typing into the Header Name field whilst adding an HTTP header to an MCP Server, each character would cause a new entry in the headers array to be created, with that letter as the header name. This PR fixes it so that entry is correct.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65734

#### Screenshots
Before:
<img width="970" height="614" alt="image" src="https://github.com/user-attachments/assets/7e859c28-28cc-4b90-96af-cb26a3228a91" />


After:
<img width="965" height="544" alt="image" src="https://github.com/user-attachments/assets/24ae1bf4-7679-4a4a-82c1-b30d8d612673" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
