### PR TITLE
Backport #754: serialize concurrent embedding writes

### DIFF
--- a/indexer/indexer_job.go
+++ b/indexer/indexer_job.go
@@ -489,7 +489,7 @@ func (s *Indexer) runCatchUpPass(ctx context.Context, jobStatus *JobStatus, sear
 	lastID := ""
 
 	for {
-		// Query posts created after the cutoff
+		// Skip posts the live hook has already indexed so catch-up doesn't redo them.
 		query := `SELECT
 			Posts.Id as id,
 			Posts.Message as message,
@@ -507,6 +507,9 @@ func (s *Indexer) runCatchUpPass(ctx context.Context, jobStatus *JobStatus, sear
 			AND Posts.Type = ''
 			AND (Posts.CreateAt, Posts.Id) > ($1, $2)
 			AND Posts.CreateAt <= $3
+			AND NOT EXISTS (
+				SELECT 1 FROM llm_posts_embeddings e WHERE e.post_id = Posts.Id
+			)
 		ORDER BY Posts.CreateAt ASC, Posts.Id ASC
 		LIMIT $4`
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -3782,3 +3782,102 @@ func TestSaveJobStatusPreservesCancelRequested(t *testing.T) {
 	assert.Equal(t, JobStatusCancelRequested, worker.Status,
 		"saveJobStatus must propagate cancel_requested to the worker's local status so it observes the cancel on the next loop iteration")
 }
+
+func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
+	type seedPost struct {
+		id      string
+		offset  int64
+		indexed bool
+	}
+	cases := []struct {
+		name              string
+		seed              []seedPost
+		expectedStoredIDs []string
+	}{
+		{
+			// Interleaved timestamps so the keyset cursor would pass through
+			// both sets in a single page absent the NOT EXISTS filter.
+			name: "mixed indexed and unseen",
+			seed: []seedPost{
+				{"indexed-1", 100, true},
+				{"unseen-1", 200, false},
+				{"indexed-2", 300, true},
+				{"unseen-2", 400, false},
+			},
+			expectedStoredIDs: []string{"unseen-1", "unseen-2"},
+		},
+		{
+			name: "all posts already indexed",
+			seed: []seedPost{
+				{"already-1", 100, true},
+				{"already-2", 200, true},
+				{"already-3", 300, true},
+				{"already-4", 400, true},
+			},
+			expectedStoredIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := testDB(t)
+			defer cleanupDB(t, db)
+
+			mockClient := mocks.NewMockClient(t)
+			mockSearch := embeddingsmocks.NewMockEmbeddingSearch(t)
+			mockBots := &bots.MMBots{}
+
+			_, err := db.Exec("INSERT INTO Channels (Id, Type, Name, TeamId) VALUES ('channel1', 'O', 'town-square', 'team1')")
+			require.NoError(t, err)
+
+			cutoffTime := model.GetMillis() - 5000
+
+			for _, p := range tc.seed {
+				_, err = db.Exec(
+					"INSERT INTO Posts (Id, CreateAt, DeleteAt, Message, Type, ChannelId, UserId) VALUES ($1, $2, 0, $3, '', 'channel1', 'user1')",
+					p.id, cutoffTime+p.offset, "content for "+p.id)
+				require.NoError(t, err)
+				if p.indexed {
+					_, err = db.Exec(
+						"INSERT INTO llm_posts_embeddings (id, post_id, content, embedding) VALUES ($1, $1, $2, '[0.1, 0.2, 0.3]')",
+						p.id, "live-hook content for "+p.id)
+					require.NoError(t, err)
+				}
+			}
+
+			var storedPostIDs []string
+			if len(tc.expectedStoredIDs) > 0 {
+				mockSearch.On("Store", mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						docs := args.Get(1).([]embeddings.PostDocument)
+						for _, doc := range docs {
+							storedPostIDs = append(storedPostIDs, doc.PostID)
+						}
+					}).
+					Return(nil).Once()
+			}
+			// No Store expectation when expectedStoredIDs is empty — an
+			// unexpected Store call will then fail the test.
+
+			mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+			mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+			mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+			mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
+			mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+			mockClient.On("LogError", mock.Anything, mock.Anything).Return().Maybe()
+
+			indexer := New(func() embeddings.EmbeddingSearch { return mockSearch }, nil, mockClient, mockBots, db, nil)
+
+			jobStatus := &JobStatus{
+				Status:    JobStatusRunning,
+				StartedAt: time.Now(),
+				CutoffAt:  cutoffTime,
+			}
+
+			count, _, err := indexer.runCatchUpPass(context.Background(), jobStatus, mockSearch)
+			require.NoError(t, err)
+			assert.Equal(t, int64(len(tc.expectedStoredIDs)), count)
+			assert.ElementsMatch(t, tc.expectedStoredIDs, storedPostIDs)
+		})
+	}
+}

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -7,14 +7,41 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 	"github.com/mattermost/mattermost-plugin-agents/chunking"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/pgvector/pgvector-go"
 )
