### PR TITLE
MCP server: return images from read_file and read text without the plugin

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -178,6 +178,29 @@ func WritePost(w *strings.Builder, entry PostEntry) {
 		fmt.Fprintf(w, "Time: %s\n", TimeFromMillis(entry.Post.CreateAt))
 	}
 
+	// File attachments as metadata so a reader can fetch content on demand
+	// (e.g. via the read_file MCP tool). Prefer the rich metadata; fall back
+	// to bare file IDs when the post carries only FileIds.
+	renderedFiles := false
+	if entry.Post.Metadata != nil {
+		for _, fileInfo := range entry.Post.Metadata.Files {
+			if fileInfo == nil {
+				continue
+			}
+			if !renderedFiles {
+				w.WriteString("Attached files:\n")
+				renderedFiles = true
+			}
+			fmt.Fprintf(w, "- %s (%s, %d bytes) [File ID: %s]\n", fileInfo.Name, fileInfo.MimeType, fileInfo.Size, fileInfo.Id)
+		}
+	}
+	if !renderedFiles && len(entry.Post.FileIds) > 0 {
+		w.WriteString("Attached files:\n")
+		for _, fileID := range entry.Post.FileIds {
+			fmt.Fprintf(w, "- [File ID: %s]\n", fileID)
+		}
+	}
+
 	fmt.Fprintf(w, "Message: %s\n\n", PostBody(entry.Post))
 }
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -380,6 +380,52 @@ func TestFormatPost(t *testing.T) {
 			},
 			expected: "**Post 1** by charlie:\nPost ID: post1\nMessage: See attached\nReport\nQ4 numbers\n\n\n",
 		},
