### PR TITLE
Backport #876: fix embedding model change search lockout

### DIFF
--- a/e2e/scripts/ci-test-groups.mjs
+++ b/e2e/scripts/ci-test-groups.mjs
@@ -33,6 +33,7 @@ const groups = {
         'tests/action-item-extraction/ui-verification.spec.ts',
         'tests/action-item-extraction/follow-ups.spec.ts',
         'tests/semantic-search/search-bot-selector.spec.ts',
+        'tests/semantic-search/reindex-after-model-change.spec.ts',
         'tests/rhs-core/new-messages-rhs.spec.ts',
         'tests/tool-config/policy-change.spec.ts',
         'tests/tool-config/tab-layout.spec.ts',

--- a/e2e/tests/semantic-search/reindex-after-model-change.spec.ts
+++ b/e2e/tests/semantic-search/reindex-after-model-change.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+
+import RunContainer from 'helpers/plugincontainer';
+import MattermostContainer from 'helpers/mmcontainer';
+import { mattermostAIAdminConfigApiFromClient, mattermostAIPluginRoutes } from 'helpers/plugin-http';
+
+let mattermost: MattermostContainer;
+
+test.beforeAll(async () => {
+    mattermost = await RunContainer();
+});
+
+test.afterAll(async () => {
+    await mattermost.stop();
+});
+
+type JobStatus = { status: string; error?: string };
+type HealthCheck = {
+    status: string;
+    model_compatible: boolean;
+    model_needs_reindex: boolean;
+    stored_model_name?: string;
+};
+type AIBots = { searchEnabled: boolean };
+
+async function waitForReindexComplete(
+    routes: ReturnType<typeof mattermostAIPluginRoutes>,
+    token: string,
+): Promise<JobStatus> {
+    const deadline = Date.now() + 60000;
+    for (;;) {
+        const status = await routes.getJson('admin/reindex/status', token) as JobStatus;
+        if (status.status === 'completed') {
+            return status;
+        }
+        if (status.status === 'failed' || status.status === 'canceled') {
+            throw new Error(`Reindex did not complete: ${status.status} (${status.error ?? 'no error'})`);
+        }
+        if (Date.now() > deadline) {
+            throw new Error(`Timed out waiting for reindex to complete, last status: ${status.status}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+}
+
+test.describe('Reindex after embedding model change', () => {
+    // MM-69713: an embedding model change disables query search until a full
+    // reindex completes, while keeping the admin reindex path available.
+    test('admin can start a full reindex after changing the embedding model, which re-enables search', async () => {
+        const admin = await mattermost.getAdminClient();
+        const token = admin.getToken();
+        const routes = mattermostAIPluginRoutes(mattermost.url());
+        const configApi = mattermostAIAdminConfigApiFromClient(admin, mattermost.url());
+
+        // Index a real post so there is content in the index.
+        const userClient = await mattermost.getClient('regularuser', 'regularuser');
+        const team = await userClient.getTeamByName('test');
+        const channel = await userClient.getChannelByName(team.id, 'town-square');
+        await userClient.createPost({
+            channel_id: channel.id,
+            message: 'The Q4 budget report shows a 15% increase in marketing spend',
+        });
+
+        // 1. Initial full reindex. This records the model the index was built
+        //    with (mock provider, no model name, 512 dimensions).
+        await routes.postJson('admin/reindex', token, { clearIndex: true });
+        await waitForReindexComplete(routes, token);
+
+        const botsBefore = await routes.getJson('ai_bots', token) as AIBots;
+        expect(botsBefore.searchEnabled).toBe(true);
+
+        // 2. Change the embedding model (same provider and dimensions, different
+        //    model name) so the configured model is incompatible with the index.
+        const config = await configApi.get();
+        const embeddingSearchConfig = config.embeddingSearchConfig as Record<string, any>;
+        embeddingSearchConfig.embeddingProvider = {
+            ...embeddingSearchConfig.embeddingProvider,
+            parameters: { embeddingModel: 'changed-embedding-model' },
+        };
+        await configApi.put({ ...config, embeddingSearchConfig });
+
+        // 3. The index needs a reindex and query search is disabled.
+        const healthAfterChange = await routes.getJson('admin/reindex/health-check', token) as HealthCheck;
+        expect(healthAfterChange.model_needs_reindex).toBe(true);
+        expect(healthAfterChange.model_compatible).toBe(false);
+
+        const botsAfterChange = await routes.getJson('ai_bots', token) as AIBots;
+        expect(botsAfterChange.searchEnabled).toBe(false);
+
+        // 4. A full reindex can be started while query search is disabled.
+        await routes.postJson('admin/reindex', token, { clearIndex: true });
+        await waitForReindexComplete(routes, token);
+
+        // 5. The reindex stores compatible model info and enables query search.
+        const healthAfterReindex = await routes.getJson('admin/reindex/health-check', token) as HealthCheck;
+        expect(healthAfterReindex.model_compatible).toBe(true);
+        expect(healthAfterReindex.model_needs_reindex).toBe(false);
+        expect(healthAfterReindex.stored_model_name).toBe('changed-embedding-model');
+
+        const botsAfterReindex = await routes.getJson('ai_bots', token) as AIBots;
+        expect(botsAfterReindex.searchEnabled).toBe(true);
+    });
+});

--- a/search/availability.go
+++ b/search/availability.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package search
+
+import (
+	"sync/atomic"
+
+	"github.com/mattermost/mattermost-plugin-agents/embeddings"
+)
+
+// Availability keeps indexing and query-time search gates separate.
+//
+// IndexSearch is available whenever search is initialized, so admins can run a
+// full reindex while the configured model is incompatible with the existing
+// index. QuerySearch additionally requires the predicate to report compatible
+// model info, and evaluates that predicate on each call.
+type Availability struct {
+	search       atomic.Pointer[embeddings.EmbeddingSearch]
+	queryAllowed atomic.Pointer[func() bool]
+}
+
+// NewAvailability returns an Availability with no search initialized.
+func NewAvailability() *Availability {
+	return &Availability{}
+}
+
+// SetQueryAllowedFunc installs the predicate used to decide whether query-time
+// search is currently allowed. A nil predicate allows querying whenever search
+// is initialized.
+func (a *Availability) SetQueryAllowedFunc(fn func() bool) {
+	if fn == nil {
+		a.queryAllowed.Store(nil)
+		return
+	}
+	a.queryAllowed.Store(&fn)
+}
+
+// Set stores the initialized embedding search. Passing nil marks search as
+// uninitialized, which disables both indexing and querying.
+func (a *Availability) Set(s embeddings.EmbeddingSearch) {
+	if s == nil {
+		a.search.Store(nil)
+		return
+	}
+	a.search.Store(&s)
+}
+
+// IndexSearch returns the embedding search for indexing and reindexing. It is
+// available whenever search is initialized, regardless of model compatibility.
+func (a *Availability) IndexSearch() embeddings.EmbeddingSearch {
+	ptr := a.search.Load()
+	if ptr == nil {
+		return nil
+	}
+	return *ptr
+}
+
+// QuerySearch returns the embedding search for query-time use, or nil when
+// search is uninitialized or the query predicate reports the configured model
+// as incompatible with the existing index.
+func (a *Availability) QuerySearch() embeddings.EmbeddingSearch {
+	s := a.IndexSearch()
+	if s == nil {
+		return nil
+	}
+	if fn := a.queryAllowed.Load(); fn != nil && !(*fn)() {
+		return nil
+	}
+	return s
+}

--- a/search/availability_test.go
+++ b/search/availability_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package search
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/embeddings"
+	"github.com/mattermost/mattermost-plugin-agents/embeddings/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvailability(t *testing.T) {
+	// boolPtr distinguishes "no predicate installed" (nil) from an installed
+	// predicate returning true/false.
+	boolPtr := func(b bool) *bool { return &b }
+
+	cases := []struct {
+		name         string
+		initialized  bool
+		queryAllowed *bool
+		wantIndex    bool
+		wantQuery    bool
+	}{
+		{
+			name:        "uninitialized disables indexing and querying",
+			initialized: false,
+			wantIndex:   false,
+			wantQuery:   false,
+		},
+		{
+			name:         "initialized without predicate allows both",
+			initialized:  true,
+			queryAllowed: nil,
+			wantIndex:    true,
+			wantQuery:    true,
+		},
+		{
+			// An incompatible model blocks queries while preserving indexing for reindexing.
+			name:         "incompatible model keeps indexing available but disables querying",
+			initialized:  true,
+			queryAllowed: boolPtr(false),
+			wantIndex:    true,
+			wantQuery:    false,
+		},
+		{
+			name:         "compatible model allows querying",
+			initialized:  true,
+			queryAllowed: boolPtr(true),
+			wantIndex:    true,
+			wantQuery:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAvailability()
+			var s embeddings.EmbeddingSearch
+			if tc.initialized {
+				s = mocks.NewMockEmbeddingSearch(t)
+				a.Set(s)
+			}
+			if tc.queryAllowed != nil {
+				allowed := *tc.queryAllowed
+				a.SetQueryAllowedFunc(func() bool { return allowed })
+			}
+
+			if tc.wantIndex {
+				require.Equal(t, s, a.IndexSearch())
+			} else {
+				require.Nil(t, a.IndexSearch())
+			}
+			if tc.wantQuery {
+				require.Equal(t, s, a.QuerySearch())
+			} else {
+				require.Nil(t, a.QuerySearch())
+			}
+		})
+	}
+
+	t.Run("query search re-enables when the model becomes compatible again", func(t *testing.T) {
+		// The predicate reflects stored model compatibility without resetting search.
+		a := NewAvailability()
+		s := mocks.NewMockEmbeddingSearch(t)
+		a.Set(s)
+
+		compatible := false
+		a.SetQueryAllowedFunc(func() bool { return compatible })
+
+		require.Nil(t, a.QuerySearch())
+		require.Equal(t, s, a.IndexSearch())
+
+		compatible = true
+		require.Equal(t, s, a.QuerySearch(), "query search should recover automatically after a reindex")
+	})
+
+	t.Run("predicate is not consulted when search is uninitialized", func(t *testing.T) {
+		// In production the predicate reads the stored model info from the KV
+		// store; short-circuiting on a nil search avoids that DB access during
+		// early initialization when no search exists yet.
+		a := NewAvailability()
+		a.SetQueryAllowedFunc(func() bool {
+			t.Fatal("predicate must not be called when search is nil")
+			return true
+		})
+		require.Nil(t, a.QuerySearch())
+	})
+
+	t.Run("setting nil disables a previously initialized search", func(t *testing.T) {
+		a := NewAvailability()
+		a.Set(mocks.NewMockEmbeddingSearch(t))
+		a.Set(nil)
+		require.Nil(t, a.IndexSearch())
+		require.Nil(t, a.QuerySearch())
+	})
+
+	t.Run("clearing predicate re-enables querying after model incompatibility", func(t *testing.T) {
+		a := NewAvailability()
+		s := mocks.NewMockEmbeddingSearch(t)
+		a.Set(s)
+		a.SetQueryAllowedFunc(func() bool { return false })
+		require.Nil(t, a.QuerySearch())
+
+		a.SetQueryAllowedFunc(nil)
+		require.Equal(t, s, a.QuerySearch())
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -232,18 +232,12 @@ func (p *Plugin) OnActivate() error {
 
 	streamingService := streaming.NewMMPostStreamService(mmClient, i18nBundle)
 
-	// Atomic pointer for the embedding search - single source of truth
-	var currentSearch atomic.Pointer[embeddings.EmbeddingSearch]
+	// Availability is the single source of truth for the embedding search.
+	// Indexing stays available whenever search is initialized so a reindex can
+	// always be started; query-time search is additionally gated on model
+	// compatibility (wired below).
+	searchAvailability := search.NewAvailability()
 	var lastSearchInitError atomic.Value // stores string
-
-	// Getter function that reads from the atomic pointer
-	getSearch := func() embeddings.EmbeddingSearch {
-		ptr := currentSearch.Load()
-		if ptr == nil {
-			return nil
-		}
-		return *ptr
-	}
 
 	// Config getter for saving model info after reindexing
 	configGetter := func() embeddings.EmbeddingSearchConfig {
@@ -273,8 +267,16 @@ func (p *Plugin) OnActivate() error {
 		// Continue without search functionality
 	}
 
-	// Create indexer service with getter function
-	indexerService := indexer.New(getSearch, configGetter, mmClient, bots, dbClient.DB, p.API)
+	// Create indexer service. IndexSearch stays available whenever search is
+	// initialized, so a full reindex can run during model incompatibility.
+	indexerService := indexer.New(searchAvailability.IndexSearch, configGetter, mmClient, bots, dbClient.DB, p.API)
+
+	// Query-time search is only allowed when the configured embedding model is
+	// compatible with the existing index.
+	searchAvailability.SetQueryAllowedFunc(func() bool {
+		cfg := p.configuration.EmbeddingSearchConfig()
+		return indexerService.CheckModelCompatibility(cfg.GetProviderType(), cfg.Dimensions, cfg.GetModelName()).Compatible
+	})
 
 	// Mark any orphaned reindex jobs as failed (any node, staleness-based).
 	// Handles wedge cases where the plugin/server crashed while a job was
@@ -284,23 +286,9 @@ func (p *Plugin) OnActivate() error {
 		pluginAPI.Log.Warn("Failed to check for orphaned reindex job", "error", orphanErr)
 	}
 
-	// Check model compatibility and disable search if the model has changed since last reindex.
-	// Search will be re-enabled by the config update listener (registered below) after a
-	// reindex updates the stored model info — this is intentional, not a deadlock.
+	// Store the initialized search; QuerySearch handles compatibility gating.
+	searchAvailability.Set(embeddingsSearch)
 	if embeddingsSearch != nil {
-		embeddingsCfg := p.configuration.EmbeddingSearchConfig()
-		compatibility := indexerService.CheckModelCompatibility(embeddingsCfg.GetProviderType(), embeddingsCfg.Dimensions, embeddingsCfg.GetModelName())
-		if !compatibility.Compatible {
-			pluginAPI.Log.Warn("Embedding model configuration has changed, search disabled until re-index",
-				"reason", compatibility.Reason)
-			embeddingsSearch = nil // Disable search
-			lastSearchInitError.Store("search disabled: " + compatibility.Reason)
-		}
-	}
-
-	// Store initial search in atomic pointer
-	if embeddingsSearch != nil {
-		currentSearch.Store(&embeddingsSearch)
 		lastSearchInitError.Store("") // Clear any previous error
 	}
 
@@ -309,9 +297,10 @@ func (p *Plugin) OnActivate() error {
 		pluginAPI.Log.Warn("Failed to reconcile vector index state", "error", reconcileErr)
 	}
 
-	// Create search service with getter function
+	// Create search service. It uses QuerySearch, which returns nil when the
+	// configured model and existing index are incompatible.
 	searchService := search.New(
-		getSearch,
+		searchAvailability.QuerySearch,
 		mmClient,
 		prompts,
 		streamingService,
@@ -331,37 +320,15 @@ func (p *Plugin) OnActivate() error {
 		if initErr != nil {
 			pluginAPI.Log.Error("Failed to reinitialize embedding search on config change", "error", initErr)
 			// Disable search on failure
-			currentSearch.Store(nil)
+			searchAvailability.Set(nil)
 			lastSearchInitError.Store(initErr.Error())
 			return
 		}
 
-		// Check model compatibility.
-		// If the configured model no longer matches the indexed model, search is intentionally
-		// disabled until a reindex updates the stored model info. This is not a deadlock: the
-		// listener re-fires on every config save and re-calls InitEmbeddingsSearch above, so
-		// after a successful reindex the next config change will pass this check and re-enable search.
-		if newEmbeddingsSearch != nil {
-			embeddingsCfg := p.configuration.EmbeddingSearchConfig()
-			compatibility := indexerService.CheckModelCompatibility(embeddingsCfg.GetProviderType(), embeddingsCfg.Dimensions, embeddingsCfg.GetModelName())
-			if !compatibility.Compatible {
-				pluginAPI.Log.Warn("Embedding model configuration has changed, search disabled until re-index",
-					"reason", compatibility.Reason)
-				newEmbeddingsSearch = nil
-				lastSearchInitError.Store("search disabled: " + compatibility.Reason)
-			}
-		}
-
-		// Update atomic pointer - both services will see the new value
-		if newEmbeddingsSearch != nil {
-			currentSearch.Store(&newEmbeddingsSearch)
-			lastSearchInitError.Store("") // Clear any previous error
-		} else {
-			currentSearch.Store(nil)
-			if lastSearchInitError.Load() != nil {
-				lastSearchInitError.Store("")
-			}
-		}
+		// Store the reinitialized search. QuerySearch blocks incompatible model
+		// queries while IndexSearch allows reindexing.
+		searchAvailability.Set(newEmbeddingsSearch)
+		lastSearchInitError.Store("")
 		pluginAPI.Log.Info("Embedding search reinitialized on config change")
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Backports the AI Enhanced Search portion of [#876](https://github.com/mattermost/mattermost-plugin-agents/pull/876) as the fifth PR in the `release-2.0` stack.

This separates indexing availability from query-time availability so administrators can run the required Full Reindex after changing the embedding model. Query search remains blocked until the index is compatible, then re-enables automatically.

Stack:
- Base: [backport #885](https://github.com/mattermost/mattermost-plugin-agents/pull/957)
- Original PR: [#876](https://github.com/mattermost/mattermost-plugin-agents/pull/876)

Backport-specific changes:
- Omitted the original squash commit's unrelated `LLMBotPost` and `turn_content_utils` RHS rendering changes and associated new test.
- Rewrote imports in `search/availability.go` and its tests to retain the `release-2.0` non-`/v2` module path.
- Retained the search availability implementation, server wiring, unit coverage, semantic-search E2E test, and E2E shard assignment from the original PR.
- Replaced the original squash commit message because it contained unrelated RHS history and co-author trailers; the new commit retains the original SHA reference.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-69713

#### Release Note

```release-note
Fixed changing the AI Enhanced Search embedding model permanently disabling search and preventing the required Full Reindex from starting. Reindexing remains available and query search re-enables automatically after recovery completes.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

