### PR TITLE
Backport #936: harden Enhanced Search post props

### DIFF
--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -6,7 +6,8 @@ import type {OptsSignalExt} from '@mattermost/types/client4';
 
 import type {ConversationResponse, Turn} from '@/types/conversation';
 
-import {normalizeConversationResponse, searchAllChannels} from './client';
+import {getConversation, normalizeConversationResponse, searchAllChannels, setSiteURL} from './client';
+import manifest from './manifest';
 
 type SearchAllChannelsOpts = Omit<ChannelSearchOpts, 'page' | 'per_page'> & OptsSignalExt;
 
@@ -20,7 +21,16 @@ jest.mock('@mattermost/client', () => {
 
         // client.tsx constructs `new Client4()`; the mocked class exposes instance methods.
         Client4: class Client4 {
+            url = '';
             searchAllChannels = mockSearchAllChannels;
+
+            setUrl(url: string) {
+                this.url = url;
+            }
+
+            getOptions(options: RequestInit) {
+                return options;
+            }
         },
         ClientError: class extends Error {},
         mockSearchAllChannels,
@@ -32,6 +42,12 @@ const {mockSearchAllChannels} = jest.requireMock('@mattermost/client') as {
         (term: string, opts?: SearchAllChannelsOpts) => Promise<ChannelWithTeamData[]>
     >;
 };
+
+const mockFetch = jest.fn<Promise<Response>, [string, RequestInit]>();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const siteURL = 'http://localhost:8065';
+const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
 function makeTurn(overrides: Partial<Turn> = {}): Turn {
     return {
@@ -120,5 +136,36 @@ describe('searchAllChannels', () => {
             include_deleted: false,
             deleted: false,
         });
+    });
+});
+
+describe('getConversation', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        setSiteURL(siteURL);
+    });
+
+    test('requests the encoded conversation route for a well-formed id', async () => {
+        mockFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(makeConv()),
+        } as Response);
+
+        await expect(getConversation(WELL_FORMED_ID)).resolves.toEqual(makeConv());
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${siteURL}/plugins/${manifest.id}/conversations/${WELL_FORMED_ID}`,
+            expect.objectContaining({method: 'GET'}),
+        );
+    });
+
+    test.each([
+        {name: 'empty', id: ''},
+        {name: 'relative path segments', id: '../../some/other/route'},
+        {name: 'separator', id: 'abcdefghijklmnopqrstuvwxy/'},
+        {name: 'leading whitespace', id: ` ${WELL_FORMED_ID}`},
+    ])('does not issue a request for a malformed id: $name', async ({id}) => {
+        await expect(getConversation(id)).rejects.toThrow();
+        expect(mockFetch).not.toHaveBeenCalled();
     });
 });

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -9,6 +9,7 @@ import {NotPagedTeamSearchOpts, Team} from '@mattermost/types/teams';
 import {PluginConfig} from '@/components/system_console/plugin_config_types';
 import type {ConversationResponse} from '@/types/conversation';
 import {UserAgent, CreateAgentRequest, UpdateAgentRequest, ServiceInfo} from '@/types/agents';
+import {isValidId} from '@/utils/ids';
 
 import manifest from './manifest';
 
@@ -32,11 +33,15 @@ function postRoute(postid: string): string {
 }
 
 function channelRoute(channelid: string): string {
-    return `${baseRoute()}/channel/${channelid}`;
+    return `${baseRoute()}/channel/${encodeURIComponent(channelid)}`;
 }
 
 function agentRoute(agentId: string): string {
-    return `${baseRoute()}/agents/${agentId}`;
+    return `${baseRoute()}/agents/${encodeURIComponent(agentId)}`;
+}
+
+function conversationRoute(conversationId: string): string {
+    return `${baseRoute()}/conversations/${encodeURIComponent(conversationId)}`;
 }
 
 export async function doReaction(postid: string) {
@@ -270,7 +275,17 @@ export function normalizeConversationResponse(raw: ConversationResponse): Conver
 }
 
 export async function getConversation(conversationId: string): Promise<ConversationResponse> {
-    const url = `${baseRoute()}/conversations/${conversationId}`;
+    // The id can arrive straight off a free-form post prop; refuse to build a
+    // request from a value that is not a well-formed id.
+    if (!isValidId(conversationId)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid conversation id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
+    const url = conversationRoute(conversationId);
     const response = await fetch(url, Client4.getOptions({
         method: 'GET',
     }));

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 import styled from 'styled-components';
@@ -14,8 +14,10 @@ import {useSelectNotAIPost} from '@/hooks';
 import {useConversation, useTurnForPost, invalidateConversation} from '@/hooks/use_conversation';
 import {PostMessagePreview} from '@/mm_webapp';
 
+import {isValidId} from '@/utils/ids';
+
 import PostText from '../post_text';
-import {SearchSources} from '../search_sources';
+import {SearchSources, parseSearchSources} from '../search_sources';
 import ToolApprovalSet from '../tool_approval_set';
 import {ToolApprovalStage, ToolCall} from '../tool_types';
 import {Annotation} from '../citations/types';
@@ -51,8 +53,11 @@ interface LLMBotPostProps {
 export const LLMBotPost = (props: LLMBotPostProps) => {
     const selectPost = useSelectNotAIPost();
 
-    // Conversation entity data
-    const conversationId: string | undefined = props.post.props?.conversation_id;
+    // Post props are free-form JSON; a conversation_id that is not a
+    // well-formed id is treated as absent so no request is built from it and
+    // the component falls back to its no-conversation rendering path.
+    const rawConversationId: unknown = props.post.props?.conversation_id;
+    const conversationId: string | undefined = isValidId(rawConversationId) ? rawConversationId : undefined; // eslint-disable-line no-undefined
     const {conversation, loading: conversationLoading, error: conversationError} = useConversation(conversationId);
     const turn = useTurnForPost(conversation, props.post.id);
 
@@ -323,6 +328,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const hasContent = message !== '' || reasoningSummary !== '';
     const showControlsBar = ((showRegenerate || showPostbackButton) && hasContent) || showStopGeneratingButton;
 
+    // Parsed defensively: search_results is a free-form post prop, so a
+    // malformed value yields an empty list instead of throwing during render.
+    const searchSources = useMemo(
+        () => parseSearchSources(props.post.props?.[SearchResultsPropKey]),
+        [props.post.props],
+    );
+
     return (
         <PostBody
             data-testid='llm-bot-post'
@@ -373,9 +385,9 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                 showCursor={generating && !precontent}
                 annotations={annotations.length > 0 ? annotations : undefined} // eslint-disable-line no-undefined
             />
-            {props.post.props?.[SearchResultsPropKey] && (
+            {searchSources.length > 0 && (
                 <SearchSources
-                    sources={JSON.parse(props.post.props[SearchResultsPropKey])}
+                    sources={searchSources}
                 />
             )}
             { showPostbackButton &&

--- a/webapp/src/components/search_sources.test.tsx
+++ b/webapp/src/components/search_sources.test.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MAX_SEARCH_SOURCES, parseSearchSources} from './search_sources';
+
+const VALID_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
+
+function source(index: number) {
+    return {
+        postId: String(index).padStart(26, '0'),
+        channelId: VALID_ID,
+        userId: VALID_ID,
+        content: `source ${index}`,
+        score: 0.5,
+    };
+}
+
+describe('parseSearchSources', () => {
+    test.each([
+        {name: 'missing', raw: undefined},
+        {name: 'non-string', raw: 42},
+        {name: 'invalid JSON', raw: '{'},
+        {name: 'non-array JSON', raw: '{}'},
+    ])('returns no sources for $name input', ({raw}) => {
+        expect(parseSearchSources(raw)).toEqual([]);
+    });
+
+    test('drops malformed ids and normalizes display fields', () => {
+        const parsed = parseSearchSources(JSON.stringify([
+            {...source(1), content: 42, score: Number.NaN},
+            {...source(2), postId: '../invalid'},
+        ]));
+
+        expect(parsed).toEqual([{
+            ...source(1),
+            content: '',
+            score: 0,
+        }]);
+    });
+
+    test('limits sources to the server maximum', () => {
+        const raw = JSON.stringify(
+            Array.from({length: MAX_SEARCH_SOURCES + 25}, (_, index) => source(index)),
+        );
+
+        expect(parseSearchSources(raw)).toHaveLength(MAX_SEARCH_SOURCES);
+    });
+});

--- a/webapp/src/components/search_sources.test.tsx
+++ b/webapp/src/components/search_sources.test.tsx
@@ -3,6 +3,10 @@
 
 import {MAX_SEARCH_SOURCES, parseSearchSources} from './search_sources';
 
+jest.mock('./post_preview', () => ({
+    PostPreview: () => null,
+}));
+
 const VALID_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
 function source(index: number) {

--- a/webapp/src/components/search_sources.test.tsx
+++ b/webapp/src/components/search_sources.test.tsx
@@ -17,7 +17,7 @@ function source(index: number) {
 
 describe('parseSearchSources', () => {
     test.each([
-        {name: 'missing', raw: undefined},
+        {name: 'null', raw: null},
         {name: 'non-string', raw: 42},
         {name: 'invalid JSON', raw: '{'},
         {name: 'non-array JSON', raw: '{}'},

--- a/webapp/src/components/search_sources.tsx
+++ b/webapp/src/components/search_sources.tsx
@@ -5,7 +5,13 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 
+import {isValidId} from '@/utils/ids';
+
 import {PostPreview} from './post_preview';
+
+// Mirrors maxMaxResults in api/api_search.go: the server never returns more
+// than this many search results, so anything beyond it is dropped.
+export const MAX_SEARCH_SOURCES = 100;
 
 // Utility for formatting relevance scores
 const formatScore = (score: number): string => {
@@ -46,16 +52,17 @@ const SourceCount = styled.span`
 	line-height: 16px;
 `;
 
-const CollapseIcon = styled.i<{isOpen: boolean}>`
+// Transient ($-prefixed) props so styled-components doesn't forward them to the DOM.
+const CollapseIcon = styled.i<{$isOpen: boolean}>`
     font-size: 18px;
     color: rgba(var(--center-channel-color-rgb), 0.56);
     margin-left: auto;
-    transform: ${(props) => (props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+    transform: ${(props) => (props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
     transition: transform 0.15s ease-in-out;
 `;
 