+		{
+			name: "post with file metadata lists attached files",
+			entry: PostEntry{
+				HeaderLabel: "Post 1",
+				Username:    "dana",
+				Post: &model.Post{
+					Id:      "post1",
+					Message: "here is the report",
+					Metadata: &model.PostMetadata{
+						Files: []*model.FileInfo{
+							{Id: "file1234567890123456789012", Name: "report.pdf", MimeType: "application/pdf", Size: 2048},
+						},
+					},
+				},
+			},
+			expected: "**Post 1** by dana:\nPost ID: post1\nAttached files:\n- report.pdf (application/pdf, 2048 bytes) [File ID: file1234567890123456789012]\nMessage: here is the report\n\n",
+		},
+		{
+			name: "post with only file ids lists bare file ids",
+			entry: PostEntry{
+				HeaderLabel: "Post 1",
+				Username:    "dana",
+				Post: &model.Post{
+					Id:      "post1",
+					Message: "see file",
+					FileIds: model.StringArray{"file1234567890123456789012"},
+				},
+			},
+			expected: "**Post 1** by dana:\nPost ID: post1\nAttached files:\n- [File ID: file1234567890123456789012]\nMessage: see file\n\n",
+		},
+		{
+			name: "metadata with only nil file entries falls back to file ids",
+			entry: PostEntry{
+				HeaderLabel: "Post 1",
+				Username:    "dana",
+				Post: &model.Post{
+					Id:      "post1",
+					Message: "see file",
+					FileIds: model.StringArray{"file1234567890123456789012"},
+					Metadata: &model.PostMetadata{
+						Files: []*model.FileInfo{nil},
+					},
+				},
+			},
+			expected: "**Post 1** by dana:\nPost ID: post1\nAttached files:\n- [File ID: file1234567890123456789012]\nMessage: see file\n\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/files"
 	"github.com/mattermost/mattermost-plugin-agents/v2/format"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // FileContentService reads the text contents of Mattermost file attachments on
@@ -29,16 +31,16 @@ type ReadFileArgs struct {
 }
 
 // readFileDescription is the MCP tool metadata description for read_file.
-const readFileDescription = "Read the text contents of a Mattermost file attachment by its File ID. Large attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Returns extracted text for documents (PDF, Office) and the raw text for plain-text files. Supports ranged reads via offset and limit to page through large files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}"
+const readFileDescription = "Read the contents of a Mattermost file attachment by its File ID. Attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Images (JPEG/PNG/GIF/WebP) are returned as viewable image content; documents (PDF, Office) return server-extracted text; plain-text files return their raw text. Supports ranged reads via offset and limit to page through large text files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}"
 
 // getFileTools returns the file-related tools.
 func (p *MattermostToolProvider) getFileTools() []MCPTool {
 	return []MCPTool{
 		{
-			Name:        "read_file",
-			Description: readFileDescription,
-			Schema:      NewJSONSchemaForAccessMode[ReadFileArgs](string(p.accessMode)),
-			Resolver:    typed("read_file", p.toolReadFile),
+			Name:         "read_file",
+			Description:  readFileDescription,
+			Schema:       NewJSONSchemaForAccessMode[ReadFileArgs](string(p.accessMode)),
+			RichResolver: typedRich("read_file", p.toolReadFile),
 		},
 		{
 			Name:        "get_file_info",
@@ -73,25 +75,118 @@ func (p *MattermostToolProvider) getFileTools() []MCPTool {
 	}
 }
 
-// toolReadFile implements the read_file tool.
-func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, args ReadFileArgs) (string, error) {
-	if err := requireID("file_id", args.FileID); err != nil {
-		return "", err
+// maxInlineImageBytes caps images returned as inline MCP image content. The
+// limit mirrors the common LLM provider per-image request cap (5 MB).
+const maxInlineImageBytes = 5 * 1024 * 1024
+
+// isInlineImageMimeType reports whether mimeType is an image format that LLM
+// providers accept as inline image content.
+func isInlineImageMimeType(mimeType string) bool {
+	switch strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0])) {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	}
+	return false
+}
+
+// isTextLikeMimeType reports whether mimeType can be served as plain text
+// straight from the raw file bytes, without server-side extraction.
+func isTextLikeMimeType(mimeType string) bool {
+	base := strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0]))
+	if strings.HasPrefix(base, "text/") {
+		return true
+	}
+	switch base {
+	case "application/json", "application/xml", "application/javascript",
+		"application/yaml", "application/x-yaml", "application/toml",
+		"application/x-sh", "application/sql", "application/csv":
+		return true
+	}
+	return false
+}
+
+// maxStandaloneTextBytes bounds how much of a raw text file the standalone
+// fallback downloads into memory, mirroring files.Service's maxDownloadBytes.
+const maxStandaloneTextBytes = 10 * 1024 * 1024
+
+// readFileContentStandalone reads a file's text directly through the user's
+// Mattermost client, for servers that cannot reach the plugin's extraction
+// endpoint. Server-side document extraction (PDF, Office) is unavailable on
+// this path, so only plain-text files have readable content.
+func readFileContentStandalone(mcpContext *MCPToolContext, info *model.FileInfo, offset, limit int) (files.Content, error) {
+	if !isTextLikeMimeType(info.MimeType) {
+		return files.Content{Name: info.Name, MimeType: info.MimeType, HasText: false}, nil
 	}
 
-	if p.fileContentService == nil {
-		return "file reading is not available", nil
+	if info.Size > maxStandaloneTextBytes {
+		return files.Content{}, fmt.Errorf("file %q is %d bytes, larger than the %d-byte limit for direct text reads", info.Name, info.Size, maxStandaloneTextBytes)
 	}
 
-	content, err := p.fileContentService.GetContent(mcpContext.Ctx, mcpContext.UserID, args.FileID, args.Offset, args.Limit)
+	data, _, err := mcpContext.Client.GetFile(mcpContext.Ctx, info.Id)
 	if err != nil {
-		if errors.Is(err, files.ErrForbidden) {
-			return "you do not have permission to read this file", nil
-		}
-		return "", fmt.Errorf("error reading file %s: %w", args.FileID, err)
+		return files.Content{}, fmt.Errorf("error downloading file: %w", err)
 	}
 
-	return formatFileContent(content), nil
+	return files.Slice(info.Name, info.MimeType, string(data), offset, limit), nil
+}
+
+// toolReadFile implements the read_file tool.
+func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, args ReadFileArgs) ([]mcp.Content, error) {
+	if err := requireID("file_id", args.FileID); err != nil {
+		return nil, err
+	}
+
+	client := mcpContext.Client
+	ctx := mcpContext.Ctx
+
+	info, _, err := client.GetFileInfo(ctx, args.FileID)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching file info for %s: %w", args.FileID, err)
+	}
+
+	// Images are returned as inline image content, fetched directly with the
+	// user's client (the extraction service is text-only).
+	if isInlineImageMimeType(info.MimeType) {
+		if info.Size > maxInlineImageBytes {
+			return []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+				"Image %q (%s) is %d bytes, larger than the %d-byte inline limit. Use get_file_link to get a URL instead.",
+				info.Name, info.MimeType, info.Size, maxInlineImageBytes)}}, nil
+		}
+		data, _, downloadErr := client.GetFile(ctx, args.FileID)
+		if downloadErr != nil {
+			return nil, fmt.Errorf("error downloading image %s: %w", args.FileID, downloadErr)
+		}
+		return []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Image: %s (%s, %dx%d, %d bytes)", info.Name, info.MimeType, info.Width, info.Height, info.Size)},
+			&mcp.ImageContent{Data: data, MIMEType: info.MimeType},
+		}, nil
+	}
+
+	// Prefer the plugin's extraction service (the only source of text for PDF
+	// and Office documents). When it fails for a plain-text file — e.g. a
+	// standalone server pointed at a Mattermost without the plugin — fall back
+	// to reading the raw bytes directly. Extraction failures for other types
+	// are surfaced as errors: the fallback cannot read them, and reporting
+	// "no extractable text" would disguise an outage as an empty file.
+	if p.fileContentService != nil {
+		content, svcErr := p.fileContentService.GetContent(ctx, mcpContext.UserID, args.FileID, args.Offset, args.Limit)
+		if svcErr == nil {
+			return []mcp.Content{&mcp.TextContent{Text: formatFileContent(content)}}, nil
+		}
+		if errors.Is(svcErr, files.ErrForbidden) {
+			return nil, fmt.Errorf("you do not have permission to read this file")
+		}
+		if !isTextLikeMimeType(info.MimeType) {
+			return nil, fmt.Errorf("error reading file %s: %w", args.FileID, svcErr)
+		}
+		p.logger.Debug("file content service unavailable, falling back to direct read", "file_id", args.FileID, "error", svcErr)
+	}
+
+	content, err := readFileContentStandalone(mcpContext, info, args.Offset, args.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s: %w", args.FileID, err)
+	}
+	return []mcp.Content{&mcp.TextContent{Text: formatFileContent(content)}}, nil
 }
 
 // formatFileContent renders a ranged file read for the LLM, including paging

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -79,10 +79,18 @@ func (p *MattermostToolProvider) getFileTools() []MCPTool {
 // limit mirrors the common LLM provider per-image request cap (5 MB).
 const maxInlineImageBytes = 5 * 1024 * 1024
 
+// baseMimeType normalizes a MIME type to its lower-cased base form, stripping
+// any parameters (e.g. "image/PNG; charset=binary" -> "image/png"). Strict MCP
+// clients validate media types against an exact list, so emitted content blocks
+// must carry the normalized form.
+func baseMimeType(mimeType string) string {
+	return strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0]))
+}
+
 // isInlineImageMimeType reports whether mimeType is an image format that LLM
 // providers accept as inline image content.
 func isInlineImageMimeType(mimeType string) bool {
-	switch strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0])) {
+	switch baseMimeType(mimeType) {
 	case "image/jpeg", "image/png", "image/gif", "image/webp":
 		return true
 	}
@@ -92,7 +100,7 @@ func isInlineImageMimeType(mimeType string) bool {
 // isTextLikeMimeType reports whether mimeType can be served as plain text
 // straight from the raw file bytes, without server-side extraction.
 func isTextLikeMimeType(mimeType string) bool {
-	base := strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0]))
+	base := baseMimeType(mimeType)
 	if strings.HasPrefix(base, "text/") {
 		return true
 	}
