### PR TITLE
Prevent resumed reindex jobs from mixing embedding models

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -180,6 +180,13 @@ func (s *Indexer) StartReindexJob(clearIndex bool) (JobStatus, error) {
 		count = 0 // Continue with zero estimate
 	}
 
+	currentModelInfo := s.getModelInfoFromConfig()
+	if !clearIndex && hasExisting && !sameEmbeddingModel(jobStatus.ModelInfo, currentModelInfo) {
+		// A cursor is only valid for the model that produced the preceding
+		// embeddings. Restart from the beginning rather than mixing models.
+		clearIndex = true
+	}
+
 	newJobStatus := JobStatus{
 		JobID:     model.NewId(),
 		Status:    JobStatusRunning,
@@ -200,7 +207,7 @@ func (s *Indexer) StartReindexJob(clearIndex bool) (JobStatus, error) {
 		// Fresh start - calculate new values and snapshot current model.
 		newJobStatus.TotalRows = count
 		newJobStatus.CutoffAt = cutoffTimestamp
-		newJobStatus.ModelInfo = s.getModelInfoFromConfig()
+		newJobStatus.ModelInfo = currentModelInfo
 	}
 
 	// CAS routes through master; the predicate rejects the write if the row
@@ -656,4 +663,14 @@ func (s *Indexer) getModelInfoFromConfig() *ModelInfo {
 		ModelName:    cfg.GetModelName(),
 		Dimensions:   cfg.Dimensions,
 	}
+}
+
+func sameEmbeddingModel(left, right *ModelInfo) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.ProviderType == right.ProviderType &&
+		left.ModelName == right.ModelName &&
+		left.Dimensions == right.Dimensions
 }

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -723,9 +723,9 @@ func waitForJobStatus(t *testing.T, store *jobKVStore, want string, timeout time
 	return status
 }
 
-// TestResumeRefreshesModelInfo covers start-time ModelInfo snapshotting:
-// fail mid-pass → resume completes → IndexerModelKey gets the original
-// snapshot (not live config). Also covers catch-up writing nothing.
+// TestResumeRefreshesModelInfo covers model snapshots across a retry:
+// unchanged configuration resumes, while changed configuration restarts.
+// Also covers catch-up writing nothing.
 func TestResumeRefreshesModelInfo(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -742,11 +742,11 @@ func TestResumeRefreshesModelInfo(t *testing.T) {
 			compatAgainst:   "model-a",
 		},
 		{
-			name:                 "resume after config change still writes the original snapshot and stays locked",
+			name:                 "resume after config change restarts and unlocks the new model",
 			changeConfigOnResume: true,
 			resumeModelName:      "model-b",
-			wantStoredModel:      "model-a",
-			wantCompatible:       false,
+			wantStoredModel:      "model-b",
+			wantCompatible:       true,
 			compatAgainst:        "model-b",
 		},
 	}