+
+// postIDs must be sorted to avoid deadlocks across batches with overlapping posts.
+func lockPostIDs(ctx context.Context, tx *sqlx.Tx, postIDs []string) error {
+	_, err := tx.ExecContext(ctx,
+		"SELECT pg_advisory_xact_lock(hashtext(p)) FROM unnest($1::text[]) AS t(p)",
+		pq.Array(postIDs),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to acquire per-post advisory lock: %w", err)
+	}
+	return nil
+}
+
+func uniqueSortedPostIDs(docs []embeddings.PostDocument) []string {
+	seen := make(map[string]struct{}, len(docs))
+	for _, doc := range docs {
+		seen[doc.PostID] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}
 
 type PGVector struct {
 	db *sqlx.DB
@@ -73,7 +100,6 @@ func NewPGVector(db *sqlx.DB, config PGVectorConfig) (*PGVector, error) {
 }
 
 func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, embeddings [][]float32) error {
-	// Validate input lengths match to prevent index out of bounds errors
 	if len(docs) != len(embeddings) {
 		return fmt.Errorf("mismatched input lengths: got %d documents but %d embeddings", len(docs), len(embeddings))
 	}
@@ -82,17 +108,7 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return nil
 	}
 
-	// Collect unique post IDs to clean up before insert
-	// This ensures that when a post is re-indexed with a different chunk count,
-	// old chunks are removed to prevent orphaned data.
-	postIDSet := make(map[string]struct{})
-	for _, doc := range docs {
-		postIDSet[doc.PostID] = struct{}{}
-	}
-	postIDs := make([]string, 0, len(postIDSet))
-	for id := range postIDSet {
-		postIDs = append(postIDs, id)
-	}
+	postIDs := uniqueSortedPostIDs(docs)
 
 	tx, err := pv.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -100,7 +116,11 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Bulk delete existing entries for all posts being updated
+	if lockErr := lockPostIDs(ctx, tx, postIDs); lockErr != nil {
+		return lockErr
+	}
+
+	// Drop any prior rows for these posts so a shrinking chunk count doesn't leave orphans.
 	deleteQuery, deleteArgs, err := sq.
 		Delete("llm_posts_embeddings").
 		Where(sq.Eq{"post_id": postIDs}).
@@ -113,7 +133,6 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return fmt.Errorf("failed to delete existing chunks: %w", err)
 	}
 
-	// Insert new entries
 	for i, doc := range docs {
 		id := doc.PostID
 		if doc.IsChunk {
@@ -127,7 +146,8 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 			VALUES (
 				:id, :post_id, :team_id, :channel_id, :user_id, :content, :embedding, :created_at,
 				:is_chunk, :chunk_index, :total_chunks
-			)`,
+			)
+			ON CONFLICT (id) DO NOTHING`,
 			map[string]interface{}{
 				"id":           id,
 				"post_id":      doc.PostID,

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -5,12 +5,16 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2187,6 +2191,159 @@ func TestConcurrentStoreOperations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, count, "Should have exactly one document for the post after concurrent operations")
 	})
