### PR TITLE
Raise agent custom instructions limit to 100k runes and add character counter

### DIFF
--- a/api/api_agents.go
+++ b/api/api_agents.go
@@ -30,9 +30,10 @@ const WebsocketEventBotsInvalidate = "bots_invalidate"
 // WebsocketEventMCPConnectionUpdated is the event name for user-scoped MCP OAuth connection updates (webapp: custom_mattermost-ai_<name>).
 const WebsocketEventMCPConnectionUpdated = "mcp_connection_updated"
 
-// MaxAgentRequestBodyBytes caps the JSON body size for agent create/update requests
-// to protect against oversized payloads in the various ID slices and MCP tool lists.
-const MaxAgentRequestBodyBytes = 512 << 10 // 512 KiB
+// MaxAgentRequestBodyBytes caps agent create/update JSON bodies. It must comfortably
+// exceed the worst-case encoded size of llm.MaxCustomInstructionsRunes plus the
+// remaining payload.
+const MaxAgentRequestBodyBytes = 2 << 20 // 2 MiB
 
 // agentErrorResponse is the JSON body returned for failed agent requests. The
 // webapp surfaces Error directly to the user, so the message must be

--- a/e2e/tests/agents/crud.spec.ts
+++ b/e2e/tests/agents/crud.spec.ts
@@ -156,7 +156,7 @@ test.describe('Agent CRUD', () => {
         await expect(agentPage.getAgentRowByName('Delete Me')).not.toBeVisible({ timeout: 10000 });
     });
 
