### PR TITLE
WIP: Add tests for the embedded mcp server

### DIFF
--- a/mcp/client_integration_test.go
+++ b/mcp/client_integration_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_CreateClient tests creating a client and verifying its properties
+func TestClient_CreateClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Verify client was created with correct properties
+	assert.NotNil(t, client.session, "Client should have a session")
+	assert.NotEmpty(t, client.Tools(), "Client should have tools")
+	assert.Equal(t, user.Id, client.userID, "Client should have correct user ID")
+	assert.Equal(t, session.Id, client.sessionID, "Client should have correct session ID")
+}
+
+// TestClient_CreateClient_InvalidSession tests session validation in CreateClient
+func TestClient_CreateClient_InvalidSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+	user, _ := suite.CreateUserAndSession(t)
+
+	// Create mock plugin API WITHOUT adding the session (so Get will fail)
+	mockPluginAPI := newMockPluginAPI()
+
+	// Create a real pluginapi.Client to get a proper LogService
+	pluginAPIClient := pluginapi.NewClient(mockPluginAPI, nil)
+
+	// Create wrapper
+	wrapper := &embeddedServerWrapper{
+		server: suite.embeddedServer,
+		api:    mockPluginAPI,
+	}
+
+	// Create embedded server client
+	embeddedClient := NewEmbeddedServerClient(wrapper, pluginAPIClient.Log, pluginAPIClient)
+
+	// Attempt to create client with invalid session - should fail
+	_, err := embeddedClient.CreateClient(ctx, user.Id, "invalid-session-id")
+	require.Error(t, err, "Should fail with invalid session")
+	assert.Contains(t, err.Error(), "session", "Error should mention session issue")
+}
+
+// TestClient_CallTool_ReadChannel tests the Client.CallTool() method with proper output validation
+func TestClient_CallTool_ReadChannel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	// Setup test data
+	user, session := suite.CreateUserAndSession(t)
+	teams, _, err := suite.adminClient.GetTeamsForUser(ctx, user.Id, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+
+	channel := suite.CreateChannel(t, teams[0].Id, user.Id)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Call tool
+	result, err := client.CallTool(ctx, "read_channel", map[string]any{
+		"channel_id": channel.Id,
+	})
+	require.NoError(t, err, "CallTool should succeed")
+
+	// Validate output content based on what read_channel tool returns
+	assert.NotEmpty(t, result, "Result should not be empty")
+	assert.Contains(t, result, "Found", "Result should contain 'Found' (part of output format)")
+	assert.Contains(t, result, "posts in channel", "Result should mention posts in channel")
+
+	t.Logf("Tool result:\n%s", result)
+}
+
+// TestClient_CallTool_SearchUsers tests search_users with output validation
+func TestClient_CallTool_SearchUsers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Call tool
+	result, err := client.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "CallTool should succeed")
+
+	// Validate output content
+	assert.NotEmpty(t, result, "Result should not be empty")
+	assert.Contains(t, result, user.Username, "Result should contain username")
+	assert.Contains(t, result, user.Email, "Result should contain email")
+
+	t.Logf("Search results:\n%s", result)
+}
+
+// TestClient_CallTool_ReadPost tests read_post with proper output validation
+func TestClient_CallTool_ReadPost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	// Setup test data
+	user, session := suite.CreateUserAndSession(t)
+	teams, _, err := suite.adminClient.GetTeamsForUser(ctx, user.Id, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+
+	channel := suite.CreateChannel(t, teams[0].Id, user.Id)
+	testMessage := "Test message content for validation"
+	post := suite.CreatePost(t, channel.Id, user.Id, testMessage)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Call tool
+	result, err := client.CallTool(ctx, "read_post", map[string]any{
+		"post_id": post.Id,
+	})
+	require.NoError(t, err, "CallTool should succeed")
+
+	// Validate output content
+	assert.NotEmpty(t, result, "Result should not be empty")
+	assert.Contains(t, result, post.Id, "Result should contain post ID")
+	assert.Contains(t, result, testMessage, "Result should contain post message")
+	// Note: Post was created by admin client, so author will be "admin"
+	assert.Contains(t, result, "admin", "Result should contain author username (admin)")
+
+	t.Logf("Post content:\n%s", result)
+}
+
+// TestClient_CallTool_InvalidToolName tests error handling for non-existent tools
+func TestClient_CallTool_InvalidToolName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Call non-existent tool
+	_, err := client.CallTool(ctx, "non_existent_tool", map[string]any{})
+	require.Error(t, err, "Should fail with non-existent tool")
+}
+
+// TestClient_CallTool_InvalidArguments tests error handling for invalid arguments
+func TestClient_CallTool_InvalidArguments(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Call tool with missing required argument
+	result, err := client.CallTool(ctx, "read_channel", map[string]any{
+		// Missing channel_id
+	})
+
+	// Tool might return error or error content
+	if err != nil {
+		assert.Contains(t, err.Error(), "channel_id", "Error should mention missing channel_id")
+	} else {
+		// Some tools return error content instead of error
+		assert.Contains(t, strings.ToLower(result), "channel_id", "Result should mention missing channel_id")
+	}
+}
+
+// TestClient_Reconnection tests the automatic reconnection logic in Client.CallTool()
+func TestClient_Reconnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// First call should work
+	result1, err := client.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "First call should succeed")
+	assert.Contains(t, result1, user.Username, "First result should contain username")
+
+	// Close the underlying session to simulate connection loss
+	client.session.Close()
+
+	// Second call should automatically reconnect and succeed
+	// This tests the reconnection logic in Client.CallTool()
+	result2, err := client.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "Second call should succeed after reconnection")
+	assert.Contains(t, result2, user.Username, "Second result should contain username")
+
+	t.Log("Successfully reconnected and executed tool after connection loss")
+}
+
+// TestClient_Tools tests that Client.Tools() returns the correct tool list
+func TestClient_Tools(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create client
+	client := suite.CreateClient(t, user, session)
+	defer client.Close()
+
+	// Get tools using Client.Tools() method
+	tools := client.Tools()
+	require.NotEmpty(t, tools, "Should have tools")
+
+	// Verify expected tools are present
+	expectedTools := []string{
+		"read_channel",
+		"get_channel_info",
+		"search_posts",
+		"search_users",
+		"read_post",
+	}
+
+	toolNames := make(map[string]bool)
+	for name := range tools {
+		toolNames[name] = true
+	}
+
+	for _, expected := range expectedTools {
+		assert.True(t, toolNames[expected], "Should have tool: %s", expected)
+	}
+
+	// Verify each tool has proper metadata
+	for name, tool := range tools {
+		assert.NotEmpty(t, tool.Description, "Tool %s should have description", name)
+		assert.NotNil(t, tool.InputSchema, "Tool %s should have input schema", name)
+	}
+}
+
+// TestClientManager_GetToolsForUser tests the ClientManager.GetToolsForUser() method
+func TestClientManager_GetToolsForUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create ClientManager
+	manager := suite.CreateClientManager(t, session)
+	defer manager.Close()
+
+	// Call GetToolsForUser
+	tools, errors := manager.GetToolsForUser(user.Id, session.Id)
+
+	// Should succeed with no errors
+	assert.Nil(t, errors, "Should have no errors")
+	require.NotEmpty(t, tools, "Should have tools")
+
+	// Verify tools structure (llm.Tool format)
+	for _, tool := range tools {
+		assert.NotEmpty(t, tool.Name, "Tool should have name")
+		assert.NotEmpty(t, tool.Description, "Tool should have description")
+		assert.NotNil(t, tool.Schema, "Tool should have schema")
+		assert.NotNil(t, tool.Resolver, "Tool should have resolver function")
+	}
+
+	t.Logf("GetToolsForUser returned %d tools", len(tools))
+}

