### PR TITLE
MM-69160: Fix capitalization and text size in agent mention reminder

### DIFF
--- a/e2e/scripts/ci-test-groups.mjs
+++ b/e2e/scripts/ci-test-groups.mjs
@@ -10,6 +10,7 @@ const testsRoot = path.resolve(e2eRoot, 'tests');
 
 const groups = {
     'e2e-shard-1': [
+        'tests/agent-mention-reminder/reminder.spec.ts',
         'tests/agents/provider-config.spec.ts',
         'tests/channel-analysis/integration/integration.spec.ts',
         'tests/bot-configuration/service-changes.spec.ts',

--- a/e2e/tests/agent-mention-reminder/reminder.spec.ts
+++ b/e2e/tests/agent-mention-reminder/reminder.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+import RunContainer from 'helpers/plugincontainer';
+import MattermostContainer from 'helpers/mmcontainer';
+import { MattermostPage } from 'helpers/mm';
+import { resetSelectedAgentPreference } from 'helpers/agent_preferences';
+import { OpenAIMockContainer, RunOpenAIMocks, responseTest } from 'helpers/openai-mock';
+
+const username = 'regularuser';
+const password = 'regularuser';
+
+let mattermost: MattermostContainer;
+let openAIMock: OpenAIMockContainer;
+
+test.beforeAll(async () => {
+  mattermost = await RunContainer();
+  openAIMock = await RunOpenAIMocks(mattermost.network);
+});
+
+test.afterAll(async () => {
+  await openAIMock.stop();
+  await mattermost.stop();
+});
+
+test.beforeEach(async () => {
+  await resetSelectedAgentPreference(mattermost, username, password);
+});
+
+test.describe('Agent mention reminder', () => {
+  // Replying in an agent thread without an @mention triggers an ephemeral
+  // reminder rendered by the custom post component. Guards MM-69160: the link
+  // text must be capitalized and match regular post text size.
+  test('renders a capitalized link at regular post text size', async ({ page }) => {
+    const mmPage = new MattermostPage(page);
+    await mmPage.login(mattermost.url(), username, password);
+
+    // Root mention creates a thread whose previous post is authored by the bot.
+    await openAIMock.addCompletionMock(responseTest);
+    await mmPage.mentionBot('mock', 'Hello');
+    await mmPage.waitForReply();
+
+    // Open the thread and reply without mentioning the bot.
+    await page.getByText('1 reply').click();
+    const replyBox = page.locator('#rhsContainer').getByTestId('reply_textbox');
+    await expect(replyBox).toBeVisible({ timeout: 15000 });
+    await replyBox.click();
+    await replyBox.fill('thanks');
+    await replyBox.press('Enter');
+
+    const rhs = page.locator('#rhsContainer');
+    await expect(rhs.getByText('To respond to an agent you must @mention them.')).toBeVisible({ timeout: 15000 });
+
+    const loopInLink = rhs.getByRole('link', { name: /loop in @Mock Bot/ });
+    await expect(loopInLink).toBeVisible();
+
+    // Capitalized "Click here" (MM-69160).
+    const linkText = (await loopInLink.textContent())?.trim() ?? '';
+    expect(linkText).toBe('Click here to loop in @Mock Bot');
+
+    // Matches regular post text size, not the smaller 13px hint size (MM-69160).
+    const fontSize = await loopInLink.evaluate((el) => window.getComputedStyle(el).fontSize);
+    expect(fontSize).toBe('14px');
+  });
+});

--- a/webapp/src/components/agent_mention_reminder_post.test.tsx
+++ b/webapp/src/components/agent_mention_reminder_post.test.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import {doLoopInAgent} from '@/client';
+
+import {AgentMentionReminderPost} from './agent_mention_reminder_post';
+
+jest.mock('@/client', () => ({
+    doLoopInAgent: jest.fn(),
+}));
+
+const mockedDoLoopInAgent = doLoopInAgent as jest.MockedFunction<typeof doLoopInAgent>;
+
+function makePost(overrides: Partial<React.ComponentProps<typeof AgentMentionReminderPost>['post']> = {}) {
+    return {
+        id: 'post_1',
+        message: 'To respond to an agent you must @mention them.',
+        props: {
+            bot_username: 'matty',
+            bot_display_name: 'Matty',
+            target_post_id: 'target_1',
+        },
+        ...overrides,
+    };
+}
+
+function renderPost(post = makePost()) {
+    return render(
+        <IntlProvider locale='en'>
+            <AgentMentionReminderPost post={post}/>
+        </IntlProvider>,
+    );
+}
+
+describe('AgentMentionReminderPost', () => {
+    beforeEach(() => {
+        mockedDoLoopInAgent.mockReset();
+    });
+
+    test('renders the loop-in link with a capitalized "Click here"', () => {
+        renderPost();
+
+        const link = screen.getByRole('link');
+        expect(link.textContent).toBe('Click here to loop in @Matty');
+    });
+
+    test('loops in the agent and shows the confirmation on click', async () => {
+        mockedDoLoopInAgent.mockImplementationOnce(() => Promise.resolve());
+        renderPost();
+
+        fireEvent.click(screen.getByRole('link'));
+
+        expect(mockedDoLoopInAgent).toHaveBeenCalledWith('target_1', 'matty');
+        await waitFor(() => expect(screen.getByText('Looped in @Matty.')).not.toBeNull());
+    });
+
+    test('shows an error message when loop-in fails', async () => {
+        jest.spyOn(console, 'error').mockImplementation(jest.fn());
+        mockedDoLoopInAgent.mockRejectedValueOnce(new Error('boom'));
+        renderPost();
+
+        fireEvent.click(screen.getByRole('link'));
+
+        await waitFor(() => expect(screen.getByText('Failed to loop in @Matty. Please try again.')).not.toBeNull());
+    });
+
+    test('falls back to the plain message when no bot username is present', () => {
+        renderPost(makePost({props: {bot_display_name: 'Matty', target_post_id: 'target_1'}}));
+
+        expect(screen.queryByRole('link')).toBeNull();
+        expect(screen.getByText('To respond to an agent you must @mention them.')).not.toBeNull();
+    });
+});

--- a/webapp/src/components/agent_mention_reminder_post.tsx
+++ b/webapp/src/components/agent_mention_reminder_post.tsx
@@ -9,8 +9,8 @@ import {doLoopInAgent} from '@/client';
 
 const Hint = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.64);
-    font-size: 13px;
-    line-height: 18px;
+    font-size: 14px;
+    line-height: 20px;
 `;
 
 const ErrorMessage = styled.div`
@@ -89,7 +89,7 @@ export const AgentMentionReminderPost = ({post}: Props) => {
         <Hint>
             <FormattedMessage
                 id='agents.agent_mention_reminder_body'
-                defaultMessage='To respond to an agent you must @mention them. <link>click here to loop in @{botDisplayName}</link>'
+                defaultMessage='To respond to an agent you must @mention them. <link>Click here to loop in @{botDisplayName}</link>'
                 values={{
                     botDisplayName,
                     link: (chunks: React.ReactNode) => (

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -277,7 +277,7 @@
   "aA+e4NGW": "Loading models...",
   "aCdAsIsV": "Copy to clipboard",
   "aKeIoYkm": "Use service default",
-  "agents.agent_mention_reminder_body": "To respond to an agent you must @mention them. <link>click here to loop in @{botDisplayName}</link>",
+  "agents.agent_mention_reminder_body": "To respond to an agent you must @mention them. <link>Click here to loop in @{botDisplayName}</link>",
   "agents.agent_mention_reminder_done": "Looped in @{botDisplayName}.",
   "agents.agent_mention_reminder_error": "Failed to loop in @{botDisplayName}. Please try again.",
   "ah95aAGi": "Action Title",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

When a user replies in an agent thread without `@mention`ing the bot, an ephemeral reminder is shown ("To respond to an agent you must @mention them. …"). This reminder had two visual issues reported in MM-69160:

- The loop-in link text started with a lowercase "c" (`click here to loop in @…`).
- The reminder text rendered at `13px`/`18px`, slightly smaller than regular post text.

This PR makes the smallest scoped fix in `webapp/src/components/agent_mention_reminder_post.tsx`:

- Capitalize the link text to `Click here to loop in @…`.
- Match the regular post text size by using `14px`/`20px` (the same size used elsewhere for post-body help text).

**QA test steps**

1. Configure an agent bot in a channel (non-DM).
2. In a channel, post `@<bot> Hello` and wait for the bot's threaded reply.
3. Open the thread and post a reply **without** mentioning the bot.
4. Observe the ephemeral reminder: the link should read **"Click here to loop in @<Bot>"** (capital C) and the text should be the same size as regular post text.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-69160

#### Screenshots

|  before  |  after  |
|----|----|
| ![before: lowercase click, smaller text](https://cursor.com/artifacts/c/art-0568a6b4-13b9-4607-b6cb-2d66f8b697a3) | ![after: capitalized Click, regular text size](https://cursor.com/artifacts/c/art-12d9682c-10ab-45d7-82de-12f1e4d18fae) |

#### Release Note

```release-note
Fixed the capitalization and text size of the "To respond to an agent you must @mention them" reminder message.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38ab5a0c-51da-460a-9d3e-b83c837ce519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38ab5a0c-51da-460a-9d3e-b83c837ce519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agent mention reminder link’s readability with standard post-sized text and clearer capitalization.
  * Added confirmation and error handling when looping an agent into a conversation.

* **Tests**
  * Added coverage for successful, failed, and unavailable agent loop-in actions.
  * Added end-to-end validation for reminder visibility, link text, and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->