-    test('should surface actionable server error when custom instructions exceed limit', async ({ page }) => {
+    test('should block saving with actionable error when custom instructions exceed limit', async ({ page }) => {
         test.setTimeout(60000);
         const mmPage = new MattermostPage(page);
         const agentPage = new AgentPageHelper(page);
@@ -167,8 +167,9 @@ test.describe('Agent CRUD', () => {
         await agentPage.getCreateButton().click();
         await agentPage.waitForModal();
 
-        // 16384 is llm.MaxCustomInstructionsRunes; one extra char trips Validate().
-        const oversizedInstructions = 'a'.repeat(16385);
+        // 100000 is llm.MaxCustomInstructionsRunes (mirrored by the webapp's
+        // MaxCustomInstructionsRunes); one extra char trips validation.
+        const oversizedInstructions = 'a'.repeat(100001);
 
         await agentPage.fillConfigTab({
             displayName: 'Oversized Prompt Agent',
@@ -179,9 +180,8 @@ test.describe('Agent CRUD', () => {
 
         await agentPage.getModalSaveButton().click();
 
-        // The fix surfaces the server-provided message verbatim. The generic
-        // "Please try again." hint was misleading because retrying never helps.
-        await expect(page.getByText(/customInstructions exceeds maximum length/i)).toBeVisible({ timeout: 15000 });
+        // Client-side validation blocks the save with a field-scoped error.
+        await expect(page.getByText('Custom instructions must be 100,000 characters or fewer')).toBeVisible({ timeout: 15000 });
         await expect(page.getByText('Failed to save agent. Please try again.')).not.toBeVisible();
     });
 

--- a/llm/configuration.go
+++ b/llm/configuration.go
@@ -11,9 +11,9 @@ import (
 	"unicode/utf8"
 )
 
-// MaxCustomInstructionsRunes caps BotConfig.CustomInstructions at a length that keeps
-// the system prompt bounded on every conversation turn.
-const MaxCustomInstructionsRunes = 16384
+// MaxCustomInstructionsRunes bounds the per-turn LLM system prompt and agent-save
+// request. Custom instructions are sent only to the LLM, not as Mattermost posts.
+const MaxCustomInstructionsRunes = 100000
 
 // DefaultMaxToolTurns is the default tool-call-execute-recall ceiling per LLM turn.
 // Agents that store 0 (legacy config bots, freshly-migrated rows before the column

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -5,6 +5,7 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,32 @@ func TestBotConfig_IsValid(t *testing.T) {
 				UserAccessLevel:    UserAccessLevelAll,
 			},
 			want: true,
+		},
+		{
+			name: "Custom instructions at maximum length",
+			fields: fields{
+				ID:                 "xxx",
+				Name:               "xxx",
+				DisplayName:        "xxx",
+				CustomInstructions: strings.Repeat("界", MaxCustomInstructionsRunes),
+				ServiceID:          "service-id",
+				ChannelAccessLevel: ChannelAccessLevelAll,
+				UserAccessLevel:    UserAccessLevelAll,
+			},
+			want: true,
+		},
+		{
+			name: "Custom instructions above maximum length",
+			fields: fields{
+				ID:                 "xxx",
+				Name:               "xxx",
+				DisplayName:        "xxx",
+				CustomInstructions: strings.Repeat("界", MaxCustomInstructionsRunes+1),
+				ServiceID:          "service-id",
+				ChannelAccessLevel: ChannelAccessLevelAll,
+				UserAccessLevel:    UserAccessLevelAll,
+			},
+			want: false,
 		},
 		{
 			name: "Valid OpenAI configuration with ChannelAccessLevelNone",

--- a/webapp/src/components/agents/agent_config_view.test.tsx
+++ b/webapp/src/components/agents/agent_config_view.test.tsx
@@ -464,13 +464,35 @@ describe('AgentConfigView', () => {
         expect(updateAgent).not.toHaveBeenCalled();
     });
 
-    test('blocks saving when custom instructions exceed the character limit', () => {
+    test.each([
+        ['exactly the ASCII character limit', 'a'.repeat(MaxCustomInstructionsRunes)],
+        // Code points under the limit but UTF-16 length over it: catches .length-based counting.
+        ['astral characters below the character limit', '😀'.repeat((MaxCustomInstructionsRunes / 2) + 1)],
+    ])('allows saving with %s', async (_description, customInstructions) => {
+        mockCreateAgent.mockResolvedValue(savedAgent);
         renderView();
 
         fireEvent.change(screen.getByLabelText('Display Name'), {target: {value: 'My Agent'}});
         fireEvent.change(screen.getByLabelText('Username'), {target: {value: 'myagent'}});
         fireEvent.change(screen.getByLabelText('Custom instructions'), {
-            target: {value: 'a'.repeat(MaxCustomInstructionsRunes + 1)},
+            target: {value: customInstructions},
+        });
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        await waitFor(() => expect(mockCreateAgent).toHaveBeenCalledTimes(1));
+        expect(screen.queryByText('Custom instructions must be 100,000 characters or fewer')).toBeNull();
+    });
+
+    test.each([
+        ['ASCII characters', 'a'.repeat(MaxCustomInstructionsRunes + 1)],
+        ['astral characters', '😀'.repeat(MaxCustomInstructionsRunes + 1)],
+    ])('blocks saving when custom instructions exceed the character limit using %s', (_description, customInstructions) => {
+        renderView();
+
+        fireEvent.change(screen.getByLabelText('Display Name'), {target: {value: 'My Agent'}});
+        fireEvent.change(screen.getByLabelText('Username'), {target: {value: 'myagent'}});
+        fireEvent.change(screen.getByLabelText('Custom instructions'), {
+            target: {value: customInstructions},
         });
         fireEvent.click(screen.getByRole('button', {name: 'Save'}));
 

--- a/webapp/src/components/agents/agent_config_view.test.tsx
+++ b/webapp/src/components/agents/agent_config_view.test.tsx
@@ -466,6 +466,7 @@ describe('AgentConfigView', () => {
 
     test.each([
         ['exactly the ASCII character limit', 'a'.repeat(MaxCustomInstructionsRunes)],
+
         // Code points under the limit but UTF-16 length over it: catches .length-based counting.
         ['astral characters below the character limit', '😀'.repeat((MaxCustomInstructionsRunes / 2) + 1)],
     ])('allows saving with %s', async (_description, customInstructions) => {

--- a/webapp/src/components/agents/agent_config_view.test.tsx
+++ b/webapp/src/components/agents/agent_config_view.test.tsx
@@ -6,7 +6,7 @@ import {fireEvent, render, screen, waitFor, waitForElementToBeRemoved} from '@te
 import {IntlProvider} from 'react-intl';
 
 import {createAgent, updateAgent} from '@/client';
-import {EnabledTool, ServiceInfo, UserAgent} from '@/types/agents';
+import {EnabledTool, MaxCustomInstructionsRunes, ServiceInfo, UserAgent} from '@/types/agents';
 
 import AgentConfigView, {AgentDraft} from './agent_config_view';
 
@@ -24,6 +24,7 @@ jest.mock('react-intl', () => {
                     defaultMessage,
                 );
             },
+            formatNumber: (value: number) => new Intl.NumberFormat('en').format(value),
         }),
         FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
     };
@@ -69,6 +70,12 @@ jest.mock('./tabs/config_tab', () => ({
                 onChange={(e) => onChange({maxToolTurns: Number(e.target.value)})}
             />
             {errors.maxToolTurns && <div>{errors.maxToolTurns}</div>}
+            <textarea
+                aria-label='Custom instructions'
+                value={draft.customInstructions}
+                onChange={(e) => onChange({customInstructions: e.target.value})}
+            />
+            {errors.customInstructions && <div>{errors.customInstructions}</div>}
             <input
                 aria-label='Dynamic tool loading'
                 type='checkbox'
@@ -455,6 +462,20 @@ describe('AgentConfigView', () => {
 
         expect(screen.getByText('Max tool turns must be between 1 and 250')).not.toBeNull();
         expect(updateAgent).not.toHaveBeenCalled();
+    });
+
+    test('blocks saving when custom instructions exceed the character limit', () => {
+        renderView();
+
+        fireEvent.change(screen.getByLabelText('Display Name'), {target: {value: 'My Agent'}});
+        fireEvent.change(screen.getByLabelText('Username'), {target: {value: 'myagent'}});
+        fireEvent.change(screen.getByLabelText('Custom instructions'), {
+            target: {value: 'a'.repeat(MaxCustomInstructionsRunes + 1)},
+        });
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(screen.getByText('Custom instructions must be 100,000 characters or fewer')).not.toBeNull();
+        expect(createAgent).not.toHaveBeenCalled();
     });
 
     test('preserves explicit dynamic tool loading false on update', async () => {

--- a/webapp/src/components/agents/agent_config_view.tsx
+++ b/webapp/src/components/agents/agent_config_view.tsx
@@ -7,7 +7,17 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {ArrowLeftIcon} from '@mattermost/compass-icons/components';
 
 import {createAgent, updateAgent, uploadAgentAvatar} from '@/client';
-import {UserAgent, CreateAgentRequest, UpdateAgentRequest, EnabledTool, ServiceInfo} from '@/types/agents';
+import {
+    UserAgent,
+    CreateAgentRequest,
+    UpdateAgentRequest,
+    EnabledTool,
+    MaxCustomInstructionsRunes,
+    ServiceInfo,
+    DefaultMaxToolTurns,
+    MaxAllowedMaxToolTurns,
+    codePointLength,
+} from '@/types/agents';
 import {ChannelAccessLevel, UserAccessLevel} from '@/components/system_console/bot';
 import {PrimaryButton, TertiaryButton} from '@/components/assets/buttons';
 import ConfirmationDialog from '@/components/confirmation_dialog';
@@ -45,12 +55,6 @@ export type AgentDraft = {
     structuredOutputEnabled: boolean;
     maxToolTurns: number;
 }
-
-// DefaultMaxToolTurns mirrors llm.DefaultMaxToolTurns on the backend. Kept
-// here so the create form pre-populates the field even before any service is
-// selected.
-export const DefaultMaxToolTurns = 30;
-export const MaxAllowedMaxToolTurns = 250;
 
 const emptyDraft: AgentDraft = {
     displayName: '',
@@ -301,6 +305,12 @@ const AgentConfigView = (props: Props) => {
         }
         if (!draft.serviceId) {
             errs.serviceId = intl.formatMessage({defaultMessage: 'AI Service is required'});
+        }
+        if (codePointLength(draft.customInstructions) > MaxCustomInstructionsRunes) {
+            errs.customInstructions = intl.formatMessage(
+                {defaultMessage: 'Custom instructions must be {max} characters or fewer'},
+                {max: intl.formatNumber(MaxCustomInstructionsRunes)},
+            );
         }
         if (draft.maxToolTurns < 1 || draft.maxToolTurns > MaxAllowedMaxToolTurns) {
             errs.maxToolTurns = intl.formatMessage(

--- a/webapp/src/components/agents/tabs/config_tab.tsx
+++ b/webapp/src/components/agents/tabs/config_tab.tsx
@@ -7,7 +7,13 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/components';
 
 import {fetchModelsForAgentService} from '@/client';
-import {ServiceInfo} from '@/types/agents';
+import {
+    codePointLength,
+    DefaultMaxToolTurns,
+    MaxAllowedMaxToolTurns,
+    MaxCustomInstructionsRunes,
+    ServiceInfo,
+} from '@/types/agents';
 import {
     BooleanItem,
     ComboboxItem,
@@ -31,7 +37,7 @@ import {IntItem} from '@/components/system_console/number_items';
 import ReasoningConfigItem from '@/components/system_console/reasoning_config';
 import {LLMService} from '@/components/system_console/service';
 
-import {AgentDraft, DefaultMaxToolTurns, MaxAllowedMaxToolTurns} from '../agent_config_view';
+import {AgentDraft} from '../agent_config_view';
 
 type Props = {
     draft: AgentDraft;
@@ -48,12 +54,16 @@ type Props = {
 // Keep in sync with legacy System Console bot form (webapp/src/components/system_console/bot.tsx).
 const visionToolServiceTypes = ['openai', 'openaicompatible', 'azure', 'anthropic', 'cohere', 'mistral', 'gemini', 'vertex'];
 const openAIStructuredOutputServiceTypes = ['openai', 'openaicompatible', 'azure'];
+const CUSTOM_INSTRUCTIONS_LENGTH_WARNING_THRESHOLD = MaxCustomInstructionsRunes * 0.9;
 
 const ConfigTab = (props: Props) => {
     const {draft, onChange, onAvatarChange, services, errors = {}, usernameLocked = false} = props;
     const intl = useIntl();
     const [advancedExpanded, setAdvancedExpanded] = useState(false);
     const [availableModels, setAvailableModels] = useState<{id: string; displayName: string}[]>([]);
+    const customInstructionsLength = useMemo(() => codePointLength(draft.customInstructions), [draft.customInstructions]);
+    const showCustomInstructionsCounter = customInstructionsLength >= CUSTOM_INSTRUCTIONS_LENGTH_WARNING_THRESHOLD;
+    const customInstructionsOverLimit = customInstructionsLength > MaxCustomInstructionsRunes;
 
     useEffect(() => {
         if (errors.maxToolTurns) {
@@ -330,6 +340,14 @@ const ConfigTab = (props: Props) => {
                     multiline={true}
                     value={draft.customInstructions}
                     onChange={(e) => onChange({customInstructions: e.target.value})}
+                    error={errors.customInstructions}
+                    helptext={showCustomInstructionsCounter && (
+                        <CharacterCounter $hasError={customInstructionsOverLimit}>
+                            {intl.formatNumber(customInstructionsLength)}
+                            {' / '}
+                            {intl.formatNumber(MaxCustomInstructionsRunes)}
+                        </CharacterCounter>
+                    )}
                 />
             </ItemList>
 
@@ -469,6 +487,11 @@ const FormContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 24px;
+`;
+
+const CharacterCounter = styled.div<{$hasError: boolean}>`
+    color: ${({$hasError}) => ($hasError ? 'var(--error-text)' : 'rgba(var(--center-channel-color-rgb), 0.64)')};
+    text-align: right;
 `;
 
 const AdvancedSection = styled.div`

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -63,7 +63,7 @@ export type TextItemProps = {
     label: string,
     value: string,
     type?: string,
-    helptext?: string,
+    helptext?: React.ReactNode,
     multiline?: boolean,
     placeholder?: string,
     maxLength?: number,

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -337,6 +337,7 @@
   "bikXVccI": "Failed to cancel reindexing job.",
   "bm20kUs+": "Needs Reindex",
   "btXAieN2": "{tokens} ({pct}%)",
+  "c3TBYq1b": "Custom instructions must be {max} characters or fewer",
   "c9vr6I5Z": "You do not have permission to perform this action.",
   "cA6M2lTV": "Multiple self-service agents require a qualifying Mattermost plan",
   "cAQb5tZd": "Use the new OpenAI Responses API with support for reasoning summaries and other advanced features. Disable for legacy Completions API compatibility.",

--- a/webapp/src/types/agents.ts
+++ b/webapp/src/types/agents.ts
@@ -3,6 +3,18 @@
 
 import {ChannelAccessLevel, UserAccessLevel} from '@/components/system_console/bot';
 
+// Mirrors llm.MaxCustomInstructionsRunes on the backend.
+export const MaxCustomInstructionsRunes = 100000;
+
+// Mirrors llm.DefaultMaxToolTurns on the backend.
+export const DefaultMaxToolTurns = 30;
+
+// Mirrors llm.MaxAllowedMaxToolTurns on the backend.
+export const MaxAllowedMaxToolTurns = 250;
+
+// Counts Unicode code points to match Go's utf8.RuneCountInString.
+export const codePointLength = (s: string): number => Array.from(s).length;
+
 // EnabledTool matches llm.EnabledMCPTool (persisted agents and config bots).
 // Inner field names stay snake_case to match the backend's json:"server_origin"
 // / json:"tool_name" tags; see .planning/phase-1/PLAN.md pitfall P2.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Raises `llm.MaxCustomInstructionsRunes` from 16,384 to 100,000. The old value was borrowed from Mattermost's max post size (`PostMessageMaxRunesV2` = 16,383), but custom instructions are never rendered as a post — they only go into the LLM system prompt, and are stored in a Postgres `TEXT` column. With modern 200k+ token context windows and dynamic MCP tool loading keeping context light, the tighter cap was arbitrary.

Changes:

- `llm/configuration.go`: raise `MaxCustomInstructionsRunes` to 100,000 and correct the rationale comment.
- `api/api_agents.go`: raise `MaxAgentRequestBodyBytes` from 512 KiB to 2 MiB so worst-case UTF-8 instructions plus the rest of the agent payload fit within the create/update body cap.
- `llm/configuration_test.go`: add boundary (exactly at limit) and over-limit validation cases using multi-byte runes to exercise rune-vs-byte semantics.
- Webapp: add a character counter to the custom instructions textarea in the agent config form. It appears at 90% of the limit, shows locale-formatted "current / max", and turns red when over. Client-side validation now blocks saving over-limit instructions with a field-scoped error instead of surfacing a raw server 400. Counting uses Unicode code points (`codePointLength` helper) to match Go's `utf8.RuneCountInString`.
- Webapp: consolidate the Go-mirrored constants (`MaxCustomInstructionsRunes`, `DefaultMaxToolTurns`, `MaxAllowedMaxToolTurns`) into `webapp/src/types/agents.ts`.
- `e2e/tests/agents/crud.spec.ts`: update the oversized-instructions test for the new limit and the client-side validation message.

QA test steps:

1. Create or edit an agent and paste more than 90,000 characters into Custom instructions — a "current / 100,000" counter appears under the textarea.
2. Exceed 100,000 characters — the counter turns red; clicking Save shows "Custom instructions must be 100,000 characters or fewer" and does not save.
3. Instructions up to 100,000 characters save successfully.

#### Screenshots

| approaching limit | over limit |
|----|----|
| <img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/cf4e94f2-a798-472c-a9c7-348773294de7" />) | <img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/45fae8b8-8b67-4646-8eb7-81572ce03a77" /> |

#### Release Note

```release-note
Increased the maximum length of an agent's custom instructions from 16,384 to 100,000 characters. The agent configuration form now shows a character counter when instructions approach the limit and validates the limit before saving.
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da624ce-c153-4633-98c7-3124fc6ecc57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da624ce-c153-4633-98c7-3124fc6ecc57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the custom-instructions limit to 100,000 characters.
  * Added a live character counter and clear validation feedback in agent configuration.
  * Unicode characters are counted accurately when checking limits.

* **Bug Fixes**
  * Prevented saving configurations when custom instructions exceed the limit.
  * Increased request capacity to support larger valid configurations.

* **Tests**
  * Added coverage for boundary conditions, Unicode input, and client-side validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->