### PR TITLE
MCP server: allow absolute attachment paths via operator-configured roots

### DIFF
--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -109,6 +109,46 @@ func EnsureDataDirectory() error {
 	return os.MkdirAll(dataDir, 0700)
 }
 
+// AttachmentRootsEnvVar names the environment variable listing extra directories
+// (separated by the OS path-list separator, e.g. ":" on Unix) that local-mode
+// attachments may be read from using absolute paths. Relative paths always
+// resolve inside the data directory regardless of this setting.
+const AttachmentRootsEnvVar = "MM_MCP_ATTACHMENT_ROOTS"
+
+// readLocalFileFromAllowedRoots reads an absolute attachment path, but only when it
+// falls under one of the operator-configured attachment roots. Each root is opened
+// via os.Root so symlinks cannot escape the allowed directory.
+func readLocalFileFromAllowedRoots(absPath string) ([]byte, error) {
+	for _, rootDir := range filepath.SplitList(os.Getenv(AttachmentRootsEnvVar)) {
+		rootDir = strings.TrimSpace(rootDir)
+		if rootDir == "" || !filepath.IsAbs(rootDir) {
+			continue
+		}
+		rootDir = filepath.Clean(rootDir)
+
+		rel, err := filepath.Rel(rootDir, absPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open attachment root %q: %w", rootDir, err)
+		}
+		defer root.Close()
+
+		file, err := root.Open(rel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open file: %w", err)
+		}
+		defer file.Close()
+
+		return readLimitedToMaxMCPBytes(file)
+	}
+
+	return nil, fmt.Errorf("absolute path %q is not inside any allowed attachment root; set the %s environment variable on the MCP server, or use a path relative to the data directory", absPath, AttachmentRootsEnvVar)
+}
+
 // fetchFileDataForLocal fetches file data from a file path or URL (local access only)
 func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode AccessMode) ([]byte, error) {
 	if filespec == "" {
@@ -157,6 +197,11 @@ func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode Acce
 	}
 
 	cleanPath := filepath.Clean(filespec)
+
+	// Absolute paths are only served from operator-configured attachment roots.
+	if filepath.IsAbs(cleanPath) {
+		return readLocalFileFromAllowedRoots(cleanPath)
+	}
 
 	// Use data directory as base for file operations
 	dataDir, err := GetDataDirectoryInternal()

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -205,6 +207,95 @@ func TestUploadInlineFiles(t *testing.T) {
 			assert.Equal(t, tt.wantFilenames, rec.filenames)
 			assert.Equal(t, tt.wantContents, rec.contents)
 			assert.Equal(t, rec.fileIDs, fileIDs)
+		})
+	}
+}
+
+func TestFetchFileDataForLocal_AbsolutePathRoots(t *testing.T) {
+	allowedDir := t.TempDir()
+	otherDir := t.TempDir()
+
+	fileContent := []byte("attachment payload")
+	allowedFile := filepath.Join(allowedDir, "report.txt")
+	require.NoError(t, os.WriteFile(allowedFile, fileContent, 0600))
+
+	nestedFile := filepath.Join(allowedDir, "sub", "nested.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nestedFile), 0700))
+	require.NoError(t, os.WriteFile(nestedFile, fileContent, 0600))
+
+	outsideFile := filepath.Join(otherDir, "secret.txt")
+	require.NoError(t, os.WriteFile(outsideFile, fileContent, 0600))
+
+	linkToOutside := filepath.Join(allowedDir, "escape-link")
+	require.NoError(t, os.Symlink(outsideFile, linkToOutside))
+
+	testCases := []struct {
+		name     string
+		roots    string
+		filespec string
+		wantData bool
+	}{
+		{
+			name:     "no roots configured rejects absolute paths",
+			roots:    "",
+			filespec: allowedFile,
+			wantData: false,
+		},
+		{
+			name:     "file inside an allowed root is readable",
+			roots:    allowedDir,
+			filespec: allowedFile,
+			wantData: true,
+		},
+		{
+			name:     "nested file inside an allowed root is readable",
+			roots:    allowedDir,
+			filespec: nestedFile,
+			wantData: true,
+		},
+		{
+			name:     "second entry in the root list also matches",
+			roots:    otherDir + string(filepath.ListSeparator) + allowedDir,
+			filespec: allowedFile,
+			wantData: true,
+		},
+		{
+			name:     "file outside every allowed root is rejected",
+			roots:    allowedDir,
+			filespec: outsideFile,
+			wantData: false,
+		},
+		{
+			name:     "path traversal out of an allowed root is rejected",
+			roots:    allowedDir,
+			filespec: filepath.Join(allowedDir, "..", filepath.Base(otherDir), "secret.txt"),
+			wantData: false,
+		},
+		{
+			name:     "symlink escaping an allowed root is rejected",
+			roots:    allowedDir,
+			filespec: linkToOutside,
+			wantData: false,
+		},
+		{
+			name:     "relative root entries are ignored",
+			roots:    "relative/dir",
+			filespec: allowedFile,
+			wantData: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(AttachmentRootsEnvVar, tc.roots)
+
+			data, err := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
+			if tc.wantData {
+				require.NoError(t, err)
+				require.Equal(t, fileContent, data)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Summary

Split from #888 to keep reviews small and focused. This part adds operator-configured roots for absolute attachment paths in local access mode:

- New environment variable `MM_MCP_ATTACHMENT_ROOTS` (OS path-list of directories, e.g. `/srv/exports:/var/reports`) allows local-mode attachments to reference absolute paths. Each root is opened through `os.Root`, so symlinks and path traversal cannot escape an allowed directory.
- Relative paths still resolve inside the data directory. Absolute paths are rejected when no roots are configured, so default behavior is unchanged.

QA test steps:
1. Without the environment variable, pass an absolute path as an attachment → the tool call fails with guidance mentioning `MM_MCP_ATTACHMENT_ROOTS`.
2. With `MM_MCP_ATTACHMENT_ROOTS=/tmp/exports`, attach `/tmp/exports/report.pdf` → the file uploads. Attach a symlink under `/tmp/exports` pointing outside it → rejected.

#### Ticket Link

None. Supersedes part of #888.

#### Release Note

```release-note
Added the MM_MCP_ATTACHMENT_ROOTS environment variable to the standalone MCP server, allowing local-mode attachments to reference absolute paths under operator-configured directories.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for accessing local attachments through configured absolute-path roots.
  * Supports multiple attachment roots while continuing to support relative paths.
  * Maintains the existing 100 MiB file-size limit.

* **Bug Fixes**
  * Improved validation for attachment paths and configured root directories.
  * Prevents access through traversal attempts, symlink escapes, or paths outside approved locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->