--- a/mcp/embedded_server_test.go
+++ b/mcp/embedded_server_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbeddedServer_InvalidSession tests that invalid session IDs are properly rejected
+func TestEmbeddedServer_InvalidSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	user, _ := suite.CreateUserAndSession(t)
+
+	// Create token resolver that rejects all session IDs
+	tokenResolver := func(sessionID string) (string, error) {
+		return "", fmt.Errorf("invalid session ID")
+	}
+
+	// Attempt to create connection with invalid session resolver
+	_, err := suite.embeddedServer.CreateConnectionForUser(
+		user.Id,
+		"invalid-session-id",
+		tokenResolver,
+	)
+
+	// Should fail during session validation
+	require.Error(t, err, "Should reject invalid session")
+	assert.Contains(t, err.Error(), "invalid session", "Error should mention invalid session")
+}
+
+// TestEmbeddedServer_MissingSessionToken tests that missing/empty session tokens are rejected at connection time
+func TestEmbeddedServer_MissingSessionToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create token resolver that returns empty token
+	tokenResolver := func(sessionID string) (string, error) {
+		if sessionID == session.Id {
+			return "", nil // Empty token
+		}
+		return "", fmt.Errorf("unknown session")
+	}
+
+	// Create connection - should FAIL because validation happens at connection time
+	// When a sessionID and tokenResolver are provided, CreateConnectionForUser validates
+	// the session immediately by calling GetMe() which will fail with an empty token
+	_, err := suite.embeddedServer.CreateConnectionForUser(
+		user.Id,
+		session.Id,
+		tokenResolver,
+	)
+	require.Error(t, err, "Connection creation should fail with empty token")
+	assert.Contains(t, err.Error(), "invalid session token", "Error should mention invalid session")
+}
+
+// TestEmbeddedServer_MultipleConnectionsPerUser tests that a user can have multiple concurrent connections
+func TestEmbeddedServer_MultipleConnectionsPerUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Create two connections for the same user
+	client1 := suite.CreateClient(t, user, session)
+	defer client1.Close()
+
+	client2 := suite.CreateClient(t, user, session)
+	defer client2.Close()
+
+	// Both clients should be able to call tools independently
+	result1, err := client1.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "First client should work")
+	assert.NotEmpty(t, result1)
+	assert.Contains(t, result1, user.Username)
+
+	result2, err := client2.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "Second client should work")
+	assert.NotEmpty(t, result2)
+	assert.Contains(t, result2, user.Username)
+}
+
+// TestEmbeddedServer_SessionLifecycle tests the full lifecycle of a session connection
+// including auto-reconnect behavior
+func TestEmbeddedServer_SessionLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// 1. Create connection
+	client := suite.CreateClient(t, user, session)
+	require.NotNil(t, client, "Client should be created")
+
+	// 2. Use connection
+	result, err := client.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "Tool call should work")
+	assert.NotEmpty(t, result)
+	assert.Contains(t, result, user.Username)
+
+	// 3. Close connection
+	err = client.Close()
+	require.NoError(t, err, "Close should succeed")
+
+	// 4. Verify auto-reconnect behavior - embedded clients automatically reconnect
+	// This is by design in client.go lines 263-278: when ErrConnectionClosed is detected,
+	// the client reconnects using the stored embeddedClient and sessionID
+	result2, err := client.CallTool(ctx, "search_users", map[string]any{
+		"term": user.Username,
+	})
+	require.NoError(t, err, "Tool call should succeed after auto-reconnect")
+	assert.NotEmpty(t, result2)
+	assert.Contains(t, result2, user.Username)
+
+	t.Log("Successfully verified auto-reconnect behavior for embedded client")
+}
+
+// TestEmbeddedServer_TokenResolverCalledAsNeeded tests that the token resolver is called appropriately
+func TestEmbeddedServer_TokenResolverCalledAsNeeded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	suite := SetupEmbeddedTestSuite(t)
+	defer suite.TearDown()
+	suite.SetupEmbeddedServer()
+
+	ctx := context.Background()
+
+	user, session := suite.CreateUserAndSession(t)
+
+	// Track how many times the resolver is called
+	resolverCallCount := 0
+
+	// Create token resolver that tracks calls
+	tokenResolver := func(sessionID string) (string, error) {
+		resolverCallCount++
+		if sessionID == session.Id {
+			return session.Token, nil
+		}
+		return "", fmt.Errorf("unknown session")
+	}
+
+	// Create connection
+	clientTransport, err := suite.embeddedServer.CreateConnectionForUser(
+		user.Id,
+		session.Id,
+		tokenResolver,
+	)
+	require.NoError(t, err)
+
+	// Token resolver should be called during connection validation
+	initialCallCount := resolverCallCount
+	t.Logf("Token resolver called %d time(s) during connection", initialCallCount)
+	require.Greater(t, initialCallCount, 0, "Token resolver should be called at least once")
+
+	// Create MCP client
+	mcpClient := mcp.NewClient(
+		&mcp.Implementation{Name: "test", Version: "1.0"},
+		&mcp.ClientOptions{},
+	)
+
+	mcpSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer mcpSession.Close()
+
+	// Make a tool call - this should trigger additional token resolution
+	_, err = mcpSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "search_users",
+		Arguments: map[string]interface{}{
+			"term": user.Username,
+		},
+	})
+	require.NoError(t, err)
+
+	finalCallCount := resolverCallCount
+	t.Logf("Token resolver called %d time(s) total", finalCallCount)
+	assert.Greater(t, finalCallCount, initialCallCount, "Token resolver should be called again for tool execution")
+}

