### PR TITLE
Backport #904: recreate pgvector table after dimension changes

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -348,13 +348,13 @@ jq -r '[.timestamp, .user_id, .team_id, .bot_username, .input_tokens, .output_to
 
 ### Post indexing
 
-Post indexing occurs automatically during initial setup and when changing embedding providers:
+Post indexing occurs automatically during initial setup. Changing the embedding **provider**, **model**, or **dimensions** requires a **Full Reindex** (do not use Resume for a dimension change — Resume keeps the existing table schema). Full Reindex recreates the embeddings table when dimensions change so new vectors match the configured width.
 
 1. Navigate to **System Console > Plugins > Agents > Embedding Search**
 2. Use the reindex controls to:
    
    - Monitor indexing progress during initial setup.
-   - Trigger reindexing when changing embedding providers.
+   - Trigger a Full Reindex when changing embedding providers, models, or dimensions.
    - Check indexing status.
 
 ### Backup and restore

--- a/embeddings/integration_test.go
+++ b/embeddings/integration_test.go
@@ -243,7 +243,8 @@ func TestBasicIndexAndSearchMechanics(t *testing.T) {
 	}
 }
 
-// TestReindexWithDimensionMismatch tests behavior when dimension changes between indexes
+// TestReindexWithDimensionMismatch verifies Full Reindex Clear recreates the
+// pgvector table when configured dimensions change.
 func TestReindexWithDimensionMismatch(t *testing.T) {
 	db := testDB(t)
 	defer cleanupDB(t, db)
@@ -285,26 +286,15 @@ func TestReindexWithDimensionMismatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, results)
 
-	// Now attempt to create a new search system with different dimensions
-	// This simulates a model configuration change
-	// The pgvector table already exists with 64 dimensions, so this should fail
-	// when trying to store new embeddings with different dimensions
-
-	// First, clear the index to simulate a reindex scenario
-	err = search64.Clear(ctx)
+	// Simulate a config change: new search at 128 dims, then Full Reindex Clear.
+	search128 := createFullSearchSystem(t, db, 128)
+	err = search128.Clear(ctx)
 	require.NoError(t, err)
 
-	// Verify index is cleared
 	var count int
 	err = db.Get(&count, "SELECT COUNT(*) FROM llm_posts_embeddings")
 	require.NoError(t, err)
 	assert.Equal(t, 0, count, "Index should be empty after clear")