@@ -158,7 +166,7 @@ func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, args R
 		}
 		return []mcp.Content{
 			&mcp.TextContent{Text: fmt.Sprintf("Image: %s (%s, %dx%d, %d bytes)", info.Name, info.MimeType, info.Width, info.Height, info.Size)},
-			&mcp.ImageContent{Data: data, MIMEType: info.MimeType},
+			&mcp.ImageContent{Data: data, MIMEType: baseMimeType(info.MimeType)},
 		}, nil
 	}
 

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -5,6 +5,10 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +16,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/files"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type fakeFileContentService struct {
@@ -32,97 +37,177 @@ func (f *fakeFileContentService) GetContent(_ context.Context, userID, fileID st
 	return f.content, f.err
 }
 
+// newTestFileServer stubs the file-info and file-download endpoints toolReadFile
+// touches. fileData is returned by the download endpoint.
+func newTestFileServer(t *testing.T, info *model.FileInfo, fileData []byte) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/files/"+info.Id+"/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(info)
+	})
+	mux.HandleFunc("/api/v4/files/"+info.Id, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fileData)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// contentText concatenates the text of all TextContent blocks.
+func contentText(contents []mcp.Content) string {
+	var sb strings.Builder
+	for _, c := range contents {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	return sb.String()
+}
+
+// firstImage returns the first ImageContent block, or nil.
+func firstImage(contents []mcp.Content) *mcp.ImageContent {
+	for _, c := range contents {
+		if ic, ok := c.(*mcp.ImageContent); ok {
+			return ic
+		}
+	}
+	return nil
+}
+
 func TestToolReadFile(t *testing.T) {
-	validID := model.NewId()
+	fileID := model.NewId()
 
 	tests := []struct {
 		name            string
 		fileID          string
+		info            *model.FileInfo
+		fileData        []byte
 		service         FileContentService
 		wantErr         bool
-		wantResult      string   // exact match when set
-		wantContains    []string // substring matches
-		wantErrContains string   // substring match against err on error paths
+		wantErrContains string
+		wantText        []string // substring matches against concatenated text content
+		wantImage       bool
 	}{
 		{
 			name:            "invalid file id",
 			fileID:          "too-short",
+			info:            &model.FileInfo{Id: fileID},
 			service:         &fakeFileContentService{},
 			wantErr:         true,
 			wantErrContains: "file_id must be a valid ID",
 		},
 		{
-			name:       "service unavailable",
-			fileID:     validID,
-			service:    nil,
-			wantResult: "file reading is not available",
+			name:     "image is returned as inline image content",
+			fileID:   fileID,
+			info:     &model.FileInfo{Id: fileID, Name: "photo.png", MimeType: "image/png", Size: 4, Width: 2, Height: 2},
+			fileData: []byte{0x89, 0x50, 0x4E, 0x47},
+			service:  &fakeFileContentService{},
+			wantText: []string{"Image: photo.png (image/png"},
+
+			wantImage: true,
 		},
 		{
-			name:       "forbidden",
-			fileID:     validID,
-			service:    &fakeFileContentService{err: files.ErrForbidden},
-			wantResult: "you do not have permission to read this file",
+			name:      "oversized image returns metadata only",
+			fileID:    fileID,
+			info:      &model.FileInfo{Id: fileID, Name: "huge.png", MimeType: "image/png", Size: maxInlineImageBytes + 1},
+			service:   &fakeFileContentService{},
+			wantText:  []string{"larger than", "get_file_link"},
+			wantImage: false,
 		},
 		{
-			name:   "success with paging instructions",
-			fileID: validID,
+			name:            "forbidden from the content service is a tool error",
+			fileID:          fileID,
+			info:            &model.FileInfo{Id: fileID, Name: "report.pdf", MimeType: "application/pdf"},
+			service:         &fakeFileContentService{err: files.ErrForbidden},
+			wantErr:         true,
+			wantErrContains: "permission",
+		},
+		{
+			name:            "service failure for a document is not masked by the fallback",
+			fileID:          fileID,
+			info:            &model.FileInfo{Id: fileID, Name: "report.pdf", MimeType: "application/pdf"},
+			service:         &fakeFileContentService{err: assert.AnError},
+			wantErr:         true,
+			wantErrContains: "error reading file",
+		},
+		{
+			name:            "oversized text file is rejected by the fallback",
+			fileID:          fileID,
+			info:            &model.FileInfo{Id: fileID, Name: "big.txt", MimeType: "text/plain", Size: maxStandaloneTextBytes + 1},
+			service:         nil,
+			wantErr:         true,
+			wantErrContains: "larger than",
+		},
+		{
+			name:   "document text comes from the content service",
+			fileID: fileID,
+			info:   &model.FileInfo{Id: fileID, Name: "report.pdf", MimeType: "application/pdf"},
 			service: &fakeFileContentService{content: files.Content{
 				Name: "report.pdf", MimeType: "application/pdf",
 				TotalRunes: 100, Offset: 0, Returned: 6, HasMore: true, HasText: true,
 				Text: "abcdef",
 			}},
-			wantResult: "File: report.pdf (application/pdf)\n" +
-				"Showing characters 0-6 of 100. More content remains; call read_file again with offset=6 to continue.\n\n" +
+			wantText: []string{
+				"File: report.pdf (application/pdf)",
+				"Showing characters 0-6 of 100. More content remains; call read_file again with offset=6 to continue.",
 				"abcdef",
+			},
 		},
 		{
-			name:   "success without more content omits the paging hint",
-			fileID: validID,
-			service: &fakeFileContentService{content: files.Content{
-				Name: "report.pdf", MimeType: "application/pdf",
-				TotalRunes: 6, Offset: 0, Returned: 6, HasMore: false, HasText: true,
-				Text: "abcdef",
-			}},
-			wantResult: "File: report.pdf (application/pdf)\nShowing characters 0-6 of 6.\n\nabcdef",
+			name:     "nil service falls back to direct read for text files",
+			fileID:   fileID,
+			info:     &model.FileInfo{Id: fileID, Name: "notes.txt", MimeType: "text/plain"},
+			fileData: []byte("plain text body"),
+			service:  nil,
+			wantText: []string{"File: notes.txt (text/plain)", "plain text body"},
 		},
 		{
-			name:   "success without a mime type omits the parenthetical",
-			fileID: validID,
-			service: &fakeFileContentService{content: files.Content{
-				Name: "notes", MimeType: "", TotalRunes: 2, Offset: 0, Returned: 2, HasText: true, Text: "hi",
-			}},
-			wantResult: "File: notes\nShowing characters 0-2 of 2.\n\nhi",
+			name:     "failing service falls back to direct read for text files",
+			fileID:   fileID,
+			info:     &model.FileInfo{Id: fileID, Name: "notes.txt", MimeType: "text/plain"},
+			fileData: []byte("plain text body"),
+			service:  &fakeFileContentService{err: assert.AnError},
+			wantText: []string{"File: notes.txt (text/plain)", "plain text body"},
 		},
 		{
-			name:   "no extractable text",
-			fileID: validID,
-			service: &fakeFileContentService{content: files.Content{
-				Name: "archive.zip", MimeType: "application/zip", HasText: false,
-			}},
-			wantResult: `File "archive.zip" (application/zip) has no extractable text content and cannot be read as text.`,
+			name:     "nil service with a binary file reports no extractable text",
+			fileID:   fileID,
+			info:     &model.FileInfo{Id: fileID, Name: "archive.zip", MimeType: "application/zip"},
+			service:  nil,
+			wantText: []string{`File "archive.zip" (application/zip) has no extractable text content`},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &MattermostToolProvider{fileContentService: tt.service}
-			ctx := &MCPToolContext{Ctx: context.Background(), UserID: model.NewId()}
+			server := newTestFileServer(t, tt.info, tt.fileData)
+			p := &MattermostToolProvider{fileContentService: tt.service, logger: &testLogger{t: t}}
+			ctx := &MCPToolContext{Ctx: context.Background(), UserID: model.NewId(), Client: newTestClient(server.URL)}
 
-			result, err := p.toolReadFile(ctx, ReadFileArgs{FileID: tt.fileID})
+			contents, err := p.toolReadFile(ctx, ReadFileArgs{FileID: tt.fileID})
 
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			text := contentText(contents)
+			for _, sub := range tt.wantText {
+				assert.Contains(t, text, sub)
+			}
+
+			image := firstImage(contents)
+			if tt.wantImage {
+				require.NotNil(t, image, "expected an ImageContent block")
+				assert.Equal(t, tt.info.MimeType, image.MIMEType)
+				assert.Equal(t, tt.fileData, image.Data)
 			} else {
-				require.NoError(t, err)
-			}
-			if tt.wantErrContains != "" {
-				assert.Contains(t, err.Error(), tt.wantErrContains)
-			}
-			if tt.wantResult != "" {
-				assert.Equal(t, tt.wantResult, result)
-			}
-			for _, sub := range tt.wantContains {
-				assert.Contains(t, result, sub)
+				assert.Nil(t, image, "expected no ImageContent block")
 			}
 		})
 	}
@@ -132,12 +217,14 @@ func TestToolReadFile(t *testing.T) {
 // the read flows the authenticated user's ID and the requested range through to
 // the content service, which is what enforces channel access.
 func TestToolReadFilePassesRequestingUser(t *testing.T) {
-	fake := &fakeFileContentService{content: files.Content{Name: "a.txt", HasText: true, Text: "hi"}}
-	p := &MattermostToolProvider{fileContentService: fake}
+	fileID := model.NewId()
+	server := newTestFileServer(t, &model.FileInfo{Id: fileID, Name: "a.pdf", MimeType: "application/pdf"}, nil)
+
+	fake := &fakeFileContentService{content: files.Content{Name: "a.pdf", HasText: true, Text: "hi"}}
+	p := &MattermostToolProvider{fileContentService: fake, logger: &testLogger{t: t}}
 
 	userID := model.NewId()
-	fileID := model.NewId()
-	ctx := &MCPToolContext{Ctx: context.Background(), UserID: userID}
+	ctx := &MCPToolContext{Ctx: context.Background(), UserID: userID, Client: newTestClient(server.URL)}
 
 	_, err := p.toolReadFile(ctx, ReadFileArgs{FileID: fileID, Offset: 12, Limit: 34})
 	require.NoError(t, err)

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -88,6 +88,7 @@ func TestToolReadFile(t *testing.T) {
 		wantErrContains string
 		wantText        []string // substring matches against concatenated text content
 		wantImage       bool
+		wantImageMIME   string // expected MIME on the image block; defaults to info.MimeType
 	}{
 		{
 			name:            "invalid file id",
@@ -106,6 +107,16 @@ func TestToolReadFile(t *testing.T) {
 			wantText: []string{"Image: photo.png (image/png"},
 
 			wantImage: true,
+		},
+		{
+			name:          "image MIME type with parameters is normalized on the image block",
+			fileID:        fileID,
+			info:          &model.FileInfo{Id: fileID, Name: "scan.png", MimeType: "image/PNG; charset=binary", Size: 4, Width: 2, Height: 2},
+			fileData:      []byte{0x89, 0x50, 0x4E, 0x47},
+			service:       &fakeFileContentService{},
+			wantText:      []string{"Image: scan.png (image/PNG; charset=binary"},
+			wantImage:     true,
+			wantImageMIME: "image/png",
 		},
 		{
 			name:      "oversized image returns metadata only",
@@ -204,7 +215,11 @@ func TestToolReadFile(t *testing.T) {
 			image := firstImage(contents)
 			if tt.wantImage {
 				require.NotNil(t, image, "expected an ImageContent block")
-				assert.Equal(t, tt.info.MimeType, image.MIMEType)
+				wantMIME := tt.wantImageMIME
+				if wantMIME == "" {
+					wantMIME = tt.info.MimeType
+				}
+				assert.Equal(t, wantMIME, image.MIMEType)
 				assert.Equal(t, tt.fileData, image.Data)
 			} else {
 				assert.Nil(t, image, "expected no ImageContent block")

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -45,6 +45,10 @@ type MCPToolContext struct {
 // MCPToolResolver defines the signature for MCP tool resolvers
 type MCPToolResolver func(*MCPToolContext, llm.ToolArgumentGetter) (string, error)
 
+// MCPRichToolResolver is a resolver that returns full MCP content blocks, for
+// tools whose output is not plain text (e.g. images).
+type MCPRichToolResolver func(*MCPToolContext, llm.ToolArgumentGetter) ([]mcp.Content, error)
+
 // typed adapts a resolver that accepts an already-decoded argument struct into
 // an MCPToolResolver. It owns argument decoding and the standard "invalid
 // arguments" error, so individual resolvers start at their real logic. The
@@ -60,12 +64,28 @@ func typed[T any](name string, fn func(*MCPToolContext, T) (string, error)) MCPT
 	}
 }
 
+// typedRich is the MCPRichToolResolver counterpart of typed, for resolvers that
+// return full MCP content blocks instead of plain text.
+func typedRich[T any](name string, fn func(*MCPToolContext, T) ([]mcp.Content, error)) MCPRichToolResolver {
+	return func(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) ([]mcp.Content, error) {
+		var args T
+		if err := argsGetter(&args); err != nil {
+			return nil, fmt.Errorf("failed to get arguments for tool %s: %w", name, err)
+		}
+		return fn(mcpContext, args)
+	}
+}
+
 // MCPTool represents a tool specifically for MCP use with our custom context
 type MCPTool struct {
 	Name        string
 	Description string
 	Schema      *jsonschema.Schema
 	Resolver    MCPToolResolver
+
+	// RichResolver, when set, takes priority over Resolver and lets the tool
+	// return non-text content blocks such as images.
+	RichResolver MCPRichToolResolver
 
 	// Available, when set, gates the tool's visibility: it is evaluated on each
 	// tools/list request and the tool is hidden when it returns false. Nil means
@@ -288,6 +308,26 @@ func (p *MattermostToolProvider) registerDynamicTool(server *mcp.Server, mcpTool
 					&mcp.TextContent{Text: "Error: " + hookErr.Error()},
 				},
 				IsError: true,
+			}, nil
+		}
+
+		// Rich resolvers return content blocks directly (e.g. images).
+		if mcpTool.RichResolver != nil {
+			contents, resolveErr := mcpTool.RichResolver(mcpContext, argsGetter)
+			if resolveErr != nil {
+				p.logger.Debug("MCP tool failed", "tool", mcpTool.Name, "error", resolveErr.Error())
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{Text: "Error: " + resolveErr.Error()},
+					},
+					IsError: true,
+				}, nil
+			}
+
+			p.logger.Debug("MCP tool completed successfully", "tool", mcpTool.Name)
+			return &mcp.CallToolResult{
+				Content: contents,
+				IsError: false,
 			}, nil
 		}
 


### PR DESCRIPTION
#### Summary

Split from #888 to keep reviews small and focused. This part makes `read_file` useful for images and for servers without the Agents plugin:

- Adds an optional `RichResolver` to `MCPTool` so tools can return non-text MCP content blocks. `read_file` now returns JPEG/PNG/GIF/WebP attachments as inline image content (5 MB cap; larger images get a metadata-only reply pointing at `get_file_link`).
- When the plugin's extraction endpoint is unreachable (e.g. a standalone MCP server pointed at a Mattermost without the plugin), `read_file` falls back to reading plain-text files directly through the user's client with the same rune-windowed paging.
- `format.WritePost` lists file attachments as metadata (name, type, size, File ID) so models can discover File IDs from `read_post`/`read_channel` and fetch content on demand via `read_file`.

QA test steps:
1. Attach an image to a post and call `read_post` → the attachment metadata includes its File ID. Call `read_file` with that ID → an inline image content block plus a short text description is returned.
2. Call `read_file` on an image larger than 5 MB → a metadata-only text reply suggesting `get_file_link`.
3. With a standalone MCP server pointed at a Mattermost without the Agents plugin, call `read_file` on a `.txt` attachment → raw text is returned with paging info.

#### Ticket Link

None. Supersedes part of #888.

#### Release Note

```release-note
The MCP server read_file tool now returns image attachments (JPEG/PNG/GIF/WebP) as inline image content, and falls back to reading plain-text files directly when the Agents plugin's extraction endpoint is unavailable. Post output now lists attachment metadata including File IDs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File reading now supports inline JPEG, PNG, GIF, and WebP images up to 5 MB.
  * File results include metadata such as name, type, size, and ID.
  * Posts display attached file details when available.
* **Bug Fixes**
  * Improved fallback handling for text extraction and file downloads.
  * Clearer errors are shown for unsupported, oversized, inaccessible, or unreadable files.
  * File links are provided when images exceed the inline size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->