### PR TITLE
MCP server: fix DM thread replies, DM/GM create_post validation, and silent attachment failures

### DIFF
--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -336,11 +336,9 @@ func uploadInlineFiles(ctx context.Context, client *model.Client4, channelID str
 	return fileIDs, nil
 }
 
-// checkCombinedFileCap returns a model-facing error when resolved legacy attachment
-// IDs plus requested inline files would exceed the per-post attachment cap. Resolvers
-// call it after resolving legacy attachments but before uploading any inline file, so
-// a cap violation never orphans inline uploads (best-effort legacy attachment uploads
-// may still be orphaned when the cap trips).
+// checkCombinedFileCap returns a model-facing error when legacy attachments plus
+// requested inline files would exceed the per-post attachment cap. Resolvers call
+// it before any upload, so a cap violation cannot orphan uploads.
 func checkCombinedFileCap(attachmentIDCount, inlineFileCount int) error {
 	if total := attachmentIDCount + inlineFileCount; total > maxFilesPerPost {
 		return fmt.Errorf("too many attachments: %d files and attachments combined but a post can have at most %d - reduce the number of inline files or attachments", total, maxFilesPerPost)
@@ -370,18 +368,19 @@ func inlineFilesMessage(count int) string {
 }
 
 // resolvePostFiles resolves a posting tool's legacy attachments and inline
-// files into the post's file IDs plus a success-message suffix. Legacy
-// attachments resolve first so the combined cap is enforced before any inline
-// upload; a failure on either path aborts because a post missing files the
-// model explicitly asked for is broken output.
+// files into the post's file IDs plus a success-message suffix. The combined
+// cap is enforced up front — each attachment resolves to exactly one file ID,
+// so the total is known before any upload — and a failure on either path
+// aborts because a post missing files the model explicitly asked for is
+// broken output.
 func resolvePostFiles(ctx context.Context, client *model.Client4, channelID string, attachments []string, files []InlineFile, accessMode AccessMode) ([]string, string, error) {
+	if capErr := checkCombinedFileCap(len(attachments), len(files)); capErr != nil {
+		return nil, "", capErr
+	}
+
 	attachmentFileIDs, attachmentMessage, err := uploadFilesAndUrlsForLocal(ctx, client, channelID, attachments, accessMode)
 	if err != nil {
 		return nil, "", err
-	}
-
-	if capErr := checkCombinedFileCap(len(attachmentFileIDs), len(files)); capErr != nil {
-		return nil, "", capErr
 	}
 
 	inlineFileIDs, err := uploadInlineFiles(ctx, client, channelID, files)

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -371,14 +371,17 @@ func inlineFilesMessage(count int) string {
 
 // resolvePostFiles resolves a posting tool's legacy attachments and inline
 // files into the post's file IDs plus a success-message suffix. Legacy
-// attachments resolve first (best-effort) so the combined cap is enforced
-// before any inline upload; an inline-file failure aborts because a post
-// missing files the model explicitly asked to create is broken output.
+// attachments resolve first so the combined cap is enforced before any inline
+// upload; a failure on either path aborts because a post missing files the
+// model explicitly asked for is broken output.
 func resolvePostFiles(ctx context.Context, client *model.Client4, channelID string, attachments []string, files []InlineFile, accessMode AccessMode) ([]string, string, error) {
-	attachmentFileIDs, attachmentMessage := uploadFilesAndUrlsForLocal(ctx, client, channelID, attachments, accessMode)
-
-	if err := checkCombinedFileCap(len(attachmentFileIDs), len(files)); err != nil {
+	attachmentFileIDs, attachmentMessage, err := uploadFilesAndUrlsForLocal(ctx, client, channelID, attachments, accessMode)
+	if err != nil {
 		return nil, "", err
+	}
+
+	if capErr := checkCombinedFileCap(len(attachmentFileIDs), len(files)); capErr != nil {
+		return nil, "", capErr
 	}
 
 	inlineFileIDs, err := uploadInlineFiles(ctx, client, channelID, files)
@@ -394,29 +397,26 @@ func resolvePostFiles(ctx context.Context, client *model.Client4, channelID stri
 	return fileIDs, attachmentMessage + inlineFilesMessage(len(inlineFileIDs)), nil
 }
 
-// uploadFilesAndUrlsForLocal uploads files from URLs or file paths (local access only) and returns file IDs and status message
-func uploadFilesAndUrlsForLocal(ctx context.Context, client *model.Client4, channelID string, attachments []string, accessMode AccessMode) ([]string, string) {
-	var fileIDs []string
-	var attachmentMessage string
-
-	if len(attachments) > 0 {
-		if accessMode != AccessModeLocal {
-			attachmentMessage = " (file attachments not supported in remote access mode)"
-			return nil, attachmentMessage
-		}
-
-		uploadedFileIDs, uploadErr := uploadFilesForLocal(ctx, client, channelID, attachments, accessMode)
-		if uploadErr != nil {
-			if errors.Is(uploadErr, errMCPFileUploadFailed) {
-				attachmentMessage = " (file upload failed)"
-			} else {
-				attachmentMessage = fmt.Sprintf(" (file upload failed: %v)", uploadErr)
-			}
-		} else {
-			fileIDs = uploadedFileIDs
-			attachmentMessage = fmt.Sprintf(" (uploaded %d files)", len(fileIDs))
-		}
+// uploadFilesAndUrlsForLocal uploads files from URLs or file paths (local access only)
+// and returns file IDs and a status message for the success response. When any
+// attachment fails to upload it returns an error so callers can abort instead of
+// posting a message without its attachments.
+func uploadFilesAndUrlsForLocal(ctx context.Context, client *model.Client4, channelID string, attachments []string, accessMode AccessMode) ([]string, string, error) {
+	if len(attachments) == 0 {
+		return nil, "", nil
 	}
 
-	return fileIDs, attachmentMessage
+	if accessMode != AccessModeLocal {
+		return nil, "", fmt.Errorf("file attachments are not supported in remote access mode; the post was NOT created - retry without attachments if the message alone is acceptable")
+	}
+
+	fileIDs, uploadErr := uploadFilesForLocal(ctx, client, channelID, attachments, accessMode)
+	if uploadErr != nil {
+		if errors.Is(uploadErr, errMCPFileUploadFailed) {
+			return nil, "", fmt.Errorf("file upload failed; the post was NOT created - fix the attachment or retry without it")
+		}
+		return nil, "", fmt.Errorf("file upload failed (%v); the post was NOT created - fix the attachment or retry without it", uploadErr)
+	}
+
+	return fileIDs, fmt.Sprintf(" (uploaded %d files)", len(fileIDs)), nil
 }

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -208,3 +208,45 @@ func TestUploadInlineFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestUploadFilesAndUrlsForLocal_FailureAbortsPost(t *testing.T) {
+	testCases := []struct {
+		name        string
+		attachments []string
+		accessMode  AccessMode
+		wantErr     bool
+	}{
+		{
+			name:        "no attachments is a no-op",
+			attachments: nil,
+			accessMode:  AccessModeLocal,
+			wantErr:     false,
+		},
+		{
+			name:        "attachments in remote mode return an error instead of posting silently",
+			attachments: []string{"anything.txt"},
+			accessMode:  AccessModeRemote,
+			wantErr:     true,
+		},
+		{
+			name:        "unreadable attachment returns an error instead of posting silently",
+			attachments: []string{"does-not-exist.txt"},
+			accessMode:  AccessModeLocal,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fileIDs, message, err := uploadFilesAndUrlsForLocal(t.Context(), nil, "channelid", tc.attachments, tc.accessMode)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Empty(t, fileIDs)
+			} else {
+				require.NoError(t, err)
+				require.Empty(t, fileIDs)
+				require.Empty(t, message)
+			}
+		})
+	}
+}

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -44,6 +44,7 @@ type CreatePostAsUserArgs struct {
 type DMArgs struct {
 	Username    string       `json:"username,omitempty" jsonschema:"Target username. If omitted the message is sent to yourself."`
 	Message     string       `json:"message" jsonschema:"The message content to send,minLength=1"`
+	RootID      string       `json:"root_id,omitempty" jsonschema:"Optional post ID to reply in an existing thread of this DM. Any post ID from the thread works; replies always land on the thread root.,maxLength=26"`
 	Attachments []string     `json:"attachments,omitempty" access:"local" jsonschema:"Optional list of file paths or URLs to attach"`
 	Files       []InlineFile `json:"files,omitempty" jsonschema:"Optional text files to create from inline content and attach to the post (max 10). The file name extension determines the file type."`
 }
@@ -52,6 +53,7 @@ type DMArgs struct {
 type GroupMessageArgs struct {
 	Usernames   []string     `json:"usernames" jsonschema:"Target usernames (must be at least 2)."`
 	Message     string       `json:"message" jsonschema:"The message content to send,minLength=1"`
+	RootID      string       `json:"root_id,omitempty" jsonschema:"Optional post ID to reply in an existing thread of this group conversation. Any post ID from the thread works; replies always land on the thread root.,maxLength=26"`
 	Attachments []string     `json:"attachments,omitempty" access:"local" jsonschema:"Optional list of file paths or URLs to attach"`
 	Files       []InlineFile `json:"files,omitempty" jsonschema:"Optional text files to create from inline content and attach to the post (max 10). The file name extension determines the file type."`
 }
@@ -62,11 +64,11 @@ type GroupMessageArgs struct {
 const (
 	readPostDescription = "Read a specific post and its thread from Mattermost. Parameters: post_id (required), include_thread (boolean, default true). Returns post content, author info, and optionally all replies in the thread. Example: {\"post_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"include_thread\": true}"
 
-	createPostDescriptionFmt = "Create a new post in Mattermost. IMPORTANT WORKFLOW: You MUST first call get_channel_info to obtain the channel_id, channel_display_name, and team_display_name. Present this context to the user before posting. Then call this tool with all required parameters. This ensures full transparency about where the message will be posted. Parameters: channel_id (required), message (required), root_id (optional - for replies), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns created post details including ID and timestamp. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"message\": \"Hello team!\"}"
+	createPostDescriptionFmt = "Create a new post in Mattermost. IMPORTANT WORKFLOW: You MUST first call get_channel_info to obtain the channel_id, channel_display_name, and team_display_name. Present this context to the user before posting. Then call this tool with all required parameters. This ensures full transparency about where the message will be posted. For DM and group conversations (which have no display name or team) pass channel_display_name 'Direct Message' or 'Group Message' and team_display_name 'N/A'. Parameters: channel_id (required), message (required), root_id (optional - for replies; any post ID from the thread works), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns created post details including ID and timestamp. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"message\": \"Hello team!\"}"
 
-	dmDescriptionFmt = "Send a direct message to a user. Provide username to specify the recipient. If username is omitted, the message is sent to yourself. This is the DEFAULT way to message people — call it multiple times to message multiple people individually. Only use the group_message tool when the user explicitly asks for a group chat. Parameters: message (required), username (optional), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns confirmation with message ID. Example: {\"message\": \"Hello!\", \"username\": \"john\"}"
+	dmDescriptionFmt = "Send a direct message to a user. Provide username to specify the recipient. If username is omitted, the message is sent to yourself. This is the DEFAULT way to message people — call it multiple times to message multiple people individually. Only use the group_message tool when the user explicitly asks for a group chat. Parameters: message (required), username (optional), root_id (optional - to reply in an existing thread of the DM), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns confirmation with message ID. Example: {\"message\": \"Hello!\", \"username\": \"john\"}"
 
-	groupMessageDescriptionFmt = "Send a message to a shared group conversation with 2 or more other users. All participants can see each other's messages. ONLY use this when the user explicitly asks for a group message, group chat, or group conversation. If the user just asks to 'message' or 'send to' multiple people, use the dm tool once per person instead. Parameters: message (required), usernames (at least 2 required), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns confirmation with message ID. Example: {\"message\": \"Hey team!\", \"usernames\": [\"alice\", \"bob\"]}"
+	groupMessageDescriptionFmt = "Send a message to a shared group conversation with 2 or more other users. All participants can see each other's messages. ONLY use this when the user explicitly asks for a group message, group chat, or group conversation. If the user just asks to 'message' or 'send to' multiple people, use the dm tool once per person instead. Parameters: message (required), usernames (at least 2 required), root_id (optional - to reply in an existing thread), files (optional: create and attach text files inline by providing name + content; the extension sets the file type; max 10)%s. Returns confirmation with message ID. Example: {\"message\": \"Hey team!\", \"usernames\": [\"alice\", \"bob\"]}"
 )
 
 // getPostTools returns all post-related tools
@@ -288,6 +290,32 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, args R
 	return result.String(), nil
 }
 
+// resolveThreadRoot validates a reply target and returns the ID of the actual
+// thread root. Mattermost only supports one level of threading, so when rootID
+// points at a reply the reply's own root is returned; models frequently pass
+// the ID of the latest post in a thread rather than the root. An empty rootID
+// resolves to "".
+func resolveThreadRoot(mcpContext *MCPToolContext, channelID, rootID string) (string, error) {
+	if rootID == "" {
+		return "", nil
+	}
+	if err := requireID("root_id", rootID); err != nil {
+		return "", err
+	}
+
+	rootPost, _, err := mcpContext.Client.GetPost(mcpContext.Ctx, rootID, "")
+	if err != nil {
+		return "", fmt.Errorf("error fetching root post %s: %w", rootID, err)
+	}
+	if rootPost.ChannelId != channelID {
+		return "", fmt.Errorf("root_id %s belongs to channel %s, not the target conversation %s - use a post ID from the same conversation", rootID, rootPost.ChannelId, channelID)
+	}
+	if rootPost.RootId != "" {
+		return rootPost.RootId, nil
+	}
+	return rootPost.Id, nil
+}
+
 // toolCreatePost implements the create_post tool
 func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args CreatePostArgs) (string, error) {
 	// Validate required fields
@@ -318,36 +346,60 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 		return "", fmt.Errorf("error fetching channel for validation: %w", err)
 	}
 
-	// Check if channel display name matches
-	if channel.DisplayName != args.ChannelDisplayName {
-		return "", fmt.Errorf("channel_display_name mismatch: provided '%s' but channel ID '%s' has display name '%s'",
-			args.ChannelDisplayName, args.ChannelID, channel.DisplayName)
+	// DM and group channels have no display name and no team, so the strict
+	// display-name context check only applies to regular team channels.
+	channelDisplayName := channel.DisplayName
+	var teamDisplayName string
+	switch channel.Type {
+	case model.ChannelTypeDirect, model.ChannelTypeGroup:
+		if channelDisplayName == "" {
+			channelDisplayName = "Direct Message"
+			if channel.Type == model.ChannelTypeGroup {
+				channelDisplayName = "Group Message"
+			}
+		}
+		teamDisplayName = "N/A"
+	default:
+		// Check if channel display name matches
+		if channel.DisplayName != args.ChannelDisplayName {
+			return "", fmt.Errorf("channel_display_name mismatch: provided '%s' but channel ID '%s' has display name '%s'",
+				args.ChannelDisplayName, args.ChannelID, channel.DisplayName)
+		}
+
+		// Get team info to validate team display name
+		team, _, teamErr := client.GetTeam(ctx, channel.TeamId, "")
+		if teamErr != nil {
+			return "", fmt.Errorf("error fetching team for validation: %w", teamErr)
+		}
+
+		// Check if team display name matches
+		if team.DisplayName != args.TeamDisplayName {
+			return "", fmt.Errorf("team_display_name mismatch: provided '%s' but team ID '%s' has display name '%s'",
+				args.TeamDisplayName, channel.TeamId, team.DisplayName)
+		}
+		teamDisplayName = team.DisplayName
 	}
 
-	// Get team info to validate team display name
-	team, _, err := client.GetTeam(ctx, channel.TeamId, "")
-	if err != nil {
-		return "", fmt.Errorf("error fetching team for validation: %w", err)
-	}
-
-	// Check if team display name matches
-	if team.DisplayName != args.TeamDisplayName {
-		return "", fmt.Errorf("team_display_name mismatch: provided '%s' but team ID '%s' has display name '%s'",
-			args.TeamDisplayName, channel.TeamId, team.DisplayName)
-	}
-
-	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, args.ChannelID, args.Attachments, args.Files, mcpContext.AccessMode)
+	// Resolve the reply target to the actual thread root
+	rootID, err := resolveThreadRoot(mcpContext, args.ChannelID, args.RootID)
 	if err != nil {
 		return "", err
 	}
 
-	// Create the post
+	// Build and validate the post before uploading attachments so validation
+	// failures do not leave orphaned uploads on the server.
 	post := &model.Post{
 		ChannelId: args.ChannelID,
 		Message:   args.Message,
-		RootId:    args.RootID,
-		FileIds:   fileIDs,
+		RootId:    rootID,
 	}
+
+	// Upload files if specified
+	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, args.ChannelID, args.Attachments, args.Files, mcpContext.AccessMode)
+	if err != nil {
+		return "", err
+	}
+	post.FileIds = fileIDs
 
 	p.stampAIGenerated(post, mcpContext, "")
 
@@ -357,7 +409,7 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 	}
 
 	return fmt.Sprintf("Successfully created post in channel '%s' (Team: %s) with ID: %s%s",
-		channel.DisplayName, team.DisplayName, createdPost.Id, filesMessage), nil
+		channelDisplayName, teamDisplayName, createdPost.Id, filesMessage), nil
 }
 
 // toolCreatePostAsUser implements the create_post_as_user tool with custom authentication
@@ -391,7 +443,10 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 	}
 
 	// Upload files if specified
-	fileIDs, attachmentMessage := uploadFilesAndUrlsForLocal(ctx, userClient, args.ChannelID, args.Attachments, mcpContext.AccessMode)
+	fileIDs, attachmentMessage, err := uploadFilesAndUrlsForLocal(ctx, userClient, args.ChannelID, args.Attachments, mcpContext.AccessMode)
+	if err != nil {
+		return "", err
+	}
 
 	// Create the post
 	post := &model.Post{
@@ -454,17 +509,26 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, args DMArgs)
 		return "", fmt.Errorf("error creating direct channel: %w", err)
 	}
 
-	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, dmChannel.Id, args.Attachments, args.Files, mcpContext.AccessMode)
+	// Resolve the reply target to the actual thread root
+	rootID, err := resolveThreadRoot(mcpContext, dmChannel.Id, args.RootID)
 	if err != nil {
 		return "", err
 	}
 