-
-	// The vector store was created with 64 dimensions and the table column is fixed
-	// A proper reindex requires creating a new vector store with correct dimensions
-
-	// Create search with 128 dimensions - this will fail because the table column is 64 dims
-	search128 := createFullSearchSystem(t, db, 128)
 
 	doc128 := embeddings.PostDocument{
 		PostID:    "post2",
@@ -315,11 +305,20 @@ func TestReindexWithDimensionMismatch(t *testing.T) {
 		Content:   "New content with different dimensions",
 	}
 
-	// This should error because embedding dimensions don't match table
 	addTestPost(t, db, "post2", "user1", "channel1", "New content with different dimensions", now+1000)
 	err = search128.Store(ctx, []embeddings.PostDocument{doc128})
-	assert.Error(t, err, "Storing with mismatched dimensions should fail")
-	assert.Contains(t, err.Error(), "dimensions", "Error should mention dimension mismatch")
+	require.NoError(t, err, "Store after dimension-aware Clear should succeed")
+
+	err = db.Get(&storedDim, "SELECT vector_dims(embedding) FROM llm_posts_embeddings WHERE post_id = 'post2'")
+	require.NoError(t, err)
+	assert.Equal(t, 128, storedDim)
+
+	results, err = search128.Search(ctx, "different dimensions", embeddings.SearchOptions{
+		Limit:  5,
+		UserID: "user1",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, results)
 }
 
 // Note: Semantic relevance testing with real embeddings is in search/search_eval_test.go

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -5,6 +5,8 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -57,7 +59,9 @@ const createVectorIndexQuery = "CREATE INDEX IF NOT EXISTS " + vectorIndexName +
 const expectedVectorIndexDefSuffix = "USING hnsw (embedding vector_l2_ops)"
 
 type PGVector struct {
-	db *sqlx.DB
+	db              *sqlx.DB
+	dimensions      int
+	skipVectorIndex bool
 }
 
 // Compile-time check that PGVector supports deferred bulk indexing.
@@ -81,8 +85,20 @@ func NewPGVector(db *sqlx.DB, config PGVectorConfig) (*PGVector, error) {
 		return nil, fmt.Errorf("failed to create vector extension: %w", err)
 	}
 
-	// Create the llm_posts_embeddings table if it doesn't exist
-	createTableQuery := `
+	pv := &PGVector{
+		db:              db,
+		dimensions:      config.Dimensions,
+		skipVectorIndex: config.SkipVectorIndex,
+	}
+	if err := pv.ensureSchema(context.Background(), !config.SkipVectorIndex, pv.db); err != nil {
+		return nil, err
+	}
+
+	return pv, nil
+}
+
+func createEmbeddingsTableQuery(dimensions int) string {
+	return `
 		CREATE TABLE IF NOT EXISTS llm_posts_embeddings (
 			id TEXT PRIMARY KEY,             								-- Post ID or chunk ID (post_id_chunk_N)
 			post_id TEXT NOT NULL REFERENCES Posts(Id) ON DELETE CASCADE,   -- Original post ID (same as id for non-chunks)
@@ -90,35 +106,94 @@ func NewPGVector(db *sqlx.DB, config PGVectorConfig) (*PGVector, error) {
 			channel_id TEXT NOT NULL,
 			user_id TEXT NOT NULL,
 			content TEXT NOT NULL,
-			embedding vector(` + strconv.Itoa(config.Dimensions) + `),
+			embedding vector(` + strconv.Itoa(dimensions) + `),
 			created_at BIGINT NOT NULL,
 			is_chunk BOOLEAN NOT NULL DEFAULT FALSE,
 			chunk_index INTEGER,              -- NULL for non-chunks
 			total_chunks INTEGER             -- NULL for non-chunks
 		)`
-	if _, err := db.Exec(createTableQuery); err != nil {
-		return nil, fmt.Errorf("failed to create llm_posts_embeddings table: %w", err)
+}
+
+type execContexter interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// ensureSchema creates the embeddings table and supporting indexes when missing.
+func (pv *PGVector) ensureSchema(ctx context.Context, withVectorIndex bool, ex execContexter) error {
+	if _, err := ex.ExecContext(ctx, createEmbeddingsTableQuery(pv.dimensions)); err != nil {
+		return fmt.Errorf("failed to create llm_posts_embeddings table: %w", err)
 	}
 
-	// Create indexes
 	queries := []string{
-		// Index on post_id for efficient lookups and deletions
 		"CREATE INDEX IF NOT EXISTS llm_posts_embeddings_post_id_idx ON llm_posts_embeddings(post_id)",
-		// Index on is_chunk to filter by chunks
 		"CREATE INDEX IF NOT EXISTS llm_posts_embeddings_is_chunk_idx ON llm_posts_embeddings(is_chunk)",
 	}
-	if !config.SkipVectorIndex {
-		// Index for similarity search using HNSW
+	if withVectorIndex {
 		queries = append(queries, createVectorIndexQuery)
 	}
 
 	for _, query := range queries {
-		if _, err := db.Exec(query); err != nil {
-			return nil, fmt.Errorf("failed to create index: %w", err)
+		if _, err := ex.ExecContext(ctx, query); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
 		}
 	}
+	return nil
+}
 
-	return &PGVector{db: db}, nil
+// embeddingColumnDimensions returns the typmod dimensions of the embedding
+// column, or 0 if the table/column does not exist.
+func (pv *PGVector) embeddingColumnDimensions(ctx context.Context) (int, error) {
+	var typeName string
+	err := pv.db.GetContext(ctx, &typeName, `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_catalog.pg_attribute a
+		JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relname = 'llm_posts_embeddings'
+			AND n.nspname = current_schema()
+			AND a.attname = 'embedding'
+			AND NOT a.attisdropped`)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read embedding column type: %w", err)
+	}
+
+	dims, err := parseVectorTypmod(typeName)
+	if err != nil {
+		return 0, err
+	}
+	return dims, nil
+}
+
+func parseVectorTypmod(typeName string) (int, error) {
+	const prefix = "vector("
+	if !strings.HasPrefix(typeName, prefix) || !strings.HasSuffix(typeName, ")") {
+		return 0, fmt.Errorf("unexpected embedding column type %q", typeName)
+	}
+	dims, err := strconv.Atoi(typeName[len(prefix) : len(typeName)-1])
+	if err != nil || dims <= 0 {
+		return 0, fmt.Errorf("unexpected embedding column type %q", typeName)
+	}
+	return dims, nil
+}
+
+func (pv *PGVector) vectorIndexExists(ctx context.Context) (bool, error) {
+	var exists bool
+	err := pv.db.GetContext(ctx, &exists, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_catalog.pg_class c
+			JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relname = $1
+				AND n.nspname = current_schema()
+				AND c.relkind = 'i'
+		)`, vectorIndexName)
+	if err != nil {
+		return false, fmt.Errorf("failed to check vector index existence: %w", err)
+	}
+	return exists, nil
 }
 
 func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, embeddings [][]float32) error {
@@ -378,9 +453,45 @@ func (pv *PGVector) Delete(ctx context.Context, postIDs []string) error {
 }
 
 func (pv *PGVector) Clear(ctx context.Context) error {
-	_, err := pv.db.ExecContext(ctx, "TRUNCATE TABLE llm_posts_embeddings")
+	tableDims, err := pv.embeddingColumnDimensions(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to clear vectors: %w", err)
+		return err
+	}
+
+	// Missing table: create at configured dimensions.
+	if tableDims == 0 {
+		return pv.ensureSchema(ctx, !pv.skipVectorIndex, pv.db)
+	}
+
+	// Same dimensions: truncate keeps typmod and any existing ANN index.
+	if tableDims == pv.dimensions {
+		if _, truncErr := pv.db.ExecContext(ctx, "TRUNCATE TABLE llm_posts_embeddings"); truncErr != nil {
+			return fmt.Errorf("failed to clear vectors: %w", truncErr)
+		}
+		return nil
+	}
+
+	// Dimension change: DROP + recreate. Preserve HNSW only if it was present
+	// (deferred reindex drops it via PrepareBulkIndex before Clear).
+	hadVectorIndex, err := pv.vectorIndexExists(ctx)
+	if err != nil {
+		return err
+	}
+
+	tx, err := pv.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction for dimension change: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, "DROP TABLE IF EXISTS llm_posts_embeddings"); err != nil {
+		return fmt.Errorf("failed to drop embeddings table for dimension change: %w", err)
+	}
+	if err := pv.ensureSchema(ctx, hadVectorIndex && !pv.skipVectorIndex, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit dimension change: %w", err)
 	}
 	return nil
 }

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -1270,7 +1270,107 @@ func TestClear(t *testing.T) {
 		err = db.Get(&count, "SELECT COUNT(*) FROM llm_posts_embeddings")
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
+
+		// Same-dim Clear keeps the vector typmod
+		dims, dimErr := pgVector.embeddingColumnDimensions(ctx)
+		require.NoError(t, dimErr)
+		assert.Equal(t, 3, dims)
 	})