@@ -780,6 +780,9 @@ func TestResumeRefreshesModelInfo(t *testing.T) {
 
 			// First run fails on Store; resume succeeds.
 			mockSearch.On("Clear", mock.Anything).Return(nil).Once()
+			if tt.changeConfigOnResume {
+				mockSearch.On("Clear", mock.Anything).Return(nil).Once()
+			}
 			mockSearch.On("Store", mock.Anything, mock.Anything).Return(errors.New("store blew up")).Once()
 			mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
@@ -813,7 +816,7 @@ func TestResumeRefreshesModelInfo(t *testing.T) {
 			require.NoError(t, err)
 			completed := waitForJobStatus(t, store, JobStatusCompleted, 5*time.Second)
 			require.NotNil(t, completed.ModelInfo)
-			assert.Equal(t, "model-a", completed.ModelInfo.ModelName, "resume must carry the original snapshot")
+			assert.Equal(t, tt.wantStoredModel, completed.ModelInfo.ModelName)
 
 			store.mu.Lock()
 			require.NotNil(t, store.model)
@@ -867,6 +870,106 @@ func TestResumeRefreshesModelInfo(t *testing.T) {
 		assert.Equal(t, "old-model", store.model.ModelName, "catch-up must not rewrite IndexerModelKey")
 		store.mu.Unlock()
 	})
+}
+
+func TestResumeAfterEmbeddingSearchReplacementDoesNotMixModels(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	now := model.GetMillis()
+	_, err := db.Exec("INSERT INTO Channels (Id, Type, Name) VALUES ('channel1', 'O', 'town-square')")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO Posts (Id, CreateAt, DeleteAt, Message, Type, ChannelId) VALUES ('post-a', $1, 0, 'first', '', 'channel1'), ('post-b', $2, 0, 'second', '', 'channel1')", now-20000, now-10000)
+	require.NoError(t, err)
+
+	store := &jobKVStore{}
+	mockClient := mocks.NewMockClient(t)
+	mockMutexAPI := &plugintest.API{}
+	mockMutexAPI.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("model.PluginKVSetOptions")).Return(true, nil).Maybe()
+	mockMutexAPI.On("KVDelete", mock.AnythingOfType("string")).Return(nil).Maybe()
+	store.wire(mockClient)
+	mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+	mockClient.On("LogError", mock.Anything, mock.Anything).Return().Maybe()
+
+	searchA := embeddingsmocks.NewMockEmbeddingSearch(t)
+	searchB := embeddingsmocks.NewMockEmbeddingSearch(t)
+	var writesMu sync.Mutex
+	var successfulAWrites, successfulBWrites []string
+
+	searchA.On("Clear", mock.Anything).Return(nil).Once()
+	searchA.On("Store", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			writesMu.Lock()
+			defer writesMu.Unlock()
+			for _, doc := range args.Get(1).([]embeddings.PostDocument) {
+				successfulAWrites = append(successfulAWrites, doc.PostID)
+			}
+		}).
+		Return(nil).Once()
+	searchA.On("Store", mock.Anything, mock.Anything).Return(errors.New("model A interrupted")).Once()
+	searchB.On("Clear", mock.Anything).Return(nil).Once()
+	searchB.On("Store", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			writesMu.Lock()
+			defer writesMu.Unlock()
+			for _, doc := range args.Get(1).([]embeddings.PostDocument) {
+				successfulBWrites = append(successfulBWrites, doc.PostID)
+			}
+		}).
+		Return(nil).Maybe()
+
+	var stateMu sync.Mutex
+	currentSearch := embeddings.EmbeddingSearch(searchA)
+	currentCfg := modelCfg("openai", "model-a", 1536)
+	currentCfg.ReindexWorkers = 1
+	currentCfg.ReindexBatchSize = 1
+	idx := New(
+		func() embeddings.EmbeddingSearch {
+			stateMu.Lock()
+			defer stateMu.Unlock()
+			return currentSearch
+		},
+		func() embeddings.EmbeddingSearchConfig {
+			stateMu.Lock()
+			defer stateMu.Unlock()
+			return currentCfg
+		},
+		mockClient, &bots.MMBots{}, db, mockMutexAPI,
+	)
+	idx.storeRetryAttempts = 1
+
+	_, err = idx.StartReindexJob(true)
+	require.NoError(t, err)
+	failed := waitForJobStatus(t, store, JobStatusFailed, 5*time.Second)
+	require.NotNil(t, failed.ModelInfo)
+	require.Equal(t, "model-a", failed.ModelInfo.ModelName)
+
+	stateMu.Lock()
+	currentSearch = searchB
+	currentCfg = modelCfg("openai", "model-b", 1536)
+	currentCfg.ReindexWorkers = 1
+	currentCfg.ReindexBatchSize = 1
+	stateMu.Unlock()
+
+	_, err = idx.StartReindexJob(false)
+	require.NoError(t, err)
+	completed := waitForJobStatus(t, store, JobStatusCompleted, 5*time.Second)
+	require.NotNil(t, completed.ModelInfo)
+	assert.Equal(t, "model-b", completed.ModelInfo.ModelName)
+	assert.Equal(t, int64(2), completed.ProcessedRows)
+
+	writesMu.Lock()
+	aWrites := append([]string(nil), successfulAWrites...)
+	bWrites := append([]string(nil), successfulBWrites...)
+	writesMu.Unlock()
+	store.mu.Lock()
+	require.NotNil(t, store.model)
+	storedModel := store.model.ModelName
+	store.mu.Unlock()
+
+	assert.Equal(t, []string{"post-a"}, aWrites)
+	assert.Equal(t, []string{"post-a", "post-b"}, bWrites)
+	assert.Equal(t, "model-b", storedModel)
 }
 
 func TestStartCatchUpJob(t *testing.T) {

--- a/webapp/src/components/search_sources.test.tsx
+++ b/webapp/src/components/search_sources.test.tsx
@@ -3,6 +3,10 @@
 
 import {MAX_SEARCH_SOURCES, parseSearchSources} from './search_sources';
 
+jest.mock('./post_preview', () => ({
+    PostPreview: () => null,
+}));
+
 const VALID_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
 function source(index: number) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Adds a release-specific correctness follow-up on top of the AI Enhanced Search backport stack.

This is not a cherry-pick. Review of the combined stack found that [#909](https://github.com/mattermost/mattermost-plugin-agents/pull/909) preserves the original job's model metadata during Resume, while a configuration update can replace the active embedding search implementation. A resumed job could therefore keep model A's cursor and metadata while writing remaining vectors with model B.

The fix compares the failed job's model snapshot with the current embedding configuration. If they differ, Resume is promoted to a fresh full reindex using the current model. Unchanged configurations retain checkpoint-based resume behavior.

Stack:
- Base: [backport #936](https://github.com/mattermost/mattermost-plugin-agents/pull/962)
- Related original PR: [#909](https://github.com/mattermost/mattermost-plugin-agents/pull/909)
- Related backport PR: [#960](https://github.com/mattermost/mattermost-plugin-agents/pull/960)

Backport-specific changes:
- New production guard in `StartReindexJob` rather than a cherry-pick from `master`.
- New regression coverage proves a model change reindexes the entire corpus with model B and stores model B metadata, while unchanged-model resumes continue from their checkpoint.
- Added the missing Jest mock needed to run the #936 search-source parser test independently on the release branch; this is test-only and does not change runtime behavior.
- Retains the `release-2.0` non-`/v2` module path.

#### Ticket Link

Related to Jira https://mattermost.atlassian.net/browse/MM-69713

#### Release Note

```release-note
Fixed resuming an interrupted AI Enhanced Search reindex after changing the embedding model potentially mixing vectors from different models. Resume now restarts a full reindex when the embedding configuration changed.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd207-979a-740b-8627-5cd9fff1151b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd207-979a-740b-8627-5cd9fff1151b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