-	// Create the post in the DM channel
+	// Build and validate the post before uploading attachments so validation
+	// failures do not leave orphaned uploads on the server.
 	post := &model.Post{
 		ChannelId: dmChannel.Id,
 		Message:   args.Message,
-		FileIds:   fileIDs,
+		RootId:    rootID,
 	}
+
+	// Upload files if specified
+	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, dmChannel.Id, args.Attachments, args.Files, mcpContext.AccessMode)
+	if err != nil {
+		return "", err
+	}
+	post.FileIds = fileIDs
 
 	// Set from_webhook only when DM'ing yourself (prevents AI auto-response loop)
 	if dmSelf {
@@ -528,16 +592,25 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 		return "", fmt.Errorf("error creating group channel: %w", err)
 	}
 
-	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, gmChannel.Id, args.Attachments, args.Files, mcpContext.AccessMode)
+	// Resolve the reply target to the actual thread root
+	rootID, err := resolveThreadRoot(mcpContext, gmChannel.Id, args.RootID)
 	if err != nil {
 		return "", err
 	}
 
+	// Build and validate the post before uploading attachments so validation
+	// failures do not leave orphaned uploads on the server.
 	post := &model.Post{
 		ChannelId: gmChannel.Id,
 		Message:   args.Message,
-		FileIds:   fileIDs,
+		RootId:    rootID,
 	}