+
+	t.Run("recreates table when configured dimensions change", func(t *testing.T) {
+		db := testDB(t)
+		defer cleanupDB(t, db)
+
+		ctx := context.Background()
+		oldStore, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+		require.NoError(t, err)
+
+		now := model.GetMillis()
+		addTestPosts(t, db, []string{"post1"}, []int64{now})
+		require.NoError(t, oldStore.Store(ctx, []embeddings.PostDocument{{
+			PostID: "post1", CreateAt: now, TeamID: "team1", ChannelID: "channel1", UserID: "user1", Content: "old",
+		}}, [][]float32{{0.1, 0.2, 0.3}}))
+
+		newStore, err := NewPGVector(db, PGVectorConfig{Dimensions: 5})
+		require.NoError(t, err)
+
+		// CREATE TABLE IF NOT EXISTS leaves the old typmod until Clear.
+		dims, err := newStore.embeddingColumnDimensions(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 3, dims)
+
+		require.NoError(t, newStore.Clear(ctx))
+
+		dims, err = newStore.embeddingColumnDimensions(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 5, dims)
+
+		hadIndex, err := newStore.vectorIndexExists(ctx)
+		require.NoError(t, err)
+		assert.True(t, hadIndex, "maintain-style Clear should recreate HNSW when it existed")
+
+		addTestPosts(t, db, []string{"post2"}, []int64{now + 1})
+		require.NoError(t, newStore.Store(ctx, []embeddings.PostDocument{{
+			PostID: "post2", CreateAt: now + 1, TeamID: "team1", ChannelID: "channel1", UserID: "user1", Content: "new",
+		}}, [][]float32{{0.1, 0.2, 0.3, 0.4, 0.5}}))
+
+		var storedDim int
+		require.NoError(t, db.Get(&storedDim, "SELECT vector_dims(embedding) FROM llm_posts_embeddings WHERE post_id = 'post2'"))
+		assert.Equal(t, 5, storedDim)
+	})
+
+	t.Run("does not recreate HNSW after PrepareBulkIndex on dimension change", func(t *testing.T) {
+		db := testDB(t)
+		defer cleanupDB(t, db)
+
+		ctx := context.Background()
+		_, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+		require.NoError(t, err)
+
+		newStore, err := NewPGVector(db, PGVectorConfig{Dimensions: 5})
+		require.NoError(t, err)
+
+		require.NoError(t, newStore.PrepareBulkIndex(ctx))
+		exists, err := newStore.vectorIndexExists(ctx)
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		require.NoError(t, newStore.Clear(ctx))
+
+		dims, err := newStore.embeddingColumnDimensions(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 5, dims)
+
+		exists, err = newStore.vectorIndexExists(ctx)
+		require.NoError(t, err)
+		assert.False(t, exists, "deferred Clear must leave HNSW dropped for FinalizeBulkIndex")
+	})
+}
+
+func TestParseVectorTypmod(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{name: "standard", input: "vector(1536)", want: 1536},
+		{name: "small", input: "vector(3)", want: 3},
+		{name: "missing dims", input: "vector", wantErr: true},
+		{name: "empty", input: "vector()", wantErr: true},
+		{name: "wrong type", input: "text", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVectorTypmod(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestSearchExcludesDeletedPosts(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Backports [#904](https://github.com/mattermost/mattermost-plugin-agents/pull/904) as the sixth PR in the AI Enhanced Search `release-2.0` stack.

This recreates the pgvector embeddings table during Full Reindex when the configured embedding dimensions no longer match the existing vector column, while preserving the deferred-index lifecycle behavior introduced by #885.

Stack:
- Base: [backport #876](https://github.com/mattermost/mattermost-plugin-agents/pull/958)
- Original stacked PR: [#904](https://github.com/mattermost/mattermost-plugin-agents/pull/904)

Backport-specific changes:
- None. This commit cherry-picked cleanly after the preceding stack PRs.
- The `release-2.0` non-`/v2` module path remains unchanged.

#### Ticket Link

Related to Jira https://mattermost.atlassian.net/browse/MM-69713

#### Release Note

```release-note
Fixed AI Enhanced Search Full Reindex after an embedding dimensions change by recreating the pgvector embeddings table when its vector width no longer matches the configured model.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