-const SourcesList = styled.div<{isOpen: boolean}>`
-    display: ${(props) => (props.isOpen ? 'flex' : 'none')};
+const SourcesList = styled.div<{$isOpen: boolean}>`
+    display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
     flex-direction: column;
     margin-top: 8px;
 `;
@@ -96,12 +103,64 @@ const SourceItem = styled.div`
     }
 `;
 
-interface Source {
+export interface Source {
     postId: string;
     channelId: string;
     userId: string;
     content: string;
     score: number;
+}
+
+// toSource accepts an entry only when it is an object referencing well-formed
+// ids; the remaining display fields are coerced to safe defaults.
+function toSource(entry: unknown): Source | null {
+    if (typeof entry !== 'object' || entry === null) {
+        return null;
+    }
+    const {postId, channelId, userId, content, score} = entry as Record<string, unknown>;
+    if (!isValidId(postId) || !isValidId(channelId) || !isValidId(userId)) {
+        return null;
+    }
+    return {
+        postId,
+        channelId,
+        userId,
+        content: typeof content === 'string' ? content : '',
+        score: typeof score === 'number' && Number.isFinite(score) ? score : 0,
+    };
+}
+
+// parseSearchSources decodes the search_results post prop. Post props are
+// free-form JSON, so the value may be missing, not a string, not valid JSON,
+// not an array, or hold entries without well-formed ids. Anything unusable is
+// dropped rather than thrown so a bad prop can never break the post render,
+// and the result is bounded to the server's maximum result count.
+export function parseSearchSources(raw: unknown): Source[] {
+    if (typeof raw !== 'string' || raw === '') {
+        return [];
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+
+    const sources: Source[] = [];
+    for (const entry of parsed) {
+        if (sources.length >= MAX_SEARCH_SOURCES) {
+            break;
+        }
+        const source = toSource(entry);
+        if (source) {
+            sources.push(source);
+        }
+    }
+    return sources;
 }
 
 interface SourceItemProps {
@@ -148,10 +207,10 @@ export const SearchSources = ({sources}: Props) => {
                 </SourcesTitle>
                 <CollapseIcon
                     className='icon-chevron-down'
-                    isOpen={isOpen}
+                    $isOpen={isOpen}
                 />
             </SourcesHeader>
-            <SourcesList isOpen={isOpen}>
+            <SourcesList $isOpen={isOpen}>
                 {sources.map((source, index) => (
                     <SearchSource
                         key={source.postId}

--- a/webapp/src/utils/ids.ts
+++ b/webapp/src/utils/ids.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const ID_PATTERN = /^[a-z0-9]{26}$/;
+
+export function isValidId(id: unknown): id is string {
+    return typeof id === 'string' && ID_PATTERN.test(id);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Backports the applicable post-prop hardening from [#936](https://github.com/mattermost/mattermost-plugin-agents/pull/936) as the ninth and final PR in the AI Enhanced Search `release-2.0` stack.

This prevents malformed `search_results` props from breaking post rendering, filters invalid source identifiers, normalizes display fields, limits source lists to the server maximum, validates conversation IDs before requests, and avoids forwarding styled-component state props to the DOM.

Stack:
- Base: [backport #930](https://github.com/mattermost/mattermost-plugin-agents/pull/961)
- Original PR: [#936](https://github.com/mattermost/mattermost-plugin-agents/pull/936)

Backport-specific changes:
- Adapted defensive search-source parsing to the release branch's single-round `LLMBotPost` renderer rather than bringing in the later multi-round renderer.
- Retained conversation ID validation in `LLMBotPost` and `getConversation`, plus channel, agent, and conversation route encoding.
- Added `webapp/src/utils/ids.ts` from the original PR's later-tree prerequisite because that shared validator does not exist on `release-2.0`.
- Omitted `getConversationContext` and `useConversationIdForThread` changes because those APIs/hooks do not exist on `release-2.0`.
- The original `llmbot_post.test.tsx` depends on later RHS architecture that was intentionally excluded from the #876 backport. Replaced its relevant coverage with a focused `search_sources.test.tsx` and expanded the release branch's `client.test.ts` conversation validation coverage.
- Added a test-only `PostPreview` mock so the focused parser suite does not evaluate Mattermost webapp globals that are unavailable in the plugin Jest environment.
- Retained the `release-2.0` non-`/v2` module path.

#### Release Note

```release-note
Fixed malformed AI Enhanced Search source and conversation post properties causing invalid requests or post rendering failures. Invalid source entries are now ignored and source lists are bounded to the server maximum.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