+
+	fileIDs, filesMessage, err := resolvePostFiles(ctx, client, gmChannel.Id, args.Attachments, args.Files, mcpContext.AccessMode)
+	if err != nil {
+		return "", err
+	}
+	post.FileIds = fileIDs
 
 	p.stampAIGenerated(post, mcpContext, currentUser.Id)
 

--- a/mcpserver/tools/posts_test.go
+++ b/mcpserver/tools/posts_test.go
@@ -162,6 +162,188 @@ const (
 	siblingPostMessage = "this is a thread reply sibling"
 )
 
+func TestResolveThreadRoot(t *testing.T) {
+	channelID := model.NewId()
+	otherChannelID := model.NewId()
+	rootID := model.NewId()
+	replyID := model.NewId()
+	foreignID := model.NewId()
+	missingID := model.NewId()
+
+	mux := http.NewServeMux()
+	postsByID := map[string]*model.Post{
+		rootID:    {Id: rootID, ChannelId: channelID},
+		replyID:   {Id: replyID, ChannelId: channelID, RootId: rootID},
+		foreignID: {Id: foreignID, ChannelId: otherChannelID},
+	}
+	for id, post := range postsByID {
+		mux.HandleFunc("/api/v4/posts/"+id, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(post)
+		})
+	}
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: newTestClient(ts.URL)}
+
+	tests := []struct {
+		name     string
+		rootID   string
+		wantRoot string
+		wantErr  bool
+	}{
+		{
+			name:     "empty root id resolves to empty",
+			rootID:   "",
+			wantRoot: "",
+		},
+		{
+			name:    "malformed root id is rejected",
+			rootID:  "notanid",
+			wantErr: true,
+		},
+		{
+			name:     "root post resolves to itself",
+			rootID:   rootID,
+			wantRoot: rootID,
+		},
+		{
+			name:     "reply resolves to its thread root",
+			rootID:   replyID,
+			wantRoot: rootID,
+		},
+		{
+			name:    "post from another conversation is rejected",
+			rootID:  foreignID,
+			wantErr: true,
+		},
+		{
+			name:    "missing post is rejected",
+			rootID:  missingID,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveThreadRoot(mcpCtx, channelID, tt.rootID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRoot, got)
+		})
+	}
+}
+
+func TestToolCreatePostChannelValidation(t *testing.T) {
+	teamID := model.NewId()
+
+	tests := []struct {
+		name               string
+		channelType        model.ChannelType
+		channelDisplayName string
+		channelTeamID      string
+		argsDisplayName    string
+		argsTeamName       string
+		wantErr            bool
+		wantTeamFetch      bool
+	}{
+		{
+			name:               "direct channel skips display name validation",
+			channelType:        model.ChannelTypeDirect,
+			channelDisplayName: "",
+			channelTeamID:      "",
+			argsDisplayName:    "Direct Message",
+			argsTeamName:       "N/A",
+			wantErr:            false,
+			wantTeamFetch:      false,
+		},
+		{
+			name:               "group channel skips display name validation",
+			channelType:        model.ChannelTypeGroup,
+			channelDisplayName: "alice, bob, carol",
+			channelTeamID:      "",
+			argsDisplayName:    "Group Message",
+			argsTeamName:       "N/A",
+			wantErr:            false,
+			wantTeamFetch:      false,
+		},
+		{
+			name:               "regular channel still validates display name",
+			channelType:        model.ChannelTypeOpen,
+			channelDisplayName: "Town Square",
+			channelTeamID:      teamID,
+			argsDisplayName:    "Wrong Name",
+			argsTeamName:       "Core Team",
+			wantErr:            true,
+			wantTeamFetch:      false,
+		},
+		{
+			name:               "regular channel with matching names succeeds",
+			channelType:        model.ChannelTypeOpen,
+			channelDisplayName: "Town Square",
+			channelTeamID:      teamID,
+			argsDisplayName:    "Town Square",
+			argsTeamName:       "Core Team",
+			wantErr:            false,
+			wantTeamFetch:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channelID := model.NewId()
+			teamFetched := false
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v4/channels/"+channelID, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(&model.Channel{
+					Id:          channelID,
+					Type:        tt.channelType,
+					DisplayName: tt.channelDisplayName,
+					TeamId:      tt.channelTeamID,
+				})
+			})
+			mux.HandleFunc("/api/v4/teams/"+teamID, func(w http.ResponseWriter, r *http.Request) {
+				teamFetched = true
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(&model.Team{Id: teamID, DisplayName: "Core Team"})
+			})
+			mux.HandleFunc("/api/v4/posts", func(w http.ResponseWriter, r *http.Request) {
+				var post model.Post
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&post))
+				post.Id = model.NewId()
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(&post)
+			})
+			ts := httptest.NewServer(mux)
+			t.Cleanup(ts.Close)
+
+			provider := newTestProvider(t, ts.URL)
+			mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: newTestClient(ts.URL)}
+
+			result, err := provider.toolCreatePost(mcpCtx, CreatePostArgs{
+				ChannelID:          channelID,
+				ChannelDisplayName: tt.argsDisplayName,
+				TeamDisplayName:    tt.argsTeamName,
+				Message:            "hello",
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, result, "Successfully created post")
+			assert.Equal(t, tt.wantTeamFetch, teamFetched, "team endpoint hit")
+		})
+	}
+}
+
 func TestReadPostIncludeThread(t *testing.T) {
 	rootID := model.NewId()
 	channelID := model.NewId()
@@ -309,9 +491,8 @@ func TestToolCreatePostWithInlineFiles(t *testing.T) {
 // TestPostToolsCombinedAttachmentCap pins the cap-before-upload ordering of the three
 // posting resolvers: when resolved legacy attachment IDs plus requested inline files
 // exceed the per-post cap, the resolver fails before any inline file is uploaded and
-// before any post is created. It also pins that the cap counts RESOLVED attachment
-// IDs: in remote mode attachments are skipped (zero IDs), so a full set of inline
-// files must still be accepted.
+// before any post is created. It also pins that remote-mode attachments abort the
+// call before any upload instead of being silently dropped from the post.
 func TestPostToolsCombinedAttachmentCap(t *testing.T) {
 	channelID := model.NewId()
 	teamID := model.NewId()
@@ -329,15 +510,6 @@ func TestPostToolsCombinedAttachmentCap(t *testing.T) {
 	originalGetDataDirectory := GetDataDirectoryInternal
 	GetDataDirectoryInternal = func() (string, error) { return dataDir, nil }
 	t.Cleanup(func() { GetDataDirectoryInternal = originalGetDataDirectory })
-
-	// inlineNames mirrors the names produced by makeInlineFiles.
-	inlineNames := func(n int) []string {
-		names := make([]string, n)
-		for i := range names {
-			names[i] = fmt.Sprintf("file-%d.txt", i)
-		}
-		return names
-	}
 
 	resolvers := []struct {
 		name string
@@ -378,11 +550,11 @@ func TestPostToolsCombinedAttachmentCap(t *testing.T) {
 			wantUploads: legacyNames,
 		},
 		{
-			name:        "remote-mode skipped attachments do not count against the cap",
+			name:        "remote-mode attachments abort before any upload instead of being dropped",
 			accessMode:  AccessModeRemote,
 			attachments: legacyNames,
 			inlineCount: maxFilesPerPost,
-			wantUploads: inlineNames(maxFilesPerPost),
+			wantErr:     "not supported in remote access mode",
 		},
 	}
 

--- a/mcpserver/tools/posts_test.go
+++ b/mcpserver/tools/posts_test.go
@@ -489,10 +489,10 @@ func TestToolCreatePostWithInlineFiles(t *testing.T) {
 }
 
 // TestPostToolsCombinedAttachmentCap pins the cap-before-upload ordering of the three
-// posting resolvers: when resolved legacy attachment IDs plus requested inline files
-// exceed the per-post cap, the resolver fails before any inline file is uploaded and
-// before any post is created. It also pins that remote-mode attachments abort the
-// call before any upload instead of being silently dropped from the post.
+// posting resolvers: when legacy attachments plus requested inline files exceed the
+// per-post cap, the resolver fails before any file is uploaded and before any post
+// is created. It also pins that remote-mode attachments abort the call before any
+// upload instead of being silently dropped from the post.
 func TestPostToolsCombinedAttachmentCap(t *testing.T) {
 	channelID := model.NewId()
 	teamID := model.NewId()
@@ -542,18 +542,17 @@ func TestPostToolsCombinedAttachmentCap(t *testing.T) {
 		wantUploads []string // exact filenames the upload endpoint must see, in order
 	}{
 		{
-			name:        "over the cap fails before any inline upload",
+			name:        "over the cap fails before any upload",
 			accessMode:  AccessModeLocal,
 			attachments: legacyNames,
 			inlineCount: 8,
 			wantErr:     "at most 10",
-			wantUploads: legacyNames,
 		},
 		{
 			name:        "remote-mode attachments abort before any upload instead of being dropped",
 			accessMode:  AccessModeRemote,
 			attachments: legacyNames,
-			inlineCount: maxFilesPerPost,
+			inlineCount: 2,
 			wantErr:     "not supported in remote access mode",
 		},
 	}


### PR DESCRIPTION
#### Summary

Split from #888 to keep reviews small and focused. This part contains only the bug fixes for the MCP posting tools:

- `dm` and `group_message` accept `root_id` to reply in existing threads. Reply targets are resolved to the actual thread root, so any post ID in the thread works (`create_post` too). Models frequently pass the ID of the latest post in a thread, which the server rejects since Mattermost only supports one level of threading.
- `create_post` no longer dead-ends on DM/GM channels: the display-name context check now only applies to regular team channels. DM/GM channels have no display name and no team, so the check could never pass before.
- Attachment upload failures now abort the post instead of silently posting the message without its files. Posts are also validated before uploading, so validation failures cannot leave orphaned uploads on the server.

Note: rebased on top of #932 after it landed. The abort-on-failure semantics now also cover the unified file-resolution path introduced there:

- inline-file and legacy-attachment upload failures both abort the post;
- remote-mode legacy attachments return an error instead of being silently dropped from the post (defense in depth — in real flows the `access:"local"` schema validation rejects them before the resolver runs);
- the combined attachment cap is checked before any upload, so a cap violation can no longer orphan already-uploaded files.

Two cases in `TestPostToolsCombinedAttachmentCap` were updated to pin the stricter behavior.

QA test steps:
1. Via an MCP client, call `dm` with a `root_id` pointing at the latest reply of an existing DM thread → the message lands in that thread instead of erroring.
2. Call `create_post` with a DM channel ID (`channel_display_name: "Direct Message"`, `team_display_name: "N/A"`) → the post is created instead of failing context validation.
3. Call `dm` with a nonexistent attachment path → the tool call errors and no post is created.

#### Ticket Link

None. Supersedes part of #888.

#### Release Note

```release-note
Fixed the MCP server posting tools: dm and group_message can reply in threads via root_id, create_post works on DM/GM channels, and attachment upload failures abort the post instead of posting without files.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added threaded reply support for direct messages and group conversations.
  * Replies now link automatically to the correct thread, and direct/group channel context is supported when creating posts.
* **Bug Fixes**
  * Attachment handling is more strict: combined attachment limits are validated before uploads.
  * Remote-mode legacy/unreadable attachments now fail the post creation flow instead of being skipped.
  * Upload failures now stop post creation rather than being ignored.
* **Tests**
  * Added coverage for thread-root resolution and attachment/post failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
