### PR TITLE
Backport #707 to release-2.0: recover stuck reindex jobs

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -552,45 +552,45 @@ func (s *Indexer) isJobStale(jobStatus *JobStatus) bool {
 	return time.Since(lastUpdate) > StaleJobThreshold
 }
 
-// MarkOrphanedJobAsFailed marks a non-terminal job owned by this node as failed.
-// Intended to run at plugin startup so a crashed run (including one stuck in
-// cancel_requested) does not block future Starts.
+// MarkOrphanedJobAsFailed reclaims any non-terminal reindex job whose
+// heartbeat is older than StaleJobThreshold, on any node. Keying on
+// staleness (not the original NodeID) lets containerized deploys —
+// where the hostname changes on restart — and clustered deploys — where
+// the original node may be gone — recover after a crash. Resumable=true
+// preserves the cursor so the admin can resume from where the wedged
+// run left off.
 func (s *Indexer) MarkOrphanedJobAsFailed() error {
 	var jobStatus JobStatus
 	err := s.pluginAPI.KVGet(ReindexJobKey, &jobStatus)
 	if err != nil {
 		if mmapi.IsKVNotFound(err) {
-			return nil // No job exists, nothing to do
+			return nil
 		}
 		return err
 	}
 
-	if jobStatus.Status != JobStatusRunning && jobStatus.Status != JobStatusCancelRequested {
-		return nil
-	}
-
-	currentNodeID := s.getNodeID()
-	if jobStatus.NodeID != currentNodeID {
+	if !s.isJobStale(&jobStatus) {
 		return nil
 	}
 
 	newStatus := jobStatus
 	newStatus.Status = JobStatusFailed
-	newStatus.Error = fmt.Sprintf("Job orphaned: plugin restarted on node %s while job was running", currentNodeID)
+	newStatus.Resumable = true
+	newStatus.Error = fmt.Sprintf("Job orphaned: heartbeat older than %s on node %q",
+		StaleJobThreshold, jobStatus.NodeID)
 	newStatus.CompletedAt = time.Now()
 
-	s.pluginAPI.LogWarn("Marking orphaned reindex job as failed",
-		"node_id", currentNodeID,
+	s.pluginAPI.LogWarn("Reclaiming stale reindex job",
+		"job_id", jobStatus.JobID,
+		"previous_status", jobStatus.Status,
+		"node_id", jobStatus.NodeID,
 		"processed_rows", jobStatus.ProcessedRows)
 
-	// CAS-gate the write so a fresh run that has already claimed the row on
-	// another node is not clobbered.
-	ok, casErr := s.pluginAPI.KVCompareAndSet(ReindexJobKey, jobStatus, newStatus)
-	if casErr != nil {
+	// CAS so a fresh run that has already claimed the row on another
+	// node is not clobbered. We don't care if the CAS loses — that just
+	// means someone else already moved the row.
+	if _, casErr := s.pluginAPI.KVCompareAndSet(ReindexJobKey, jobStatus, newStatus); casErr != nil {
 		return casErr
-	}
-	if !ok {
-		return nil
 	}
 	return nil
 }

--- a/indexer/indexer_job.go
+++ b/indexer/indexer_job.go
@@ -413,6 +413,13 @@ func (s *Indexer) getLastIndexedTimestamp() int64 {
 // saveJobStatus persists the worker's view of the job, gated on JobID match
 // so a worker whose row has been claimed by a newer run does not clobber it.
 // A status with no JobID falls back to an unconditional set.
+//
+// The cancel-survival guard closes a race in which the admin's
+// CancelJob CAS lands before this worker's KVGet: without it, the
+// worker would read cancel_requested and then CAS back to running,
+// silently erasing the cancel. Propagating cancel_requested onto the
+// worker's local status makes the next loop iteration observe the
+// cancel and exit.
 func (s *Indexer) saveJobStatus(status *JobStatus) {
 	if status.JobID == "" {
 		if err := s.pluginAPI.KVSet(ReindexJobKey, status); err != nil {
@@ -432,6 +439,12 @@ func (s *Indexer) saveJobStatus(status *JobStatus) {
 		s.pluginAPI.LogWarn("Reindex worker superseded by a newer run, dropping status write",
 			"worker_job_id", status.JobID,
 			"current_job_id", current.JobID)
+		return
+	}
+
+	if err == nil && current.JobID == status.JobID &&
+		current.Status == JobStatusCancelRequested && status.Status == JobStatusRunning {
+		status.Status = JobStatusCancelRequested
 		return
 	}
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -2741,13 +2741,13 @@ func TestResumeFromCheckpoint(t *testing.T) {
 
 // TestMarkOrphanedJobAsFailed tests the automatic marking of orphaned jobs on startup
 func TestMarkOrphanedJobAsFailed(t *testing.T) {
-	t.Run("marks running job on same node as failed", func(t *testing.T) {
+	t.Run("marks stale running job on same node as failed", func(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		// Get current hostname to match the job's NodeID
 		hostname, _ := os.Hostname()
 
-		// Return a running job on this node
+		// Return a stale running job on this node
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
@@ -2776,21 +2776,67 @@ func TestMarkOrphanedJobAsFailed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, savedStatus)
 		assert.Equal(t, JobStatusFailed, savedStatus.Status)
-		assert.Contains(t, savedStatus.Error, "Job orphaned")
-		assert.Contains(t, savedStatus.Error, hostname)
+		assert.Contains(t, savedStatus.Error, "orphaned")
+		assert.True(t, savedStatus.Resumable,
+			"orphan reclaim must mark the row Resumable so admins can resume from cursor")
+		assert.Equal(t, int64(1000), savedStatus.ProcessedRows,
+			"orphan reclaim must preserve ProcessedRows for resume")
 		assert.False(t, savedStatus.CompletedAt.IsZero())
 	})
 
-	t.Run("does not mark job running on different node", func(t *testing.T) {
+	t.Run("marks stale running job on a different node as failed", func(t *testing.T) {
+		// Hostname-bound recovery is the wedge: in containerized deploys the
+		// hostname changes on restart, and in clusters the original node may
+		// be gone. Reclaim must key on staleness, not NodeID.
 		mockClient := mocks.NewMockClient(t)
 
-		// Return a running job on a DIFFERENT node
+		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
+			Run(func(args mock.Arguments) {
+				status := args.Get(1).(*JobStatus)
+				status.JobID = "wedged-job"
+				status.Status = JobStatusRunning
+				status.NodeID = "different-node-hostname"
+				status.ProcessedRows = 5000
+				status.StartedAt = time.Now().Add(-1 * time.Hour)
+				status.LastUpdatedAt = time.Now().Add(-StaleJobThreshold - time.Minute)
+			}).
+			Return(nil)
+
+		var saved JobStatus
+		mockClient.On("KVCompareAndSet", ReindexJobKey, mock.AnythingOfType("indexer.JobStatus"), mock.MatchedBy(func(v interface{}) bool {
+			status, ok := v.(JobStatus)
+			if !ok {
+				return false
+			}
+			saved = status
+			return status.Status == JobStatusFailed
+		})).Return(true, nil)
+
+		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+
+		indexer := New(nil, nil, mockClient, nil, nil, nil)
+		err := indexer.MarkOrphanedJobAsFailed()
+
+		require.NoError(t, err)
+		assert.Equal(t, JobStatusFailed, saved.Status,
+			"a stale row on any node must be reclaimable; otherwise hostname-bound deploys wedge forever")
+		assert.True(t, saved.Resumable)
+		assert.Equal(t, int64(5000), saved.ProcessedRows)
+	})
+
+	t.Run("does NOT mark a job whose heartbeat is just inside the threshold", func(t *testing.T) {
+		// Boundary case: don't kill live jobs. A heartbeat one second
+		// inside StaleJobThreshold must not be treated as stale.
+		mockClient := mocks.NewMockClient(t)
+
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
 				status.Status = JobStatusRunning
 				status.NodeID = "different-node-hostname"
 				status.ProcessedRows = 1000
+				status.StartedAt = time.Now().Add(-time.Hour)
+				status.LastUpdatedAt = time.Now().Add(-StaleJobThreshold + time.Second)
 			}).
 			Return(nil)
 
@@ -2871,6 +2917,7 @@ func TestMarkOrphanedJobAsFailed(t *testing.T) {
 				status.Status = JobStatusRunning
 				status.NodeID = hostname
 				status.JobID = "stale-observation"
+				status.StartedAt = time.Now().Add(-1 * time.Hour)
 			}).
 			Return(nil)
 
@@ -3597,17 +3644,15 @@ func TestCancelRequestedIsRecoverableWhenStale(t *testing.T) {
 			"cancel_requested with no recent heartbeat must be flagged stale or it wedges every future Start")
 	})
 
-	t.Run("MarkOrphanedJobAsFailed reclaims a cancel_requested row owned by this node", func(t *testing.T) {
+	t.Run("MarkOrphanedJobAsFailed reclaims a stale cancel_requested row regardless of node", func(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
-
-		hostname, _ := os.Hostname()
 
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
 				status.JobID = "wedged-cancel"
 				status.Status = JobStatusCancelRequested
-				status.NodeID = hostname
+				status.NodeID = "any-other-node"
 				status.StartedAt = time.Now().Add(-time.Hour)
 			}).
 			Return(nil)
@@ -3629,6 +3674,7 @@ func TestCancelRequestedIsRecoverableWhenStale(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, JobStatusFailed, saved.Status,
 			"MarkOrphanedJobAsFailed must reclaim cancel_requested rows or the row stays wedged forever")
+		assert.True(t, saved.Resumable, "reclaim should mark cancel-wedged rows resumable")
 	})
 }
 
@@ -3703,4 +3749,36 @@ func TestStartReindexJob_FreshInstall_AuthenticUpstreamContract(t *testing.T) {
 			"masked a missing key as present-but-zero")
 
 	time.Sleep(50 * time.Millisecond) // let background goroutine settle
+}
+
+// TestSaveJobStatusPreservesCancelRequested asserts that saveJobStatus
+// must not silently overwrite cancel_requested with running for the same
+// JobID. Otherwise the worker's heartbeat would erase the admin's cancel
+// signal.
+func TestSaveJobStatusPreservesCancelRequested(t *testing.T) {
+	mockClient := mocks.NewMockClient(t)
+
+	const jobID = "running-job"
+	mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
+		Run(func(args mock.Arguments) {
+			status := args.Get(1).(*JobStatus)
+			status.JobID = jobID
+			status.Status = JobStatusCancelRequested
+		}).
+		Return(nil)
+	mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+
+	indexer := New(nil, nil, mockClient, nil, nil, nil)
+
+	worker := &JobStatus{
+		JobID:         jobID,
+		Status:        JobStatusRunning,
+		ProcessedRows: 100,
+	}
+	indexer.saveJobStatus(worker)
+
+	mockClient.AssertNotCalled(t, "KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "KVSet", mock.Anything, mock.Anything)
+	assert.Equal(t, JobStatusCancelRequested, worker.Status,
+		"saveJobStatus must propagate cancel_requested to the worker's local status so it observes the cancel on the next loop iteration")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -275,8 +275,10 @@ func (p *Plugin) OnActivate() error {
 	// Create indexer service with getter function
 	indexerService := indexer.New(getSearch, configGetter, mmClient, bots, dbClient.DB, p.API)
 
-	// Mark any orphaned reindex jobs from this node as failed
-	// This handles the case where the plugin/server crashed while a job was running
+	// Mark any orphaned reindex jobs as failed (any node, staleness-based).
+	// Handles wedge cases where the plugin/server crashed while a job was
+	// running; works in containerized deploys where the hostname changes
+	// on restart and clustered deploys where the original node may be gone.
 	if orphanErr := indexerService.MarkOrphanedJobAsFailed(); orphanErr != nil {
 		pluginAPI.Log.Warn("Failed to check for orphaned reindex job", "error", orphanErr)
 	}

--- a/webapp/src/components/system_console/embedding_search/reindex_section.tsx
+++ b/webapp/src/components/system_console/embedding_search/reindex_section.tsx
@@ -189,6 +189,12 @@ const StaleText = styled.div`
     flex: 1;
 `;
 
+const StaleActions = styled.div`
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+`;
+
 interface ReindexSectionProps {
     jobStatus: JobStatusType | null;
     statusMessage: StatusMessageType;
@@ -221,6 +227,8 @@ export const ReindexSection = ({
     // cancel_requested is non-terminal: the worker is still running until it
     // observes the request and writes canceled.
     const isReindexing = jobStatus?.status === 'running' || jobStatus?.status === 'cancel_requested';
+
+    const hasProgress = (jobStatus?.processed_rows ?? 0) > 0;
 
     // Check if job can be resumed (failed or canceled with progress)
     const canResume = (jobStatus?.status === 'failed' || jobStatus?.status === 'canceled') &&
@@ -266,9 +274,19 @@ export const ReindexSection = ({
                         <strong><FormattedMessage defaultMessage='Job May Be Stale'/></strong>
                         <br/>
                         <FormattedMessage
-                            defaultMessage='The reindex job has not updated in over 10 minutes. The node running it ({nodeId}) may have crashed. You can start a new reindex to resume from where it left off.'
+                            defaultMessage='The reindex job has not updated in over 10 minutes. The node running it ({nodeId}) may have crashed. Start a new run to take over from where it left off.'
                             values={{nodeId: jobStatus?.node_id || 'unknown'}}
                         />
+                        <StaleActions>
+                            {hasProgress && (
+                                <SecondaryButton onClick={onResumeClick}>
+                                    <FormattedMessage defaultMessage='Resume from checkpoint'/>
+                                </SecondaryButton>
+                            )}
+                            <SecondaryButton onClick={onReindexClick}>
+                                <FormattedMessage defaultMessage='Reindex from scratch'/>
+                            </SecondaryButton>
+                        </StaleActions>
                     </StaleText>
                 </StaleBanner>
             )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Backports [#707](https://github.com/mattermost/mattermost-plugin-agents/pull/707) onto `release-2.0` as the first PR in the AI Enhanced Search backport stack.

This restores stale reindex-job recovery across node or hostname changes and prevents heartbeat updates from overwriting an administrator's cancellation request.

Backport-specific changes:
- Resolved the `indexer/indexer_test.go` conflict by retaining the existing `release-2.0` fresh-install regression test from #764 alongside #707's cancellation-preservation test.
- Retained the `release-2.0` module path.
- Production behavior otherwise matches the original PR.

#### Release Note

```release-note
Fixed stuck AI Enhanced Search reindex jobs remaining unrecoverable after plugin restarts, hostname changes, or interrupted cancellation.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