+}
+
+// Any non-duplicate error (e.g. a deadlock or serialization failure) also
+// fails the test so a regression can't hide behind a different error class.
+func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	addTestPosts(t, db, []string{"race_post"}, []int64{now})
+
+	ctx := context.Background()
+	const numGoroutines = 30
+	const numIterations = 10
+
+	var dupKeyCount, otherErrCount atomic.Int32
+	var sampleDupErr, sampleOtherErr atomic.Value
+
+	for iter := 0; iter < numIterations; iter++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				docs := []embeddings.PostDocument{{
+					PostID:    "race_post",
+					CreateAt:  now,
+					TeamID:    "team1",
+					ChannelID: "channel1",
+					UserID:    "user1",
+					Content:   fmt.Sprintf("iter %d worker %d", iter, idx),
+				}}
+				vecs := [][]float32{{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}}
+				storeErr := pgVector.Store(ctx, docs, vecs)
+				if storeErr == nil {
+					return
+				}
+				var pqErr *pq.Error
+				if errors.As(storeErr, &pqErr) && pqErr.Code == "23505" {
+					dupKeyCount.Add(1)
+					sampleDupErr.Store(storeErr.Error())
+					return
+				}
+				otherErrCount.Add(1)
+				sampleOtherErr.Store(storeErr.Error())
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	if got := dupKeyCount.Load(); got > 0 {
+		sample, _ := sampleDupErr.Load().(string)
+		t.Fatalf("Store returned duplicate key error under concurrent writes (%d occurrences); sample: %s", got, sample)
+	}
+	if got := otherErrCount.Load(); got > 0 {
+		sample, _ := sampleOtherErr.Load().(string)
+		t.Fatalf("Store returned non-duplicate-key error under concurrent writes (%d occurrences); sample: %s", got, sample)
+	}
+}
+
+// Concurrent Store calls for the same post_id with differing chunk counts
+// must never leave a mixed state (some chunks from one writer, some from
+// another). Without the advisory lock, writer A's DELETE can run against a
+// snapshot from before writer B commits, leaving B's chunk rows beyond A's
+// chunk count behind as orphans alongside A's freshly inserted rows.
+func TestStoreConcurrentChunkConsistency(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	const postID = "consistency_post"
+	addTestPosts(t, db, []string{postID}, []int64{now})
+
+	ctx := context.Background()
+	const numGoroutines = 20
+	const numIterations = 10
+
+	for iter := 0; iter < numIterations; iter++ {
+		start := make(chan struct{})
+		storeErrs := make([]error, numGoroutines)
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+
+				// Distinct chunk counts so writers' row sets overlap unevenly;
+				// tag encoded in content lets us detect mixed-writer states.
+				tag := fmt.Sprintf("iter%d-writer%d", iter, idx)
+				chunkCount := idx + 1
+
+				docs := make([]embeddings.PostDocument, chunkCount)
+				vecs := make([][]float32, chunkCount)
+				for j := 0; j < chunkCount; j++ {
+					docs[j] = embeddings.PostDocument{
+						PostID:    postID,
+						CreateAt:  now,
+						TeamID:    "team1",
+						ChannelID: "channel1",
+						UserID:    "user1",
+						Content:   fmt.Sprintf("%s/chunk%d", tag, j),
+						ChunkInfo: chunking.ChunkInfo{
+							IsChunk:     true,
+							ChunkIndex:  j,
+							TotalChunks: chunkCount,
+						},
+					}
+					vecs[j] = []float32{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}
+				}
+				storeErrs[idx] = pgVector.Store(ctx, docs, vecs)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		for i, err := range storeErrs {
+			require.NoErrorf(t, err, "iter %d: writer %d Store failed", iter, i)
+		}
+
+		var contents []string
+		err := db.Select(&contents, "SELECT content FROM llm_posts_embeddings WHERE post_id = $1 ORDER BY chunk_index", postID)
+		require.NoError(t, err)
+		require.NotEmpty(t, contents, "iter %d: at least one writer should have committed rows", iter)
+
+		// Every surviving row must belong to the same writer, and the count
+		// must equal that writer's TotalChunks — the winning Store must have
+		// replaced the row set atomically.
+		firstTag := strings.SplitN(contents[0], "/", 2)[0]
+		for _, c := range contents {
+			tag := strings.SplitN(c, "/", 2)[0]
+			if tag != firstTag {
+				t.Fatalf("iter %d: mixed-writer state: rows tagged with both %q and %q (rows=%v)",
+					iter, firstTag, tag, contents)
+			}
+		}
+
+		var winnerIdx int
+		_, err = fmt.Sscanf(firstTag, fmt.Sprintf("iter%d-writer%%d", iter), &winnerIdx)
+		require.NoErrorf(t, err, "iter %d: could not parse winning writer index from tag %q", iter, firstTag)
+		require.Equalf(t, winnerIdx+1, len(contents),
+			"iter %d: winner is writer%d (TotalChunks=%d) but found %d rows: %v",
+			iter, winnerIdx, winnerIdx+1, len(contents), contents)
+	}
 }
 
 func TestDeleteOrphaned(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -546,19 +546,11 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 }
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *model.Post) {
-	// Handle indexing of updated posts
 	if p.indexerService != nil {
-		// Delete the old post from index
-		if err := p.indexerService.DeletePost(context.Background(), oldPost.Id); err != nil {
-			p.pluginAPI.Log.Error("Failed to delete post from vector database", "error", err)
-		}
-
-		// Get channel to retrieve team ID
 		channel, err := p.API.GetChannel(newPost.ChannelId)
 		if err != nil {
 			p.pluginAPI.Log.Error("Failed to get channel for post indexing", "error", err)
 		} else {
-			// Index the updated post
 			if err := p.indexerService.IndexPost(context.Background(), newPost, channel); err != nil {
 				p.pluginAPI.Log.Error("Failed to index updated post in vector database", "error", err)
 			}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Backports [#754](https://github.com/mattermost/mattermost-plugin-agents/pull/754) as the second PR in the AI Enhanced Search `release-2.0` stack.

This serializes concurrent embedding writes for the same post, preventing duplicate-key failures and mixed stale/new chunks when reindex workers and live post hooks overlap.

Stack:
- Base: [backport #707](https://github.com/mattermost/mattermost-plugin-agents/pull/954)
- Original PR: [#754](https://github.com/mattermost/mattermost-plugin-agents/pull/754)

Backport-specific changes:
- Resolved the `postgres/pgvector_test.go` import conflict while retaining the `release-2.0` non-`/v2` module path.
- Production behavior otherwise matches the original PR.

#### Release Note

```release-note
Fixed concurrent AI Enhanced Search embedding writes for the same post producing duplicate or inconsistent chunks.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