--- a/mcp/testhelpers_test.go
+++ b/mcp/testhelpers_test.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-ai/mcpserver"
+	"github.com/mattermost/mattermost/server/public/model"
+	plugintest "github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	mmcontainer "github.com/mattermost/testcontainers-mattermost-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// EmbeddedTestSuite provides infrastructure for testing the embedded MCP server
+type EmbeddedTestSuite struct {
+	t              *testing.T
+	container      *mmcontainer.MattermostContainer
+	serverURL      string
+	adminClient    *model.Client4
+	embeddedServer *mcpserver.MattermostInMemoryMCPServer
+	logger         *testLogger
+}
+
+// SetupEmbeddedTestSuite initializes a test environment with a real Mattermost container
+// and an embedded MCP server
+func SetupEmbeddedTestSuite(t *testing.T) *EmbeddedTestSuite {
+	ctx := context.Background()
+
+	// Start Mattermost container
+	container, err := mmcontainer.RunContainer(ctx,
+		mmcontainer.WithLicense(""),
+	)
+	require.NoError(t, err, "Failed to start Mattermost container")
+
+	// Enable personal access tokens for authentication testing
+	// err = container.SetConfig(ctx, "ServiceSettings.EnableUserAccessTokens", "true")
+	// require.NoError(t, err, "Failed to enable personal access tokens")
+
+	// Enable open server to allow test user signups
+	err = container.SetConfig(ctx, "TeamSettings.EnableOpenServer", "true")
+	require.NoError(t, err, "Failed to enable open server")
+
+	// Enable user creation
+	err = container.SetConfig(ctx, "TeamSettings.EnableUserCreation", "true")
+	require.NoError(t, err, "Failed to enable user creation")
+
+	// Get connection details
+	serverURL, err := container.URL(ctx)
+	require.NoError(t, err, "Failed to get server URL")
+
+	// Get admin client
+	adminClient, err := container.GetAdminClient(ctx)
+	require.NoError(t, err, "Failed to get admin client")
+
+	suite := &EmbeddedTestSuite{
+		t:           t,
+		container:   container,
+		serverURL:   serverURL,
+		adminClient: adminClient,
+	}
+
+	return suite
+}
+
+// SetupEmbeddedServer creates and configures an embedded MCP server for the test suite
+func (s *EmbeddedTestSuite) SetupEmbeddedServer() {
+	// Create logger
+	s.logger = &testLogger{t: s.t}
+
+	// Create embedded server configuration
+	config := mcpserver.InMemoryConfig{
+		BaseConfig: mcpserver.BaseConfig{
+			MMServerURL:         s.serverURL,
+			MMInternalServerURL: s.serverURL,
+			DevMode:             false,
+		},
+	}
+
+	// Create embedded server
+	server, err := mcpserver.NewInMemoryServer(config, s.logger)
+	require.NoError(s.t, err, "Failed to create embedded MCP server")
+
+	s.embeddedServer = server
+}
+
+// TearDown cleans up the test suite
+func (s *EmbeddedTestSuite) TearDown() {
+	if s.container != nil {
+		ctx := context.Background()
+		if err := s.container.Terminate(ctx); err != nil {
+			s.t.Logf("Failed to terminate container: %v", err)
+		}
+	}
+}
+
+// CreateUserAndSession creates a new test user and returns the user and an active session
+func (s *EmbeddedTestSuite) CreateUserAndSession(t *testing.T) (*model.User, *model.Session) {
+	ctx := context.Background()
+
+	// Create a unique user
+	username := fmt.Sprintf("testuser_%d", model.GetMillis())
+	email := fmt.Sprintf("%s@test.com", username)
+
+	user := &model.User{
+		Username: username,
+		Email:    email,
+		Password: "TestPassword123!",
+	}
+
+	createdUser, _, err := s.adminClient.CreateUser(ctx, user)
+	require.NoError(t, err, "Failed to create test user")
+
+	// Get or create a default team for the user
+	teams, _, err := s.adminClient.GetAllTeams(ctx, "", 0, 1)
+	require.NoError(t, err, "Failed to get teams")
+
+	var teamID string
+	if len(teams) > 0 {
+		// Use existing team
+		teamID = teams[0].Id
+	} else {
+		// Create a new team
+		team := &model.Team{
+			Name:        fmt.Sprintf("testteam_%d", model.GetMillis()),
+			DisplayName: "Test Team",
+			Type:        model.TeamOpen,
+		}
+		createdTeam, _, err := s.adminClient.CreateTeam(ctx, team)
+		require.NoError(t, err, "Failed to create team")
+		teamID = createdTeam.Id
+	}
+
+	// Add user to team
+	_, _, err = s.adminClient.AddTeamMember(ctx, teamID, createdUser.Id)
+	require.NoError(t, err, "Failed to add user to team")
+
+	// Create a new client for the user to login
+	userClient := model.NewAPIv4Client(s.serverURL)
+
+	// Log in to create a session
+	sessionUser, _, err := userClient.Login(ctx, user.Email, user.Password)
+	require.NoError(t, err, "Failed to login")
+
+	// Get the session token (stored in client after login)
+	token := userClient.AuthToken
+
+	// Use admin client to get all sessions for this user
+	sessions, _, err := userClient.GetSessions(ctx, sessionUser.Id, "")
+	require.NoError(t, err, "Failed to get sessions")
+	require.NotEmpty(t, sessions, "Should have at least one session after login")
+
+	// The most recently created session should be the one we just created from login
+	// Sessions are typically returned with most recent first, or we find by creation time
+	var activeSession *model.Session
+	var mostRecentTime int64 = 0
+	for i := range sessions {
+		if sessions[i].CreateAt > mostRecentTime {
+			mostRecentTime = sessions[i].CreateAt
+			activeSession = sessions[i]
+		}
+	}
+	require.NotNil(t, activeSession, "Should find active session")
+
+	// Update the token in the session object since GetSessions might not return it
+	activeSession.Token = token
+
+	return createdUser, activeSession
+}
+
+// CreateChannel creates a test channel for the given team and adds the user as a member
+func (s *EmbeddedTestSuite) CreateChannel(t *testing.T, teamID, userID string) *model.Channel {
+	ctx := context.Background()
+
+	channelName := fmt.Sprintf("testchannel_%d", model.GetMillis())
+	channel := &model.Channel{
+		TeamId:      teamID,
+		Name:        channelName,
+		DisplayName: "Test Channel",
+		Type:        model.ChannelTypeOpen,
+		CreatorId:   userID,
+	}
+
+	createdChannel, _, err := s.adminClient.CreateChannel(ctx, channel)
+	require.NoError(t, err, "Failed to create test channel")
+
+	// Add the user as a member of the channel
+	_, _, err = s.adminClient.AddChannelMember(ctx, createdChannel.Id, userID)
+	require.NoError(t, err, "Failed to add user to channel")
+
+	return createdChannel
+}
+
+// CreatePost creates a test post in the given channel
+func (s *EmbeddedTestSuite) CreatePost(t *testing.T, channelID, userID, message string) *model.Post {
+	ctx := context.Background()
+
+	post := &model.Post{
+		ChannelId: channelID,
+		UserId:    userID,
+		Message:   message,
+	}
+
+	createdPost, _, err := s.adminClient.CreatePost(ctx, post)
+	require.NoError(t, err, "Failed to create test post")
+
+	return createdPost
+}
+
+// testLogger is a simple logger implementation for tests that implements pluginapi.LogService
+type testLogger struct {
+	t *testing.T
+}
+
+func (l *testLogger) Debug(message string, keyValuePairs ...any) {
+	l.t.Logf("[DEBUG] %s %v", message, keyValuePairs)
+}
+
+func (l *testLogger) Info(message string, keyValuePairs ...any) {
+	l.t.Logf("[INFO] %s %v", message, keyValuePairs)
+}
+
+func (l *testLogger) Warn(message string, keyValuePairs ...any) {
+	l.t.Logf("[WARN] %s %v", message, keyValuePairs)
+}
+
+func (l *testLogger) Error(message string, keyValuePairs ...any) {
+	l.t.Logf("[ERROR] %s %v", message, keyValuePairs)
+}
+
+func (l *testLogger) Flush() error {
+	// No-op for test logger
+	return nil
+}
+
+// mockPluginAPI wraps plugintest.API and adds session handling for testing
+type mockPluginAPI struct {
+	*plugintest.API
+	sessions map[string]*model.Session
+	mu       sync.RWMutex
+}
+
+func newMockPluginAPI() *mockPluginAPI {
+	mockAPI := &plugintest.API{}
+	// Setup mock expectations for logging methods
+	// Log methods accept variadic arguments, so we need to match various argument counts
+	// Using mock.Anything for up to 20 arguments (should cover most log calls)
+	anyArgs := make([]interface{}, 20)
+	for i := range anyArgs {
+		anyArgs[i] = mock.Anything
+	}
+	mockAPI.On("LogDebug", anyArgs...).Maybe()
+	mockAPI.On("LogInfo", anyArgs...).Maybe()
+	mockAPI.On("LogWarn", anyArgs...).Maybe()
+	mockAPI.On("LogError", anyArgs...).Maybe()
+
+	return &mockPluginAPI{
+		API:      mockAPI,
+		sessions: make(map[string]*model.Session),
+	}
+}
+
+func (m *mockPluginAPI) addSession(session *model.Session) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[session.Id] = session
+}
+
+func (m *mockPluginAPI) GetSession(sessionID string) (*model.Session, *model.AppError) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, exists := m.sessions[sessionID]
+	if !exists {
+		return nil, model.NewAppError("GetSession", "api.context.session_expired.app_error", nil, "", 401)
+	}
+	return session, nil
+}
+
+// CreateClient creates a Client using the actual EmbeddedServerClient.CreateClient() method
+func (s *EmbeddedTestSuite) CreateClient(t *testing.T, user *model.User, session *model.Session) *Client {
+	ctx := context.Background()
+
+	// Create mock plugin API and add the session
+	mockPluginAPI := newMockPluginAPI()
+	mockPluginAPI.addSession(session)
+
+	// Create a real pluginapi.Client to get a proper LogService
+	// The first parameter is the plugin API, second is the driver (nil for tests)
+	pluginAPIClient := pluginapi.NewClient(mockPluginAPI, nil)
+
+	// Create a wrapper that implements EmbeddedMCPServer interface
+	wrapper := &embeddedServerWrapper{
+		server: s.embeddedServer,
+		api:    mockPluginAPI,
+	}
+
+	// Create embedded server client
+	embeddedClient := NewEmbeddedServerClient(wrapper, pluginAPIClient.Log, pluginAPIClient)
+
+	// Create client
+	client, err := embeddedClient.CreateClient(ctx, user.Id, session.Id)
+	require.NoError(t, err, "Should create client successfully")
+	require.NotNil(t, client, "Client should not be nil")
+
+	return client
+}
+
+// embeddedServerWrapper wraps the MattermostInMemoryMCPServer to work with mock plugin API
+type embeddedServerWrapper struct {
+	server *mcpserver.MattermostInMemoryMCPServer
+	api    *mockPluginAPI
+}
+
+// CreateClientTransport implements EmbeddedMCPServer interface
+// Note: The signature must match the interface (takes *pluginapi.Client), but in tests
+// we ignore the passed pluginAPI parameter and use our mock instead
+func (w *embeddedServerWrapper) CreateClientTransport(userID, sessionID string, pluginAPI *pluginapi.Client) (*mcp.InMemoryTransport, error) {
+	// Create token resolver using our mock (ignore the passed pluginAPI in tests)
+	tokenResolver := func(sid string) (string, error) {
+		session, err := w.api.GetSession(sid)
+		if err != nil {
+			return "", err
+		}
+		if session == nil {
+			return "", fmt.Errorf("session not found")
+		}
+		return session.Token, nil
+	}
+
+	// Call the underlying server's CreateConnectionForUser
+	return w.server.CreateConnectionForUser(userID, sessionID, tokenResolver)
+}
+
+// CreateClientManager creates a ClientManager for testing
+func (s *EmbeddedTestSuite) CreateClientManager(t *testing.T, session *model.Session) *ClientManager {
+	// Create mock plugin API and add the session
+	mockPluginAPI := newMockPluginAPI()
+	mockPluginAPI.addSession(session)
+
+	// Create a real pluginapi.Client to get a proper LogService
+	pluginAPIClient := pluginapi.NewClient(mockPluginAPI, nil)
+
+	// Create wrapper
+	wrapper := &embeddedServerWrapper{
+		server: s.embeddedServer,
+		api:    mockPluginAPI,
+	}
+
+	// Create config for testing (no remote servers, just embedded)
+	config := Config{
+		EmbeddedServer: EmbeddedServerConfig{
+			Enabled: true,
+		},
+		Servers:            []ServerConfig{}, // No remote servers for testing
+		IdleTimeoutMinutes: 30,
+	}
+
+	// Create ClientManager
+	manager := NewClientManager(config, pluginAPIClient.Log, pluginAPIClient, nil, wrapper)
+	require.NotNil(t, manager, "ClientManager should not be nil")
+
+	return manager
+}


### PR DESCRIPTION
#### Summary
Some integration tests for the embedded mcp server where we are using test containers and a real in memory server to look at tool responses

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
