### PR TITLE
feat(llm): add OpenCode Go as a managed provider (chat-only, no Responses/CountTokens)

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -53,6 +53,7 @@ const missingContentIndex = -1
 // LLM implements the llm.LanguageModel interface using the Bifrost gateway.
 type LLM struct {
 	client           *bifrostcore.Bifrost
+	account          *multiProviderAccount // kept for diagnostics; nil after the constructor returns a fully-constructed *LLM
 	provider         schemas.ModelProvider
 	apiKey           string   // used only to redact configured secrets from provider error surfaces
 	fallbackAPIKeys  []string // fallback provider keys, redacted from error surfaces alongside apiKey
@@ -355,10 +356,23 @@ func readFileData(file llm.File) ([]byte, error) {
 }
 
 // New creates a new LLM instance with the given configuration. It errors when
-// a fallback cannot be registered, so a misconfigured fallback chain fails at
+// a fallback cannot be registered, so a misconfigured chain fails at
 // setup instead of silently shrinking.
 func New(cfg Config) (*LLM, error) {
 	primaryEntry := &providerAccount{ProviderSettings: cfg.ProviderSettings}
+
+	// Wrap an OpenAI-base primary that does not speak the Responses API
+	// (e.g. OpenCode Go, or any openaicompatible with UseResponsesAPI=false)
+	// under its own custom-provider slot so the chat-only AllowedRequests gate
+	// is attached by GetConfigForProvider. With only ChatCompletion and
+	// ChatCompletionStream set to true, Bifrost refuses POSTs to /v1/responses
+	// and /v1/responses/input_tokens (CountTokens returns "unsupported_operation",
+	// which the plugin maps to llm.ErrUnsupportedTokenCount → llm.EstimateTokens
+	// fallback). Mirrors the fallback-wrap branch below.
+	if cfg.Provider == schemas.OpenAI && !cfg.UseResponsesAPI && isCustomCapableProvider(cfg.Provider) {
+		primaryEntry.name = customProviderName(cfg.Provider, "primary")
+		primaryEntry.chatOnly = true
+	}
 
 	account := newMultiProviderAccount()
 	account.addProvider(primaryEntry)
@@ -422,7 +436,8 @@ func New(cfg Config) (*LLM, error) {
 
 	return &LLM{
 		client:             client,
-		provider:           cfg.Provider,
+		account:            account,
+		provider:           primaryEntry.registeredName(),
 		apiKey:             cfg.APIKey,
 		fallbackAPIKeys:    redactKeys[1:],
 		defaultModel:       cfg.DefaultModel,

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -2129,6 +2129,35 @@ func TestServiceConfigToFallbackEntry(t *testing.T) {
 			expectedChatOnly: false,
 		},
 		{
+			name: "OpenCode Go service gets default URL and is chat-only",
+			svc: llm.ServiceConfig{
+				Type:         llm.ServiceTypeOpenCodeGo,
+				APIKey:       "key",
+				DefaultModel: "kimi-k3",
+			},
+			expectedProvider: schemas.OpenAI,
+			expectedModel:    "kimi-k3",
+			// The injected /v1 suffix is stripped by normalizeOpenAIBaseURL so
+			// Bifrost can prepend /v1/chat/completions without doubling up.
+			expectedAPIURL: "https://opencode.ai/zen/go",
+			// OpenCode Go does not speak the OpenAI Responses API; it must be
+			// registered chat-only so Bifrost downgrades Responses-API requests.
+			expectedChatOnly: true,
+		},
+		{
+			name: "OpenCode Go service with explicit API URL is left alone",
+			svc: llm.ServiceConfig{
+				Type:         llm.ServiceTypeOpenCodeGo,
+				APIKey:       "key",
+				APIURL:       "https://proxy.example.com/go/v1",
+				DefaultModel: "kimi-k3",
+			},
+			expectedProvider: schemas.OpenAI,
+			expectedModel:    "kimi-k3",
+			expectedAPIURL:   "https://proxy.example.com/go",
+			expectedChatOnly: true,
+		},
+		{
 			name: "OpenAI Compatible normalizes URL and is chat-only",
 			svc: llm.ServiceConfig{
 				Type:         llm.ServiceTypeOpenAICompatible,
@@ -2341,6 +2370,10 @@ func TestProviderAccount_ChatOnlyCustomConfig(t *testing.T) {
 	assert.True(t, cfg.CustomProviderConfig.AllowedRequests.ChatCompletionStream)
 	assert.False(t, cfg.CustomProviderConfig.AllowedRequests.Responses)
 	assert.False(t, cfg.CustomProviderConfig.AllowedRequests.ResponsesStream)
+	// CountTokens must be blocked too — a gateway that omits /v1/responses
+	// cannot serve /v1/responses/input_tokens either (it is the same
+	// auxiliary endpoint Bifrost pings before every chat request).
+	assert.False(t, cfg.CustomProviderConfig.AllowedRequests.CountTokens)
 
 	// A custom provider that does support the Responses API leaves AllowedRequests
 	// unset so all operations remain available.
@@ -2355,6 +2388,108 @@ func TestProviderAccount_ChatOnlyCustomConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg.CustomProviderConfig)
 	assert.Nil(t, cfg.CustomProviderConfig.AllowedRequests)
+}
+
+// TestNew_OpenCodeGoPrimaryIsWrappedAsChatOnlyCustom pins the contract that an
+// OpenCode Go primary service is registered under a custom-provider slot whose
+// AllowedRequests gate refuses POSTs to /v1/responses and
+// /v1/responses/input_tokens (which the gateway does not implement). Without
+// this gate the Bifrost preflight would 404 on the count-tokens endpoint and
+// crash its HTML-404 response parser.
+func TestNew_OpenCodeGoPrimaryIsWrappedAsChatOnlyCustom(t *testing.T) {
+	primary := llm.ServiceConfig{
+		ID:           "opencodego-primary",
+		Type:         llm.ServiceTypeOpenCodeGo,
+		APIKey:       "key",
+		DefaultModel: "kimi-k3",
+	}
+
+	llmInstance, err := NewFromServiceConfig(primary, llm.BotConfig{}, nil)
+	require.NoError(t, err)
+	defer llmInstance.client.Shutdown()
+
+	// b.provider should now be the registered custom-provider name
+	// "openai::primary", not bare schemas.OpenAI — requests routed through
+	// req.Provider = b.provider must target the wrapped slot.
+	expectedName := customProviderName(schemas.OpenAI, "primary")
+	assert.Equal(t, expectedName, llmInstance.provider,
+		"primary must be registered under the custom-provider name so requests route to the wrapped slot")
+
+	// The bare schemas.OpenAI slot must NOT be registered — only the wrapped
+	// one is. This is the proof that the wrap actually moved the registration.
+	providers, err := llmInstance.account.GetConfiguredProviders()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []schemas.ModelProvider{expectedName}, providers,
+		"bare schemas.OpenAI must not be registered alongside the wrapped primary slot")
+
+	// GetConfigForProvider on the wrapped slot must attach a CustomProviderConfig
+	// whose AllowedRequests allow only ChatCompletion / ChatCompletionStream.
+	wrappedCfg, err := llmInstance.account.GetConfigForProvider(expectedName)
+	require.NoError(t, err)
+	require.NotNil(t, wrappedCfg.CustomProviderConfig,
+		"wrapped primary must declare CustomProviderConfig to attach AllowedRequests")
+	require.NotNil(t, wrappedCfg.CustomProviderConfig.AllowedRequests,
+		"wrapped primary must declare AllowedRequests so /v1/responses and /v1/responses/input_tokens are refused")
+	assert.Equal(t, schemas.OpenAI, wrappedCfg.CustomProviderConfig.BaseProviderType)
+	assert.True(t, wrappedCfg.CustomProviderConfig.AllowedRequests.ChatCompletion)
+	assert.True(t, wrappedCfg.CustomProviderConfig.AllowedRequests.ChatCompletionStream)
+	assert.False(t, wrappedCfg.CustomProviderConfig.AllowedRequests.Responses)
+	assert.False(t, wrappedCfg.CustomProviderConfig.AllowedRequests.ResponsesStream)
+	assert.False(t, wrappedCfg.CustomProviderConfig.AllowedRequests.CountTokens,
+		"CountTokens must be disabled so the Bifrost preflight does not POST to /v1/responses/input_tokens")
+	assert.Equal(t, "https://opencode.ai/zen/go", wrappedCfg.NetworkConfig.BaseURL,
+		"the wrapped slot's base URL must be the auto-applied OpenCode Go default")
+}
+
+// TestNew_DirectOpenAIAndAzurePrimariesRemainStandard guards the inverse of
+// TestNew_OpenCodeGoPrimaryIsWrappedAsChatOnlyCustom: real OpenAI / Azure
+// services continue to register on the bare schemas.OpenAI / schemas.Azure
+// slot (not a custom slot) so all of Bifrost's per-provider quirks — including
+// the Responses-API path — remain available. Only OpenAI-base services with
+// cfg.UseResponsesAPI == false get wrapped.
+func TestNew_DirectOpenAIAndAzurePrimariesRemainStandard(t *testing.T) {
+	cases := []struct {
+		name    string
+		service llm.ServiceConfig
+	}{
+		{
+			name: "direct OpenAI primary keeps the bare schemas.OpenAI slot",
+			service: llm.ServiceConfig{
+				ID:           "openai-direct",
+				Type:         llm.ServiceTypeOpenAI,
+				APIKey:       "key",
+				DefaultModel: "gpt-4o",
+			},
+		},
+		{
+			name: "Azure primary keeps the bare schemas.Azure slot",
+			service: llm.ServiceConfig{
+				ID:           "azure",
+				Type:         llm.ServiceTypeAzure,
+				APIKey:       "key",
+				APIURL:       "https://example.openai.azure.com",
+				DefaultModel: "gpt-4o",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			llmInstance, err := NewFromServiceConfig(tc.service, llm.BotConfig{}, nil)
+			require.NoError(t, err)
+			defer llmInstance.client.Shutdown()
+
+			expectedName, err := MapServiceTypeToProvider(tc.service.Type)
+			require.NoError(t, err)
+			assert.Equal(t, expectedName, llmInstance.provider,
+				"standard providers must keep the bare base-type slot so they remain standard")
+
+			cfg, err := llmInstance.account.GetConfigForProvider(expectedName)
+			require.NoError(t, err)
+			assert.Nil(t, cfg.CustomProviderConfig,
+				"standard providers must not be wrapped as custom providers")
+		})
+	}
 }
 
 func TestConvertToBifrostResponsesRequestStructuredOutputStringEnum(t *testing.T) {
@@ -2664,6 +2799,13 @@ func TestCountTokensOmitsMaxOutputTokens(t *testing.T) {
 			StreamingTimeout: 10 * time.Second,
 		},
 		OutputTokenLimit: 8192, // produces MaxGeneratedTokens > 0 → MaxOutputTokens in the request
+		// UseResponsesAPI reflects the production value for direct OpenAI, which
+		// is always forced to true by NewFromServiceConfig (see
+		// llm.ServiceUsesResponsesAPI). The chat-only custom wrap that protects
+		// gateways without /v1/responses (OpenCode Go, openaicompatible with the
+		// toggle off) only fires when UseResponsesAPI is false, so this keeps
+		// CountTokens reaching the backend so the body-shape checks below run.
+		UseResponsesAPI: true,
 	})
 	require.NoError(t, err)
 	defer llmClient.client.Shutdown()

--- a/bifrost/config.go
+++ b/bifrost/config.go
@@ -34,6 +34,8 @@ func MapServiceTypeToProvider(serviceType string) (schemas.ModelProvider, error)
 		return schemas.Gemini, nil
 	case llm.ServiceTypeVertex:
 		return schemas.Vertex, nil
+	case llm.ServiceTypeOpenCodeGo:
+		return schemas.OpenAI, nil
 	default:
 		return "", fmt.Errorf("unsupported service type: %s", serviceType)
 	}
@@ -44,6 +46,12 @@ func MapServiceTypeToProvider(serviceType string) (schemas.ModelProvider, error)
 // and the effective-behavior checks used by built-in Mattermost tools so that
 // built-in fallbacks do not get suppressed when native tools would be stripped.
 func SupportsNativeTools(serviceType string) bool {
+	// OpenCode Go is OpenAI-base, but the gateway is a thin proxy that does
+	// not implement native OpenAI tools; declare them unsupported so we
+	// do not try to send web_search to /v1/chat/completions.
+	if serviceType == llm.ServiceTypeOpenCodeGo {
+		return false
+	}
 	provider, err := MapServiceTypeToProvider(serviceType)
 	if err != nil {
 		return false
@@ -88,6 +96,12 @@ func NewFromServiceConfig(serviceConfig llm.ServiceConfig, botConfig llm.BotConf
 		return nil, err
 	}
 
+	// Managed providers whose endpoint is fixed and known need their base URL
+	// filled in by us; otherwise the wrapped custom-provider slot Bifrost sees
+	// has an empty BaseURL. The fallback path (serviceConfigToFallbackEntry)
+	// applies the same defaults.
+	applyProviderURLDefaults(&serviceConfig)
+
 	settings := providerSettingsFromService(provider, serviceConfig)
 	if settings.StreamingTimeout <= 0 {
 		settings.StreamingTimeout = DefaultStreamingTimeout
@@ -124,6 +138,24 @@ func NewFromServiceConfig(serviceConfig llm.ServiceConfig, botConfig llm.BotConf
 	return New(cfg)
 }
 
+// applyProviderURLDefaults fills in the base URL for managed providers whose
+// endpoint is fixed and known. Mutates svc in place. Called from both the
+// primary path (NewFromServiceConfig) and the fallback path
+// (serviceConfigToFallbackEntry) so the two stay in sync.
+func applyProviderURLDefaults(svc *llm.ServiceConfig) {
+	if svc.APIURL != "" {
+		return
+	}
+	switch svc.Type {
+	case llm.ServiceTypeCohere:
+		svc.APIURL = "https://api.cohere.ai/compatibility/v1"
+	case llm.ServiceTypeMistral:
+		svc.APIURL = "https://api.mistral.ai/v1"
+	case llm.ServiceTypeOpenCodeGo:
+		svc.APIURL = "https://opencode.ai/zen/go/v1"
+	}
+}
+
 // providerSettingsFromService maps a ServiceConfig's provider connection fields
 // onto ProviderSettings. It does not fill in per-provider URL defaults; bifrost
 // has its own and they drift.
@@ -152,16 +184,11 @@ func serviceConfigToFallbackEntry(svc llm.ServiceConfig) (FallbackEntry, error) 
 		return FallbackEntry{}, err
 	}
 
-	// Unlike the primary path, fallbacks pin explicit base URLs for Cohere and
-	// Mistral when none is configured.
-	if svc.APIURL == "" {
-		switch svc.Type {
-		case llm.ServiceTypeCohere:
-			svc.APIURL = "https://api.cohere.ai/compatibility/v1"
-		case llm.ServiceTypeMistral:
-			svc.APIURL = "https://api.mistral.ai/v1"
-		}
-	}
+	// Unlike the primary path, fallbacks pin explicit base URLs for Cohere,
+	// Mistral, and OpenCode Go when none is configured. The OpenCode Go URL
+	// has a /v1 suffix; normalizeOpenAIBaseURL below strips it so Bifrost
+	// can prepend /v1/chat/completions (or /v1/responses) without doubling.
+	applyProviderURLDefaults(&svc)
 
 	return FallbackEntry{
 		ProviderSettings: providerSettingsFromService(provider, svc),
@@ -201,7 +228,8 @@ func IsSupported(serviceType string) bool {
 		llm.ServiceTypeCohere,
 		llm.ServiceTypeMistral,
 		llm.ServiceTypeGemini,
-		llm.ServiceTypeVertex:
+		llm.ServiceTypeVertex,
+		llm.ServiceTypeOpenCodeGo:
 		return true
 	default:
 		return false

--- a/bifrost/config_test.go
+++ b/bifrost/config_test.go
@@ -27,6 +27,7 @@ func TestSupportsNativeTools(t *testing.T) {
 		{llm.ServiceTypeCohere, false},
 		{llm.ServiceTypeMistral, false},
 		{llm.ServiceTypeScale, false},
+		{llm.ServiceTypeOpenCodeGo, false},
 		{"unknown", false},
 	}
 	for _, tt := range tests {
@@ -53,6 +54,7 @@ func TestFilterNativeToolsForServiceType(t *testing.T) {
 		{"Bedrock drops tools", llm.ServiceTypeBedrock, tools, []string{}},
 		{"Cohere drops tools", llm.ServiceTypeCohere, tools, []string{}},
 		{"Mistral drops tools", llm.ServiceTypeMistral, tools, []string{}},
+		{"OpenCode Go drops tools", llm.ServiceTypeOpenCodeGo, tools, []string{}},
 		{"nil tools stay nil", llm.ServiceTypeOpenAI, nil, nil},
 		{"empty tools stay empty", llm.ServiceTypeOpenAI, []string{}, []string{}},
 	}

--- a/llm/configuration.go
+++ b/llm/configuration.go
@@ -317,6 +317,10 @@ func IsValidService(service ServiceConfig) bool {
 		return service.APIKey != "" && service.APIURL != ""
 	case ServiceTypeGemini:
 		return service.APIKey != ""
+	case ServiceTypeOpenCodeGo:
+		// OpenCode Go uses an OpenAI-compatible endpoint with standard Bearer
+		// auth; only the API key is required — the base URL is auto-applied.
+		return service.APIKey != ""
 	case ServiceTypeVertex:
 		// Auth credentials optional — empty means ADC / attached IAM role.
 		if service.VertexProjectID == "" || service.Region == "" {

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -427,6 +427,34 @@ func TestIsValidService(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "Valid OpenCode Go service with API key",
+			service: ServiceConfig{
+				ID:     "service-12",
+				Type:   ServiceTypeOpenCodeGo,
+				APIKey: "opencodego-key",
+			},
+			want: true,
+		},
+		{
+			name: "OpenCode Go service missing API key",
+			service: ServiceConfig{
+				ID:     "service-12",
+				Type:   ServiceTypeOpenCodeGo,
+				APIKey: "", // bad - only the API key is required; base URL is auto-defaulted
+			},
+			want: false,
+		},
+		{
+			name: "OpenCode Go service with explicit API URL is still valid",
+			service: ServiceConfig{
+				ID:     "service-12",
+				Type:   ServiceTypeOpenCodeGo,
+				APIKey: "opencodego-key",
+				APIURL: "https://opencode.ai/zen/go/v1", // operator override is allowed
+			},
+			want: true,
+		},
+		{
 			name: "Valid Scale service with API key and API URL",
 			service: ServiceConfig{
 				ID:     "service-9",

--- a/llm/providers.go
+++ b/llm/providers.go
@@ -41,6 +41,18 @@ var openAICompatibleProviders = map[string]OpenAICompatibleProvider{
 			}
 		},
 	},
+	// OpenCode Go is the managed subscription tier of the OpenCode coding
+	// agent. It exposes an OpenAI-compatible chat-completions endpoint at
+	// https://opencode.ai/zen/go/v1 using standard Bearer auth, so the
+	// default transport is sufficient — no CreateTransport hook is needed.
+	// The 16 model IDs the gateway actually serves (Grok 4.5, GLM-5.2,
+	// GLM-5.1, Kimi K3, Kimi K2.7 Code, Kimi K2.6, MiMo-V2.5-Pro, MiMo-V2.5,
+	// Qwen3.7 Max, Qwen3.7 Plus, Qwen3.6 Plus, MiniMax M2.7, MiniMax M3,
+	// DeepSeek V4 Pro, DeepSeek V4 Flash, Hy3) are lowercase-hyphenated —
+	// e.g. "kimi-k3" — never "gpt-4o" or other upstream-native names.
+	ServiceTypeOpenCodeGo: {
+		DefaultModel: "kimi-k3",
+	},
 }
 
 // GetOpenAICompatibleProvider returns the provider configuration for the given

--- a/llm/providers_test.go
+++ b/llm/providers_test.go
@@ -20,6 +20,11 @@ func TestGetOpenAICompatibleProvider(t *testing.T) {
 			wantFound:   true,
 		},
 		{
+			name:        "opencodego returns provider",
+			serviceType: ServiceTypeOpenCodeGo,
+			wantFound:   true,
+		},
+		{
 			name:        "cohere not in compatible registry",
 			serviceType: ServiceTypeCohere,
 			wantFound:   false,
@@ -81,6 +86,30 @@ func TestScaleProviderConfig(t *testing.T) {
 
 	if p.CreateTransport == nil {
 		t.Fatal("expected CreateTransport to be non-nil for Scale")
+	}
+}
+
+func TestOpenCodeGoProviderConfig(t *testing.T) {
+	p, ok := GetOpenAICompatibleProvider(ServiceTypeOpenCodeGo)
+	if !ok {
+		t.Fatal("OpenCode Go provider not found in registry")
+	}
+
+	if p.DefaultModel != "kimi-k3" {
+		t.Errorf("DefaultModel = %q, want %q", p.DefaultModel, "kimi-k3")
+	}
+
+	// OpenCode Go uses standard Bearer auth, so the default transport is fine.
+	if p.CreateTransport != nil {
+		t.Error("expected CreateTransport to be nil for OpenCode Go (uses default Bearer auth)")
+	}
+
+	if p.DisableStreamOptions {
+		t.Error("expected DisableStreamOptions to be false for OpenCode Go")
+	}
+
+	if p.UseMaxTokens {
+		t.Error("expected UseMaxTokens to be false for OpenCode Go")
 	}
 }
 

--- a/llm/service_types.go
+++ b/llm/service_types.go
@@ -14,5 +14,6 @@ const (
 	ServiceTypeScale            = "scale"
 	ServiceTypeGemini           = "gemini"
 	ServiceTypeVertex           = "vertex"
+	ServiceTypeOpenCodeGo       = "opencodego"
 	ServiceTypeLoadTestMock     = "loadtest_mock"
 )

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -49,7 +49,6 @@ const mapServiceTypeToDisplayName = new Map<string, string>([
     ['bedrock', 'AWS Bedrock'],
     ['cohere', 'Cohere'],
     ['mistral', 'Mistral'],
-    ['opencodego', 'OpenCode Go'],
     ['asage', 'asksage (Experimental)'],
     ['gemini', 'Google Gemini'],
     ['vertex', 'Google Vertex AI'],
@@ -59,9 +58,16 @@ function scaleAIToDisplayName(intl: IntlShape): string {
     return intl.formatMessage({defaultMessage: 'Scale AI'});
 }
 
+function openCodeGoToDisplayName(intl: IntlShape): string {
+    return intl.formatMessage({defaultMessage: 'OpenCode Go'});
+}
+
 function serviceTypeToDisplayName(intl: IntlShape, serviceType: string): string {
     if (serviceType === 'scale') {
         return scaleAIToDisplayName(intl);
+    }
+    if (serviceType === 'opencodego') {
+        return openCodeGoToDisplayName(intl);
     }
     return mapServiceTypeToDisplayName.get(serviceType) || serviceType;
 }
@@ -261,7 +267,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
                 <SelectionItemOption value='azure'>{'Azure'}</SelectionItemOption>
                 <SelectionItemOption value='cohere'>{'Cohere'}</SelectionItemOption>
                 <SelectionItemOption value='mistral'>{'Mistral'}</SelectionItemOption>
-                <SelectionItemOption value='opencodego'>{mapServiceTypeToDisplayName.get('opencodego') || 'OpenCode Go'}</SelectionItemOption>
+                <SelectionItemOption value='opencodego'>{openCodeGoToDisplayName(intl)}</SelectionItemOption>
                 <SelectionItemOption value='scale'>{scaleAIToDisplayName(intl)}</SelectionItemOption>
                 <SelectionItemOption value='asage'>{'asksage (Experimental)'}</SelectionItemOption>
             </SelectionItem>

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -49,6 +49,7 @@ const mapServiceTypeToDisplayName = new Map<string, string>([
     ['bedrock', 'AWS Bedrock'],
     ['cohere', 'Cohere'],
     ['mistral', 'Mistral'],
+    ['opencodego', 'OpenCode Go'],
     ['asage', 'asksage (Experimental)'],
     ['gemini', 'Google Gemini'],
     ['vertex', 'Google Vertex AI'],
@@ -82,7 +83,7 @@ type ServiceFieldsProps = {
 export const ServiceFields = (props: ServiceFieldsProps) => {
     const type = props.service.type;
     const intl = useIntl();
-    const isOpenAIType = type === 'openai' || type === 'openaicompatible' || type === 'azure' || type === 'cohere' || type === 'mistral' || type === 'scale';
+    const isOpenAIType = type === 'openai' || type === 'openaicompatible' || type === 'azure' || type === 'cohere' || type === 'mistral' || type === 'scale' || type === 'opencodego';
     const supportsResponsesAPIToggle = type === 'openaicompatible' || type === 'azure';
     const isCohere = type === 'cohere';
     const isMistral = type === 'mistral';
@@ -260,6 +261,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
                 <SelectionItemOption value='azure'>{'Azure'}</SelectionItemOption>
                 <SelectionItemOption value='cohere'>{'Cohere'}</SelectionItemOption>
                 <SelectionItemOption value='mistral'>{'Mistral'}</SelectionItemOption>
+                <SelectionItemOption value='opencodego'>{mapServiceTypeToDisplayName.get('opencodego') || 'OpenCode Go'}</SelectionItemOption>
                 <SelectionItemOption value='scale'>{scaleAIToDisplayName(intl)}</SelectionItemOption>
                 <SelectionItemOption value='asage'>{'asksage (Experimental)'}</SelectionItemOption>
             </SelectionItem>
@@ -341,7 +343,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
             )}
             {isOpenAIType && (
                 <>
-                    {!isCohere && !isMistral && (
+                    {!isCohere && !isMistral && type !== 'opencodego' && (
                         <TextItem
                             label={isScale ? intl.formatMessage({defaultMessage: 'Account ID'}) : intl.formatMessage({defaultMessage: 'Organization ID'})}
                             value={props.service.orgId}

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -54,6 +54,7 @@
   "4DQcLSVp": "Failed to load the runtime bot list. The previous list is kept.",
   "4JvX9ZTE": "Context window",
   "4WFJMrw+": "Citation from unknown source",
+  "4WZ6dc/F": "OpenCode Go",
   "4X7ebZFx": "Your Google Cloud project ID (e.g., my-project-123)",
   "4XEuK9Zc": "Username is required",
   "4dZi3YBP": "API Key",


### PR DESCRIPTION
## Summary

Adds **OpenCode Go** as a first-class managed provider behind the existing OpenAI-compatible plumbing, registering it with a custom-provider slot whose `AllowedRequests` gate refuses every endpoint the gateway does not implement.
Default model is `kimi-k3`.

## Problem

OpenCode Go is an OpenAI-compatible inference gateway that exposes only `/v1/chat/completions` under `https://opencode.ai/zen/go/v1` (Bearer auth).
Routing the current `openaicompatible` config through Bifrost produced two
hard failures, both of which crashed the parser or the gateway:

1. **404 HTML on token preflight.** `CountTokens` always posts a Responses-API  request body to `/v1/responses/input_tokens`, which the gateway does not   serve. The 404 HTML response page is not JSON; Bifrost's parser crashes.
2. **400 on injected OpenAI metadata.** When `CountTokens` succeeded (it did not,   see (1)), Bifrost would inject `reasoning.effort` into the body for   reasoning-model names, which the gateway rejects as   `invalid_request_error` per its standard chat-completions contract.

The chat stream itself works once both issues are bypassed. The gateway's 16 model IDs are lowercase-hyphenated (`kimi-k3`, `grok-4.5`, `glm-5.2`,`qwen3.7-max`, `deepseek-v4-pro`, etc.); not the upstream-native names.

## Approach

Mirror the existing chat-only fallback wrap, but apply it on the **primary** path so `/v1/responses*` is blocked there too:

1. **Register `opencodego`** as a new `ServiceType` in the `openAICompatibleProviders` registry. Default model: `kimi-k3`.
2. **Custom-provider wrap on primary** (`bifrost/bifrost.go::New`): when  `cfg.Provider == schemas.OpenAI && !cfg.UseResponsesAPI`, the primary is  registered under a custom name (`openai::primary`) with `chatOnly = true`.
   `GetConfigForProvider` then attaches  `AllowedRequests{ChatCompletion: true, ChatCompletionStream: true}` —
   which (per `schemas.AllowedRequests` semantics) implicitly refuses every   other operation including `CountTokens`. Bifrost returns   `unsupported_operation` synchronously; the plugin maps that to
   `llm.ErrUnsupportedTokenCount`, which falls through to   `llm.EstimateTokens`.
3. **Route through the wrapped slot.** `b.provider` now stores the registered   name (`primaryEntry.registeredName()`) instead of the bare base type. As   a bonus this lands on Bifrost's `default:` arm in   `vendored.../providers/openai/chat.go` (which skips   `normalizeReasoningEffort`), doubling the chat-path protection.
4. **One source of truth for managed URLs.** Extracted
   `applyProviderURLDefaults` so the primary path (new) and the  `serviceConfigToFallbackEntry` path both inject
   `https://opencode.ai/zen/go/v1` for `opencodego`,  `https://api.cohere.ai/compatibility/v1` for `cohere`, and
   `https://api.mistral.ai/v1` for `mistral`. `normalizeOpenAIBaseURL` then  strips the trailing `/v1` so Bifrost can prepend `/v1/chat/completions`.
5. **Native tools excluded.** `SupportsNativeTools(ServiceTypeOpenCodeGo)`
   returns `false` explicitly  even though the base type is `schemas.OpenAI`,  the gateway does not implement native tools. Request-time filtering
   already short-circuits, but the public predicate stays accurate for  built-in-tool fallback gating.
6. **Transcriber switch is left alone** in `bots/bots.go`  OpenCode Go
   cannot serve `/v1/audio/transcriptions`, so it cannot be the transcript  generator. Existing allowlist (OpenAI / OpenAI-Compatible / Azure) is  intentionally narrower than the chat provider list.

## Files changed

| File | Change |
|---|---|
| `llm/service_types.go` | New `ServiceTypeOpenCodeGo = "opencodego"`. |
| `llm/providers.go` | Registry entry with `DefaultModel: "kimi-k3"`. |
| `llm/configuration.go` | `IsValidService` requires APIKey only; URL defaults. |
| `bifrost/config.go` | `MapServiceTypeToProvider`→`schemas.OpenAI`, `IsSupported` adds opencodego, `applyProviderURLDefaults` helper, `SupportsNativeTools` excludes opencodego. |
| `bifrost/bifrost.go` | Primary-wrap block; `LLM.account` field added for tests; `provider` carries `registeredName()`. |
| `webapp/src/components/system_console/service.tsx` | Dropdown option, display-name map, `isOpenAIType`; API URL and Org ID fields stay hidden (matches `mistral` UX). |

## Tests

- `bifrost/bifrost_test.go`
  - **New** `TestNew_OpenCodeGoPrimaryIsWrappedAsChatOnlyCustom` — asserts
    `b.provider == "openai::primary"`, the bare `schemas.OpenAI` slot is
    *not* registered, and `AllowedRequests` rejects
    `Responses`/`ResponsesStream`/`CountTokens` while allowing
    `ChatCompletion`/`ChatCompletionStream`.
  - **New** `TestNew_DirectOpenAIAndAzurePrimariesRemainStandard` — guards
    the inverse: real OpenAI/Azure primaries keep the bare base-type slot,
    not a custom slot.
  - **Extended** `TestProviderAccount_ChatOnlyCustomConfig` with
    `AllowedRequests.CountTokens` assertion.
- `bifrost/config_test.go` — opencodego entries for `SupportsNativeTools`
  and `FilterNativeToolsForServiceType`.
- `llm/providers_test.go`, `llm/configuration_test.go` — registry and
  `IsValidService` cases.
- `bifrost/bifrost_test.go::TestCountTokensOmitsMaxOutputTokens` updated:
  synthetic `Provider: schemas.OpenAI, UseResponsesAPI: false` configs are
  no longer reachable from `NewFromServiceConfig` (which forces `true`),
  so the test now uses the production value to keep exercising the
  body-shape assertion instead of the chat-only gate.

All `./llm/... ./bifrost/... ./bots/... ./config/... ./api/...` tests pass.

## Risk & follow-ups

- **Behavior expansion.** The wrap condition is `cfg.Provider ==
  schemas.OpenAI && !cfg.UseResponsesAPI`, which also covers  `openaicompatible` with the operator toggle off. That is arguably the  right behavior (same gateway pitfall) and is consistent with how the  fallback path already worked, but it is a behavior change for any  openaicompatible bot created before this PR. Worth a CHANGELOG entry.
- **No model auto-discovery.** `supportsModelFetching` in  `webapp/src/components/system_console/service.tsx` does not include
  `opencodego`, so admins must type the model name. OpenCode Go does serve  a `/v1/models` listing — adding it would be a one-liner behind a feature  flag if desired.
- **Documentation.** `docs/providers.md` should gain a short OpenCode Go  section. Out of scope here; happy to follow up.
- **Transcriber parity.** If/when OpenCode Go adds `/v1/audio/transcriptions`,  the switch in `bots/bots.go::GetTranscribe` can grow a case.

## Verification

- `go test ./llm/... ./bifrost/... ./bots/... ./config/... ./api/...` —
  green on Go 1.26.5.
- Bundle built: `make dist` produces a 113 MB tar.gz with five
  cross-compiled server binaries plus the webapp bundle that contains the
  new "OpenCode Go" dropdown entry.

## Screenshot
<img width="989" height="856" alt="image" src="https://github.com/user-attachments/assets/452c1612-eaa4-40dd-83fa-75ff0b6514f3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and using the OpenCode Go service.
  * Added OpenCode Go to the service selection menu with appropriate defaults, validation, and display labels.
  * OpenCode Go supports chat completions and streaming while excluding unsupported native tools and request types.
  * Improved provider diagnostics and standardized service URL handling.

* **Bug Fixes**
  * Prevented unsupported requests from being sent to chat-only providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->