### PR TITLE
feat(abac): add durable service and MCP IDs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,11 +70,10 @@ type MCPClientManager interface {
 	GetConfig() mcp.Config
 
 	RegisterPluginServer(cfg mcp.PluginServerConfig)
-	UpdatePluginServer(cfg mcp.PluginServerConfig)
+	UpdatePluginServerAdminFields(pluginID string, enabled bool, toolConfigs []mcp.ToolConfig) (mcp.PluginServerConfig, bool)
 	UnregisterPluginServer(pluginID string)
 	ListPluginServers() []mcp.PluginServerConfig
 	GetPluginServer(pluginID string) (mcp.PluginServerConfig, bool)
-	IsPluginRegistered(pluginID string) bool
 
 	DiscoverPluginServerTools(ctx context.Context, userID string, cfg mcp.PluginServerConfig) ([]mcp.ToolInfo, error)
 }
@@ -83,6 +82,10 @@ type MCPClientManager interface {
 type ConfigStore interface {
 	GetConfig() (*config.Config, error)
 	SaveConfig(cfg config.Config) error
+	// UpdateConfig atomically reads the active config, applies transform, and
+	// persists the result under the config advisory lock. A transform error
+	// aborts the update and is returned as-is.
+	UpdateConfig(transform func(prev *config.Config) (config.Config, error)) (config.Config, error)
 }
 
 // AgentStore provides CRUD access to user-created agents in the database.

--- a/api/api_admin.go
+++ b/api/api_admin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/audit"
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/indexer"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mmapi"
@@ -284,6 +285,8 @@ type MCPServerInfo struct {
 	Enabled    bool   `json:"enabled"`
 	// ToolConfigs is populated for plugin rows only.
 	ToolConfigs []mcp.ToolConfig `json:"toolConfigs,omitempty"`
+	// ID is the stable ABAC policy identity when present.
+	ID string `json:"id,omitempty"`
 }
 
 // MCPToolsResponse represents the response structure for MCP tools endpoint
@@ -362,6 +365,7 @@ func (a *API) buildMCPDiscoveryRows(ctx context.Context, userID string) []mcpDis
 				// Embedded MCP is always available after PR #617, even if older
 				// configs still have the legacy toggle stored as false.
 				Enabled: true,
+				ID:      embeddedConfig.ID,
 			},
 			discover: func() ([]MCPToolInfo, error) {
 				return a.discoverEmbeddedServerTools(ctx, userID, embeddedConfig, embeddedServer)
@@ -389,6 +393,7 @@ func (a *API) buildMCPDiscoveryRows(ctx context.Context, userID string) []mcpDis
 				Tools:      []MCPToolInfo{},
 				ServerType: "remote",
 				Enabled:    serverConfig.Enabled,
+				ID:         serverConfig.ID,
 			},
 		}
 		if message, conflicting := conflictMessages[i]; conflicting {
@@ -402,12 +407,10 @@ func (a *API) buildMCPDiscoveryRows(ctx context.Context, userID string) []mcpDis
 	}
 
 	// Render disabled plugin entries (with an empty tool list) so the admin UI
-	// can re-enable them. Skip orphans hydrated from persisted config without
-	// a live source-plugin registration; surfacing them as "session not found"
-	// rows is misleading, and their persisted policy is preserved on disk
-	// regardless of whether they appear here.
+	// can re-enable them. Skip config-only orphans without a live source-plugin
+	// registration; their persisted identity and policy remain on disk.
 	for _, cfg := range a.mcpClientManager.ListPluginServers() {
-		if !a.mcpClientManager.IsPluginRegistered(cfg.PluginID) {
+		if !isPluginMCPServerRegistered(a.mcpClientManager, cfg.PluginID) {
 			continue
 		}
 
@@ -419,6 +422,7 @@ func (a *API) buildMCPDiscoveryRows(ctx context.Context, userID string) []mcpDis
 				ServerType:  "plugin",
 				Enabled:     cfg.Enabled,
 				ToolConfigs: cfg.ToolConfigs,
+				ID:          cfg.ID,
 			},
 		}
 		if cfg.Enabled {
@@ -430,6 +434,21 @@ func (a *API) buildMCPDiscoveryRows(ctx context.Context, userID string) []mcpDis
 	}
 
 	return rows
+}
+
+func isPluginMCPServerRegistered(manager MCPClientManager, pluginID string) bool {
+	registry, ok := manager.(interface {
+		IsPluginRegistered(string) bool
+	})
+	if ok {
+		return registry.IsPluginRegistered(pluginID)
+	}
+	for _, cfg := range manager.ListPluginServers() {
+		if cfg.PluginID == pluginID {
+			return true
+		}
+	}
+	return false
 }
 
 func applyMCPDiscoveryResult(info *MCPServerInfo, tools []MCPToolInfo, err error) {
@@ -556,7 +575,7 @@ func (a *API) handleUpdatePluginServer(c *gin.Context) {
 	audit.AddParam(auditRec(c), "tool_configs_changed", req.ToolConfigs != nil)
 
 	live, foundLive := a.mcpClientManager.GetPluginServer(pluginID)
-	if !foundLive {
+	if !foundLive || !isPluginMCPServerRegistered(a.mcpClientManager, pluginID) {
 		c.AbortWithError(http.StatusNotFound, fmt.Errorf("plugin MCP server %q is not registered", pluginID))
 		return
 	}
@@ -569,40 +588,57 @@ func (a *API) handleUpdatePluginServer(c *gin.Context) {
 		updated.ToolConfigs = *req.ToolConfigs
 	}
 
-	// Effective final value after partial-update merge, not the raw request.
+	// Best-effort fallback; overwritten below when persisted state is available.
 	audit.AddParam(auditRec(c), "enabled", updated.Enabled)
 
-	existing, getErr := a.configStore.GetConfig()
-	if getErr != nil {
-		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to load config for plugin-server save: %w", getErr))
-		return
-	}
-	if existing == nil {
-		c.AbortWithError(http.StatusInternalServerError, errors.New("no plugin configuration available"))
-		return
-	}
-	// Clone to avoid mutating the store's cached pointer.
-	cfg := existing.Clone()
-
-	// Merge by PluginID against the persisted list rather than overwriting
-	// with the in-memory snapshot, which would silently drop entries for
-	// plugins that are persisted but currently inactive in memory.
-	merged := append([]mcp.PluginServerConfig(nil), cfg.MCP.PluginServers...)
-	mergedIdx := -1
-	for i := range merged {
-		if merged[i].PluginID == updated.PluginID {
-			mergedIdx = i
-			break
+	// Apply the request to the freshest persisted entry inside the UpdateConfig
+	// transform; rebasing onto the live snapshot read above would let two
+	// concurrent field updates overwrite each other.
+	saved, err := a.configStore.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		if prev == nil {
+			// Replacing a nil persisted config with a zero-value baseline
+			// would clobber unrelated settings on the next save.
+			return config.Config{}, errors.New("no plugin configuration available")
 		}
-	}
-	if mergedIdx >= 0 {
-		merged[mergedIdx] = updated
-	} else {
-		merged = append(merged, updated)
-	}
-	cfg.MCP.PluginServers = merged
+		// Clone to avoid mutating the store's cached pointer.
+		cfg := prev.Clone()
 
-	if err := a.configStore.SaveConfig(*cfg); err != nil {
+		// Merge by PluginID against the persisted list rather than overwriting
+		// with the in-memory snapshot, which would silently drop entries for
+		// plugins that are persisted but currently inactive in memory.
+		merged := append([]mcp.PluginServerConfig(nil), cfg.MCP.PluginServers...)
+		mergedIdx := -1
+		for i := range merged {
+			if merged[i].PluginID == pluginID {
+				mergedIdx = i
+				break
+			}
+		}
+
+		// Live entry owns Name/Path/ExposeExternal; persisted admin fields
+		// (Enabled, ToolConfigs, ID) overlay via the shared merge helper.
+		base := live
+		if mergedIdx >= 0 {
+			base = mcp.ApplyPersistedPluginServerFields(base, merged[mergedIdx])
+		}
+		if req.Enabled != nil {
+			base.Enabled = *req.Enabled
+		}
+		if req.ToolConfigs != nil {
+			base.ToolConfigs = *req.ToolConfigs
+		}
+		updated = base
+		audit.AddParam(auditRec(c), "enabled", updated.Enabled)
+
+		if mergedIdx >= 0 {
+			merged[mergedIdx] = base
+		} else {
+			merged = append(merged, base)
+		}
+		cfg.MCP.PluginServers = merged
+		return *cfg, nil
+	})
+	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to save plugin-server config: %w", err))
 		return
 	}
@@ -616,8 +652,13 @@ func (a *API) handleUpdatePluginServer(c *gin.Context) {
 		return
 	}
 
-	a.mcpClientManager.UpdatePluginServer(updated)
-	a.configUpdater.Update(cfg)
+	// Patch admin fields rather than replace the whole object, so plugin-owned
+	// fields survive a concurrent re-registration. A missing entry means the
+	// plugin unregistered; it is hydrated again on its next registration.
+	if patched, ok := a.mcpClientManager.UpdatePluginServerAdminFields(pluginID, updated.Enabled, updated.ToolConfigs); ok {
+		updated = patched
+	}
+	a.configUpdater.Update(&saved)
 
 	// Rebuild when either old or new state was external so removed tools
 	// disappear from the aggregate server.

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -571,6 +572,92 @@ func TestHandleGetMCPTools_OmitsOrphanPluginServers(t *testing.T) {
 		"orphan plugin must not be probed; probing would surface a misleading session-not-found error")
 }
 
+type stubAdminEmbeddedServer struct{}
+
+func (s *stubAdminEmbeddedServer) CreateClientTransport(string, string, *pluginapi.Client) (*gomcp.InMemoryTransport, error) {
+	return nil, errors.New("stub: discovery not needed for ID assertions")
+}
+
+func TestHandleGetMCPTools_ReturnsStableIDs(t *testing.T) {
+	api, mockAPI, _ := setupAdminTestEnvironment(t)
+	defer mockAPI.AssertExpectations(t)
+
+	mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return().Maybe()
+	mockAPI.On("LogDebug", mock.Anything).Return().Maybe()
+
+	const (
+		embeddedID = "abcdefghijklmnopqrstuvwx01"
+		remoteID   = "abcdefghijklmnopqrstuvwx02"
+		pluginID   = "abcdefghijklmnopqrstuvwx03"
+	)
+
+	cfg := api.config.(*testConfigImpl)
+	cfg.mcpConfig = mcp.Config{
+		Enabled: true,
+		EmbeddedServer: mcp.EmbeddedServerConfig{
+			ID:      embeddedID,
+			Enabled: true,
+		},
+		Servers: []mcp.ServerConfig{{
+			ID:      remoteID,
+			Name:    "Remote",
+			Enabled: true,
+			BaseURL: "https://mcp.example.com",
+		}},
+		PluginServers: []mcp.PluginServerConfig{{
+			ID:       pluginID,
+			PluginID: "com.mattermost.demo",
+			Name:     "Demo",
+			Path:     "/mcp",
+			Enabled:  true,
+		}},
+	}
+
+	mgr := api.mcpClientManager.(*mockMCPClientManager)
+	mgr.embeddedServer = &stubAdminEmbeddedServer{}
+	// Non-nil client so remote discovery fails cleanly instead of panicking.
+	mgr.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("stub: discovery not needed for ID assertions")
+	})}
+	// Live registry carries the effective ID after config sync.
+	mgr.pluginServers = []mcp.PluginServerConfig{{
+		ID:       pluginID,
+		PluginID: "com.mattermost.demo",
+		Name:     "Demo",
+		Path:     "/mcp",
+		Enabled:  true,
+	}}
+	mgr.discoverPluginToolsResponse = []mcp.ToolInfo{{Name: "echo"}}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/mcp/tools", nil)
+	req.Header.Set("Mattermost-User-Id", "admin-user")
+
+	recorder := httptest.NewRecorder()
+	api.ServeHTTP(&plugin.Context{}, recorder, req)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body MCPToolsResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	byType := map[string]MCPServerInfo{}
+	for _, s := range body.Servers {
+		byType[s.ServerType] = s
+	}
+
+	require.Equal(t, embeddedID, byType["embedded"].ID)
+	require.Equal(t, remoteID, byType["remote"].ID)
+	require.Equal(t, pluginID, byType["plugin"].ID)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func TestHandleUpdatePluginServer(t *testing.T) {
 	tests := []struct {
 		name                   string
@@ -579,7 +666,7 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 		body                   string
 		hasAdminPerm           bool
 		expectStatus           int
-		expectRegistryCalls    int
+		expectPatchCalls       int
 		expectEnabledAfter     bool
 		expectExposeAfter      bool
 		expectToolConfigsAfter []mcp.ToolConfig
@@ -592,13 +679,13 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
-			body:                `{"enabled": false}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  false,
-			expectExposeAfter:   false,
-			expectRebuildCalls:  0,
+			body:               `{"enabled": false}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: false,
+			expectExposeAfter:  false,
+			expectRebuildCalls: 0,
 		},
 		{
 			name:     "enabled update preserves existing ExposeExternal",
@@ -607,13 +694,13 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp",
 				Enabled: true, ExposeExternal: true,
 			}},
-			body:                `{"enabled": false}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  false,
-			expectExposeAfter:   true,
-			expectRebuildCalls:  1,
+			body:               `{"enabled": false}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: false,
+			expectExposeAfter:  true,
+			expectRebuildCalls: 1,
 		},
 		{
 			name:     "expose_external field is ignored",
@@ -622,13 +709,13 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp",
 				Enabled: true, ExposeExternal: false,
 			}},
-			body:                `{"expose_external": true}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  true,
-			expectExposeAfter:   false,
-			expectRebuildCalls:  0,
+			body:               `{"expose_external": true}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: true,
+			expectExposeAfter:  false,
+			expectRebuildCalls: 0,
 		},
 		{
 			name:     "empty body preserves both fields",
@@ -637,13 +724,13 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp",
 				Enabled: true, ExposeExternal: true,
 			}},
-			body:                `{}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  true,
-			expectExposeAfter:   true,
-			expectRebuildCalls:  1,
+			body:               `{}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: true,
+			expectExposeAfter:  true,
+			expectRebuildCalls: 1,
 		},
 		{
 			name:     "admin update keeps config-only orphan unregistered",
@@ -651,12 +738,12 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
-			orphanPluginIDs:     map[string]bool{"com.mattermost.demo": true},
-			body:                `{"enabled": false}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  false,
+			orphanPluginIDs:    map[string]bool{"com.mattermost.demo": true},
+			body:               `{"enabled": false}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: false,
 		},
 		{
 			name:         "404 when pluginID not registered",
@@ -681,10 +768,10 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
-			body:                `{"enabled": false}`,
-			hasAdminPerm:        false,
-			expectStatus:        http.StatusForbidden,
-			expectRegistryCalls: 0,
+			body:             `{"enabled": false}`,
+			hasAdminPerm:     false,
+			expectStatus:     http.StatusForbidden,
+			expectPatchCalls: 0,
 		},
 		{
 			name:     "tool_configs partial PUT sets policy, preserves enabled",
@@ -693,12 +780,12 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp",
 				Enabled: true, ExposeExternal: false,
 			}},
-			body:                `{"tool_configs": [{"name": "echo", "policy": "ask", "enabled": false}]}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  true,
-			expectExposeAfter:   false,
+			body:               `{"tool_configs": [{"name": "echo", "policy": "ask", "enabled": false}]}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: true,
+			expectExposeAfter:  false,
 			expectToolConfigsAfter: []mcp.ToolConfig{
 				{Name: "echo", Policy: "ask", Enabled: false},
 			},
@@ -716,7 +803,7 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			body:                   `{"tool_configs": []}`,
 			hasAdminPerm:           true,
 			expectStatus:           http.StatusOK,
-			expectRegistryCalls:    1,
+			expectPatchCalls:       1,
 			expectEnabledAfter:     true,
 			expectExposeAfter:      false,
 			expectToolConfigsAfter: []mcp.ToolConfig{},
@@ -732,12 +819,12 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 					{Name: "echo", Policy: "auto_run_in_dm", Enabled: true},
 				},
 			}},
-			body:                `{"enabled": false}`,
-			hasAdminPerm:        true,
-			expectStatus:        http.StatusOK,
-			expectRegistryCalls: 1,
-			expectEnabledAfter:  false,
-			expectExposeAfter:   false,
+			body:               `{"enabled": false}`,
+			hasAdminPerm:       true,
+			expectStatus:       http.StatusOK,
+			expectPatchCalls:   1,
+			expectEnabledAfter: false,
+			expectExposeAfter:  false,
 			expectToolConfigsAfter: []mcp.ToolConfig{
 				{Name: "echo", Policy: "auto_run_in_dm", Enabled: true},
 			},
@@ -775,18 +862,18 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			require.Equal(t, tt.expectStatus, resp.StatusCode)
 
 			require.Empty(t, mgr.registerCalls)
-			require.Len(t, mgr.updateCalls, tt.expectRegistryCalls)
+			require.Len(t, mgr.adminPatchCalls, tt.expectPatchCalls)
 			if tt.expectStatus == http.StatusOK {
-				require.Equal(t, tt.expectEnabledAfter, mgr.updateCalls[0].Enabled)
-				require.Equal(t, tt.expectExposeAfter, mgr.updateCalls[0].ExposeExternal)
-				require.Equal(t, "Demo", mgr.updateCalls[0].Name)
-				require.Equal(t, "/mcp", mgr.updateCalls[0].Path)
-				require.Equal(t, "com.mattermost.demo", mgr.updateCalls[0].PluginID)
+				require.Equal(t, tt.expectEnabledAfter, mgr.adminPatchCalls[0].Enabled)
+				require.Equal(t, tt.expectExposeAfter, mgr.adminPatchCalls[0].ExposeExternal)
+				require.Equal(t, "Demo", mgr.adminPatchCalls[0].Name)
+				require.Equal(t, "/mcp", mgr.adminPatchCalls[0].Path)
+				require.Equal(t, "com.mattermost.demo", mgr.adminPatchCalls[0].PluginID)
 				if tt.expectToolConfigsAfter != nil {
-					require.Equal(t, tt.expectToolConfigsAfter, mgr.updateCalls[0].ToolConfigs, "ToolConfigs assertion")
+					require.Equal(t, tt.expectToolConfigsAfter, mgr.adminPatchCalls[0].ToolConfigs, "ToolConfigs assertion")
 				}
 				if tt.orphanPluginIDs[tt.pluginID] {
-					require.False(t, mgr.IsPluginRegistered(tt.pluginID))
+					require.True(t, mgr.orphanPluginIDs[tt.pluginID], "admin update must not mark a config-only orphan as registered")
 				}
 			}
 			require.Equal(t, tt.expectRebuildCalls, spy.callCount)
@@ -808,7 +895,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 		expectSaveCalls       int
 		expectUpdateCalls     int
 		expectPublishCalls    int
-		expectRegistryCalls   int
+		expectPatchCalls      int
 		expectUnregisterCalls int
 		assertPersistedState  func(t *testing.T, savedCfg *config.Config)
 	}{
@@ -825,7 +912,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       1,
 			expectUpdateCalls:     1,
 			expectPublishCalls:    1,
-			expectRegistryCalls:   1,
+			expectPatchCalls:      1,
 			expectUnregisterCalls: 0,
 			assertPersistedState: func(t *testing.T, savedCfg *config.Config) {
 				require.Len(t, savedCfg.MCP.PluginServers, 1)
@@ -870,7 +957,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       1,
 			expectUpdateCalls:     1,
 			expectPublishCalls:    1,
-			expectRegistryCalls:   1,
+			expectPatchCalls:      1,
 			expectUnregisterCalls: 0,
 			assertPersistedState: func(t *testing.T, savedCfg *config.Config) {
 				require.Len(t, savedCfg.MCP.PluginServers, 2,
@@ -906,7 +993,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       0,
 			expectUpdateCalls:     0,
 			expectPublishCalls:    0,
-			expectRegistryCalls:   0,
+			expectPatchCalls:      0,
 			expectUnregisterCalls: 0,
 		},
 		{
@@ -920,7 +1007,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       1,
 			expectUpdateCalls:     0,
 			expectPublishCalls:    0,
-			expectRegistryCalls:   0,
+			expectPatchCalls:      0,
 			expectUnregisterCalls: 0,
 		},
 		{
@@ -934,7 +1021,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       1,
 			expectUpdateCalls:     0,
 			expectPublishCalls:    1,
-			expectRegistryCalls:   0,
+			expectPatchCalls:      0,
 			expectUnregisterCalls: 0,
 		},
 		{
@@ -951,7 +1038,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectSaveCalls:       0,
 			expectUpdateCalls:     0,
 			expectPublishCalls:    0,
-			expectRegistryCalls:   0,
+			expectPatchCalls:      0,
 			expectUnregisterCalls: 0,
 		},
 	}
@@ -1006,7 +1093,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			require.Equal(t, tt.expectPublishCalls, stores.clusterNotifier.callCount)
 
 			require.Empty(t, mgr.registerCalls)
-			require.Len(t, mgr.updateCalls, tt.expectRegistryCalls, "live plugin registry must not be mutated on failure paths")
+			require.Len(t, mgr.adminPatchCalls, tt.expectPatchCalls, "live plugin registry must not be mutated on failure paths")
 			require.Len(t, mgr.unregisterCalls, tt.expectUnregisterCalls, "live plugin registry must not be mutated on failure paths")
 
 			if tt.assertPersistedState != nil {
@@ -1015,6 +1102,106 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Lost-update regression: two updates to different fields that both read the
+// same live state must both survive in the persisted config (the merge must
+// rebase onto the freshest persisted entry inside the UpdateConfig transform).
+func TestHandleUpdatePluginServer_ConcurrentFieldUpdatesBothSurvive(t *testing.T) {
+	api, mockAPI, stores := setupAdminTestEnvironment(t)
+	defer mockAPI.AssertExpectations(t)
+
+	mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return().Maybe()
+
+	// Fresh copies each time: the mock's RegisterPluginServer mutates the
+	// slice in place, and the reset below must restore the pristine state.
+	liveSnapshot := func() []mcp.PluginServerConfig {
+		return []mcp.PluginServerConfig{{
+			PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
+		}}
+	}
+	mgr := api.mcpClientManager.(*mockMCPClientManager)
+	mgr.pluginServers = liveSnapshot()
+	stores.configStore.cfg = &config.Config{}
+
+	put := func(body string) int {
+		req := httptest.NewRequest(http.MethodPut, "/admin/mcp/plugin-servers/com.mattermost.demo", strings.NewReader(body))
+		req.Header.Set("Mattermost-User-Id", "admin-user")
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		api.ServeHTTP(&plugin.Context{}, recorder, req)
+		return recorder.Result().StatusCode
+	}
+
+	require.Equal(t, http.StatusOK, put(`{"enabled": false}`))
+
+	// Pin the exact racing interleaving: the second request read the live
+	// registry before the first request's admin-field patch landed, so it
+	// sees the original Enabled:true snapshot.
+	mgr.pluginServers = liveSnapshot()
+
+	require.Equal(t, http.StatusOK, put(`{"tool_configs": [{"name": "echo", "policy": "ask", "enabled": false}]}`))
+
+	require.Len(t, stores.configStore.cfg.MCP.PluginServers, 1)
+	persisted := stores.configStore.cfg.MCP.PluginServers[0]
+	require.False(t, persisted.Enabled, "first update's Enabled=false must survive the second update")
+	require.Len(t, persisted.ToolConfigs, 1, "second update's tool_configs must be applied")
+	require.Equal(t, "echo", persisted.ToolConfigs[0].Name)
+}
+
+// Pins field ownership: the source plugin owns Name/Path/ExposeExternal and
+// admins own Enabled/ToolConfigs. An admin update whose persisted entry
+// predates a plugin re-registration must not resurrect stale plugin-owned
+// values in the persisted config, the runtime registry, or the response.
+func TestHandleUpdatePluginServer_PluginOwnedFieldsNotReverted(t *testing.T) {
+	api, mockAPI, stores := setupAdminTestEnvironment(t)
+	defer mockAPI.AssertExpectations(t)
+
+	mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return().Maybe()
+
+	// The plugin re-registered with new plugin-owned values after the entry
+	// below was persisted.
+	mgr := api.mcpClientManager.(*mockMCPClientManager)
+	mgr.pluginServers = []mcp.PluginServerConfig{{
+		PluginID: "com.mattermost.demo", Name: "Demo v2", Path: "/mcp/v2",
+		Enabled: true, ExposeExternal: true,
+	}}
+	stores.configStore.cfg = &config.Config{}
+	stores.configStore.cfg.MCP.PluginServers = []config.PluginServerConfig{{
+		PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp",
+		Enabled: false, ExposeExternal: false,
+		ToolConfigs: []config.MCPToolConfig{{Name: "echo", Policy: config.MCPToolPolicyAsk, Enabled: false}},
+	}}
+
+	spy := &spyRebuilder{}
+	api.SetExternalRebuilderForTest(spy)
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/mcp/plugin-servers/com.mattermost.demo", strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Mattermost-User-Id", "admin-user")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	api.ServeHTTP(&plugin.Context{}, recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+
+	require.Len(t, stores.configStore.cfg.MCP.PluginServers, 1)
+	persisted := stores.configStore.cfg.MCP.PluginServers[0]
+	require.Equal(t, "Demo v2", persisted.Name, "persisted Name must come from the live registration")
+	require.Equal(t, "/mcp/v2", persisted.Path, "persisted Path must come from the live registration")
+	require.True(t, persisted.ExposeExternal, "persisted ExposeExternal must come from the live registration")
+	require.True(t, persisted.Enabled, "request patch must apply")
+	require.Equal(t, []config.MCPToolConfig{{Name: "echo", Policy: config.MCPToolPolicyAsk, Enabled: false}},
+		persisted.ToolConfigs, "persisted admin-owned ToolConfigs must carry over")
+
+	require.Len(t, mgr.adminPatchCalls, 1, "runtime registration must be an admin-field patch")
+	require.Empty(t, mgr.registerCalls, "runtime registration must not be a whole-object replacement")
+	patched := mgr.adminPatchCalls[0]
+	require.Equal(t, "Demo v2", patched.Name)
+	require.Equal(t, "/mcp/v2", patched.Path)
+	require.True(t, patched.ExposeExternal)
+	require.True(t, patched.Enabled)
+	require.Equal(t, []mcp.ToolConfig{{Name: "echo", Policy: config.MCPToolPolicyAsk, Enabled: false}}, patched.ToolConfigs)
 }
 
 // failingConfigStore is a testConfigStore variant with configurable error injection on Get/Save.
@@ -1037,6 +1224,20 @@ func (s *failingConfigStore) SaveConfig(cfg config.Config) error {
 	clone := cfg
 	s.cfg = &clone
 	return nil
+}
+
+func (s *failingConfigStore) UpdateConfig(transform func(prev *config.Config) (config.Config, error)) (config.Config, error) {
+	if s.getErr != nil {
+		return config.Config{}, s.getErr
+	}
+	next, err := transform(s.cfg)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if err := s.SaveConfig(next); err != nil {
+		return next, err
+	}
+	return next, nil
 }
 
 // setupAdminAuditTest wires the full-router environment with audit capture so

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -672,6 +672,7 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 		expectToolConfigsAfter []mcp.ToolConfig
 		expectRebuildCalls     int
 		orphanPluginIDs        map[string]bool
+		expectStateUnchanged   bool
 	}{
 		{
 			name:     "happy path: flips Enabled true->false",
@@ -733,17 +734,18 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			expectRebuildCalls: 1,
 		},
 		{
-			name:     "admin update keeps config-only orphan unregistered",
+			name:     "admin update rejects config-only orphan",
 			pluginID: "com.mattermost.demo",
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
-			orphanPluginIDs:    map[string]bool{"com.mattermost.demo": true},
-			body:               `{"enabled": false}`,
-			hasAdminPerm:       true,
-			expectStatus:       http.StatusOK,
-			expectPatchCalls:   1,
-			expectEnabledAfter: false,
+			orphanPluginIDs:      map[string]bool{"com.mattermost.demo": true},
+			body:                 `{"enabled": false}`,
+			hasAdminPerm:         true,
+			expectStatus:         http.StatusNotFound,
+			expectPatchCalls:     0,
+			expectRebuildCalls:   0,
+			expectStateUnchanged: true,
 		},
 		{
 			name:         "404 when pluginID not registered",
@@ -843,6 +845,11 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 			mgr := api.mcpClientManager.(*mockMCPClientManager)
 			mgr.pluginServers = tt.preRegistered
 			mgr.orphanPluginIDs = tt.orphanPluginIDs
+			pluginServersBefore := append([]mcp.PluginServerConfig(nil), mgr.pluginServers...)
+			orphanPluginIDsBefore := make(map[string]bool, len(mgr.orphanPluginIDs))
+			for pluginID, orphaned := range mgr.orphanPluginIDs {
+				orphanPluginIDsBefore[pluginID] = orphaned
+			}
 
 			// Seed a baseline persisted config so the handler can clone it
 			// instead of treating the store's nil as a 500.
@@ -872,11 +879,16 @@ func TestHandleUpdatePluginServer(t *testing.T) {
 				if tt.expectToolConfigsAfter != nil {
 					require.Equal(t, tt.expectToolConfigsAfter, mgr.adminPatchCalls[0].ToolConfigs, "ToolConfigs assertion")
 				}
-				if tt.orphanPluginIDs[tt.pluginID] {
-					require.True(t, mgr.orphanPluginIDs[tt.pluginID], "admin update must not mark a config-only orphan as registered")
-				}
 			}
 			require.Equal(t, tt.expectRebuildCalls, spy.callCount)
+			if tt.expectStateUnchanged {
+				require.Equal(t, pluginServersBefore, mgr.pluginServers)
+				require.Equal(t, orphanPluginIDsBefore, mgr.orphanPluginIDs)
+				require.Empty(t, mgr.unregisterCalls)
+				require.Equal(t, &config.Config{}, stores.configStore.cfg)
+				require.Zero(t, stores.configUpdater.callCount)
+				require.Zero(t, stores.clusterNotifier.callCount)
+			}
 		})
 	}
 }

--- a/api/api_agents_test.go
+++ b/api/api_agents_test.go
@@ -66,6 +66,21 @@ func (m *mockConfigStore) SaveConfig(cfg config.Config) error {
 	return nil
 }
 
+func (m *mockConfigStore) UpdateConfig(transform func(prev *config.Config) (config.Config, error)) (config.Config, error) {
+	var prev *config.Config
+	if m.cfg != nil {
+		prev = m.cfg
+	}
+	next, err := transform(prev)
+	if err != nil {
+		return next, err
+	}
+	if err := m.SaveConfig(next); err != nil {
+		return next, err
+	}
+	return next, nil
+}
+
 // overrideLicenseMocks replaces any GetConfig/GetLicense expectations already
 // registered (e.g. by SetupTestEnvironment). Testify matches the first
 // registered expectation, so simply adding new ones would not take effect.

--- a/api/api_bridge_mcp.go
+++ b/api/api_bridge_mcp.go
@@ -186,13 +186,15 @@ func (a *API) persistPluginServerID(pluginID string, registration *mcp.PluginSer
 			break
 		}
 	}
-	if a.clusterNotifier != nil {
-		if notifyErr := a.clusterNotifier.PublishConfigUpdate(); notifyErr != nil {
-			return fmt.Errorf("failed to notify cluster of plugin-server ID: %w", notifyErr)
-		}
-	}
 	if a.configUpdater != nil {
 		a.configUpdater.Update(&saved)
+	}
+	// Propagation is best-effort; the ID is already persisted, so a failed
+	// notification must not abort this registration.
+	if a.clusterNotifier != nil {
+		if notifyErr := a.clusterNotifier.PublishConfigUpdate(); notifyErr != nil {
+			a.pluginAPI.Log.Warn("Failed to notify cluster of plugin-server ID", "error", notifyErr)
+		}
 	}
 	return nil
 }

--- a/api/api_bridge_mcp.go
+++ b/api/api_bridge_mcp.go
@@ -4,13 +4,16 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/audit"
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
 	"github.com/mattermost/mattermost-plugin-agents/v2/public/bridgeclient"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // externalServerRebuilder rebuilds the external MCP aggregate after plugin changes.
@@ -98,15 +101,29 @@ func (a *API) handleMCPRegister(c *gin.Context) {
 	// Snapshot effective external exposure so we rebuild when it turns on or off.
 	prevEffectiveExternal := a.pluginServerExternallyExposed(trustedPluginID)
 
-	// Preserve Enabled and ToolConfigs across re-registration, even after unregister.
-	// A first-time registration with no explicit enabled flag defaults to enabled.
-	persisted, hasPersisted := a.findPersistedPluginServer(trustedPluginID)
+	// Overlay admin-owned fields (Enabled, ToolConfigs, ID). Live entry first,
+	// then persisted config — so a re-register after unregister recovers from
+	// config, while a live-only ID is not rotated when the config row is absent.
 	if existing, found := a.mcpClientManager.GetPluginServer(trustedPluginID); found {
-		cfg.Enabled = existing.Enabled
-		cfg.ToolConfigs = existing.ToolConfigs
-	} else if hasPersisted {
-		cfg.Enabled = persisted.Enabled
-		cfg.ToolConfigs = persisted.ToolConfigs
+		cfg = mcp.ApplyPersistedPluginServerFields(cfg, existing)
+	}
+	persisted, hasPersisted := a.findPersistedPluginServer(trustedPluginID)
+	if hasPersisted {
+		cfg = mcp.ApplyPersistedPluginServerFields(cfg, persisted)
+	}
+
+	// Mint only when neither live nor persisted carried an ID. Persist when the
+	// config row is missing or ID-less so a live-only identity is written.
+	if cfg.ID == "" {
+		cfg.ID = model.NewId()
+	}
+	if !hasPersisted || persisted.ID == "" {
+		if err := a.persistPluginServerID(trustedPluginID, &cfg); err != nil {
+			c.JSON(http.StatusInternalServerError, bridgeclient.ErrorResponse{
+				Error: fmt.Sprintf("failed to persist plugin server ID: %v", err),
+			})
+			return
+		}
 	}
 
 	// Effective final value after the preserve-on-reregister merge, not the
@@ -123,6 +140,61 @@ func (a *API) handleMCPRegister(c *gin.Context) {
 	}
 
 	c.Status(http.StatusOK)
+}
+
+// persistPluginServerID ensures cfg.MCP.PluginServers holds a stable ID for
+// pluginID. Only mints when the entry is missing or ID-less; concurrent
+// writers that already assigned an ID win (their ID is adopted onto
+// registration).
+func (a *API) persistPluginServerID(pluginID string, registration *mcp.PluginServerConfig) error {
+	if a.configStore == nil || registration == nil {
+		return nil
+	}
+	saved, err := a.configStore.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		if prev == nil {
+			return config.Config{}, errors.New("no plugin configuration available")
+		}
+		cfg := prev.Clone()
+		for i := range cfg.MCP.PluginServers {
+			if cfg.MCP.PluginServers[i].PluginID != pluginID {
+				continue
+			}
+			if cfg.MCP.PluginServers[i].ID == "" {
+				cfg.MCP.PluginServers[i].ID = uniquePluginServerID(cfg.MCP, registration.ID)
+			}
+			return *cfg, nil
+		}
+		id := uniquePluginServerID(cfg.MCP, registration.ID)
+		cfg.MCP.PluginServers = append(cfg.MCP.PluginServers, config.PluginServerConfig{
+			ID:             id,
+			PluginID:       registration.PluginID,
+			Name:           registration.Name,
+			Path:           registration.Path,
+			Enabled:        registration.Enabled,
+			ExposeExternal: registration.ExposeExternal,
+			ToolConfigs:    registration.ToolConfigs,
+		})
+		return *cfg, nil
+	})
+	if err != nil {
+		return err
+	}
+	// Adopt the persisted ID in case another writer raced and minted first.
+	for i := range saved.MCP.PluginServers {
+		if saved.MCP.PluginServers[i].PluginID == pluginID && saved.MCP.PluginServers[i].ID != "" {
+			registration.ID = saved.MCP.PluginServers[i].ID
+			break
+		}
+	}
+	if a.clusterNotifier != nil {
+		if notifyErr := a.clusterNotifier.PublishConfigUpdate(); notifyErr != nil {
+			return fmt.Errorf("failed to notify cluster of plugin-server ID: %w", notifyErr)
+		}
+	}
+	if a.configUpdater != nil {
+		a.configUpdater.Update(&saved)
+	}
+	return nil
 }
 
 // pluginServerExternallyExposed reports whether the plugin should appear on the
@@ -161,6 +233,22 @@ func (a *API) handleMCPUnregister(c *gin.Context) {
 	}
 
 	c.Status(http.StatusOK)
+}
+
+// uniquePluginServerID keeps candidate when free across all MCP kinds; otherwise mints.
+func uniquePluginServerID(mcpCfg config.MCPConfig, candidate string) string {
+	occupied := config.OccupiedMCPServerIDs(mcpCfg)
+	if candidate != "" {
+		if _, taken := occupied[candidate]; !taken {
+			return candidate
+		}
+	}
+	for {
+		id := model.NewId()
+		if _, taken := occupied[id]; !taken {
+			return id
+		}
+	}
 }
 
 func (a *API) findPersistedPluginServer(pluginID string) (mcp.PluginServerConfig, bool) {

--- a/api/api_bridge_mcp.go
+++ b/api/api_bridge_mcp.go
@@ -155,16 +155,19 @@ func (a *API) persistPluginServerID(pluginID string, registration *mcp.PluginSer
 			return config.Config{}, errors.New("no plugin configuration available")
 		}
 		cfg := prev.Clone()
+		id := registration.ID
+		if id == "" {
+			id = model.NewId()
+		}
 		for i := range cfg.MCP.PluginServers {
 			if cfg.MCP.PluginServers[i].PluginID != pluginID {
 				continue
 			}
 			if cfg.MCP.PluginServers[i].ID == "" {
-				cfg.MCP.PluginServers[i].ID = uniquePluginServerID(cfg.MCP, registration.ID)
+				cfg.MCP.PluginServers[i].ID = id
 			}
 			return *cfg, nil
 		}
-		id := uniquePluginServerID(cfg.MCP, registration.ID)
 		cfg.MCP.PluginServers = append(cfg.MCP.PluginServers, config.PluginServerConfig{
 			ID:             id,
 			PluginID:       registration.PluginID,
@@ -235,22 +238,6 @@ func (a *API) handleMCPUnregister(c *gin.Context) {
 	}
 
 	c.Status(http.StatusOK)
-}
-
-// uniquePluginServerID keeps candidate when free across all MCP kinds; otherwise mints.
-func uniquePluginServerID(mcpCfg config.MCPConfig, candidate string) string {
-	occupied := config.OccupiedMCPServerIDs(mcpCfg)
-	if candidate != "" {
-		if _, taken := occupied[candidate]; !taken {
-			return candidate
-		}
-	}
-	for {
-		id := model.NewId()
-		if _, taken := occupied[id]; !taken {
-			return id
-		}
-	}
 }
 
 func (a *API) findPersistedPluginServer(pluginID string) (mcp.PluginServerConfig, bool) {

--- a/api/api_bridge_mcp_test.go
+++ b/api/api_bridge_mcp_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -893,6 +894,35 @@ func TestHandleMCPRegister_MintsStableIDAcrossReregister(t *testing.T) {
 	require.Equal(t, firstID, e.mcp.registerCalls[1].ID, "re-register must reuse the persisted ID")
 	require.Equal(t, firstID, store.cfg.MCP.PluginServers[0].ID)
 	require.Len(t, store.cfg.MCP.PluginServers, 1, "re-register must not create a duplicate config entry")
+}
+
+func TestHandleMCPRegister_ClusterNotifyFailureStillRegisters(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	store := &testConfigStore{cfg: &config.Config{}}
+	updater := &testConfigUpdater{}
+	notifier := &testClusterNotifier{err: errors.New("cluster down")}
+	e.api.configStore = store
+	e.api.configUpdater = updater
+	e.api.clusterNotifier = notifier
+
+	body := mcp.PluginServerConfig{
+		PluginID: testCallerPluginID, Name: "Playbooks MCP", Path: "/mcp",
+		Enabled: true, ExposeExternal: false,
+	}
+	req := mcpRegisterRequest(t, body)
+	req.Header.Set("Mattermost-Plugin-ID", testCallerPluginID)
+	resp := serveAndReturn(e, req)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, e.mcp.registerCalls, 1, "registration must complete even when cluster notify fails")
+	require.True(t, model.IsValidId(e.mcp.registerCalls[0].ID))
+	require.Len(t, store.cfg.MCP.PluginServers, 1)
+	require.Equal(t, 1, notifier.callCount)
+	require.Equal(t, 1, updater.callCount, "in-memory config must still be updated")
 }
 
 // Live registry ID must win when the persisted PluginServers row is missing,

--- a/api/api_bridge_mcp_test.go
+++ b/api/api_bridge_mcp_test.go
@@ -102,7 +102,10 @@ func TestHandleMCPRegister(t *testing.T) {
 			wantStatus: http.StatusOK,
 			assertMock: func(t *testing.T, m *mockMCPClientManager) {
 				require.Len(t, m.registerCalls, 1)
-				require.Equal(t, validCfg, m.registerCalls[0])
+				got := m.registerCalls[0]
+				require.True(t, model.IsValidId(got.ID), "register must mint a stable Mattermost ID")
+				got.ID = ""
+				require.Equal(t, validCfg, got)
 				require.Empty(t, m.unregisterCalls)
 			},
 		},
@@ -841,7 +844,99 @@ func TestHandleMCPRegister_PreservesAdminFieldsAfterUnregister(t *testing.T) {
 		saved := e.mcp.registerCalls[0]
 		require.Equal(t, true, saved.Enabled, "nil configStore: plugin payload preserved")
 		require.Equal(t, false, saved.ExposeExternal, "nil configStore: plugin payload preserved")
+		require.True(t, model.IsValidId(saved.ID), "nil configStore: in-memory registration still receives a minted ID")
 	})
+}
+
+func TestHandleMCPRegister_MintsStableIDAcrossReregister(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	store := &testConfigStore{cfg: &config.Config{}}
+	e.api.configStore = store
+	e.api.configUpdater = &testConfigUpdater{}
+	e.api.clusterNotifier = &testClusterNotifier{}
+
+	e.mockAPI.On("LogError", mock.Anything).Maybe()
+	e.mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	body := mcp.PluginServerConfig{
+		PluginID: testCallerPluginID, Name: "Playbooks MCP", Path: "/mcp",
+		Enabled: true, ExposeExternal: false,
+	}
+	req := mcpRegisterRequest(t, body)
+	req.Header.Set("Mattermost-Plugin-ID", testCallerPluginID)
+	resp := serveAndReturn(e, req)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, e.mcp.registerCalls, 1)
+	firstID := e.mcp.registerCalls[0].ID
+	require.True(t, model.IsValidId(firstID))
+	require.Len(t, store.cfg.MCP.PluginServers, 1)
+	require.Equal(t, firstID, store.cfg.MCP.PluginServers[0].ID)
+
+	// Unregister clears the in-memory registry but must leave the persisted ID.
+	unreg := mcpUnregisterRequest(t, struct{}{})
+	unreg.Header.Set("Mattermost-Plugin-ID", testCallerPluginID)
+	require.Equal(t, http.StatusOK, serveAndReturn(e, unreg).StatusCode)
+	require.Equal(t, firstID, store.cfg.MCP.PluginServers[0].ID, "unregister must not remove the persisted ID")
+
+	// Re-register with a different path: ID must be stable.
+	body.Path = "/mcp/v2"
+	req2 := mcpRegisterRequest(t, body)
+	req2.Header.Set("Mattermost-Plugin-ID", testCallerPluginID)
+	resp2 := serveAndReturn(e, req2)
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	require.Len(t, e.mcp.registerCalls, 2)
+	require.Equal(t, firstID, e.mcp.registerCalls[1].ID, "re-register must reuse the persisted ID")
+	require.Equal(t, firstID, store.cfg.MCP.PluginServers[0].ID)
+	require.Len(t, store.cfg.MCP.PluginServers, 1, "re-register must not create a duplicate config entry")
+}
+
+// Live registry ID must win when the persisted PluginServers row is missing,
+// and that ID must be written into config (not rotated).
+func TestHandleMCPRegister_PreservesLiveIDWhenPersistedRowAbsent(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	const liveID = "abcdefghijklmnopqrstuvwx0l"
+	store := &testConfigStore{cfg: &config.Config{}}
+	e.api.configStore = store
+	e.api.configUpdater = &testConfigUpdater{}
+	e.api.clusterNotifier = &testClusterNotifier{}
+
+	e.mcp.pluginServers = []mcp.PluginServerConfig{{
+		ID: liveID, PluginID: testCallerPluginID, Name: "Playbooks MCP", Path: "/mcp",
+		Enabled: true, ExposeExternal: false,
+	}}
+
+	e.mockAPI.On("LogError", mock.Anything).Maybe()
+	e.mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	body := mcp.PluginServerConfig{
+		PluginID: testCallerPluginID, Name: "Playbooks MCP", Path: "/mcp/v2",
+		Enabled: false, ExposeExternal: true,
+	}
+	req := mcpRegisterRequest(t, body)
+	req.Header.Set("Mattermost-Plugin-ID", testCallerPluginID)
+	resp := serveAndReturn(e, req)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, e.mcp.registerCalls, 1)
+
+	saved := e.mcp.registerCalls[0]
+	require.Equal(t, liveID, saved.ID, "live registry ID must not be rotated")
+	require.True(t, saved.Enabled, "Enabled preserved from live entry")
+	require.True(t, saved.ExposeExternal, "ExposeExternal comes from plugin payload")
+	require.Equal(t, "/mcp/v2", saved.Path)
+
+	require.Len(t, store.cfg.MCP.PluginServers, 1)
+	require.Equal(t, liveID, store.cfg.MCP.PluginServers[0].ID, "live ID must be persisted")
+	require.Equal(t, testCallerPluginID, store.cfg.MCP.PluginServers[0].PluginID)
 }
 
 func TestAuditMCPRegister(t *testing.T) {

--- a/api/api_config.go
+++ b/api/api_config.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 func normalizeAdminConfig(cfg config.Config) config.Config {
@@ -21,6 +24,38 @@ func normalizeAdminConfig(cfg config.Config) config.Config {
 	for i := range cfg.Services {
 		if cfg.Services[i].Type == llm.ServiceTypeOpenAI {
 			cfg.Services[i].UseResponsesAPI = true
+		}
+	}
+
+	// Backstop for direct API automation and stale webapp bundles: every
+	// persisted service and MCP server (external, embedded, plugin) must
+	// have a stable ID. Minting avoids IDs already occupied across kinds.
+	for i := range cfg.Services {
+		if cfg.Services[i].ID == "" {
+			cfg.Services[i].ID = model.NewId()
+		}
+	}
+	occupied := config.OccupiedMCPServerIDs(cfg.MCP)
+	mintMCPID := func() string {
+		for {
+			id := model.NewId()
+			if _, taken := occupied[id]; !taken {
+				occupied[id] = struct{}{}
+				return id
+			}
+		}
+	}
+	for i := range cfg.MCP.Servers {
+		if cfg.MCP.Servers[i].ID == "" {
+			cfg.MCP.Servers[i].ID = mintMCPID()
+		}
+	}
+	if cfg.MCP.EmbeddedServer.ID == "" {
+		cfg.MCP.EmbeddedServer.ID = mintMCPID()
+	}
+	for i := range cfg.MCP.PluginServers {
+		if cfg.MCP.PluginServers[i].ID == "" {
+			cfg.MCP.PluginServers[i].ID = mintMCPID()
 		}
 	}
 
@@ -61,6 +96,8 @@ func (a *API) handleGetConfig(c *gin.Context) {
 
 // handleSaveConfig saves a new plugin configuration to the database,
 // updates the in-memory configuration, and notifies other cluster nodes.
+// It responds with the normalized saved config so clients can adopt
+// server-minted service/MCP server IDs without a refetch.
 // PUT /admin/config
 func (a *API) handleSaveConfig(c *gin.Context) {
 	var cfg config.Config
@@ -69,27 +106,53 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 		return
 	}
 
-	cfg = normalizeAdminConfig(cfg)
-
-	// Duplicate MCP server names or endpoints are rejected here rather than at
-	// activation: names key the per-user client map, the shared tools cache,
-	// and stored OAuth grants, so colliding entries silently shadow each other.
+	// Names key per-user clients and OAuth grants, while URLs key the shared
+	// tools cache, so duplicate names or endpoints cannot be persisted.
 	if err := cfg.MCP.Validate(); err != nil {
 		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid MCP configuration: %w", err))
 		return
 	}
 
-	// Audit which top-level config sections change — never their values,
-	// since services/webSearch/mcp carry credentials. Best effort: a failed
-	// read of the prior config must not block the save, so the record then
-	// simply omits changed_keys.
-	if rec := auditRec(c); rec != nil {
-		if prev, err := a.configStore.GetConfig(); err == nil {
-			audit.AddParam(rec, "changed_keys", audit.ChangedJSONKeys(prev, cfg))
+	// Read-previous → reconcile → normalize → save runs atomically under the
+	// config advisory lock. Reconciliation carries stable service and MCP
+	// server IDs forward before normalizeAdminConfig mints fresh ones, so
+	// clients that drop the id field cannot rotate IDs on every save;
+	// identity conflicts abort the save entirely.
+	var changedKeys []string
+	saved, err := a.configStore.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		next := cfg
+		// Reconcile even on the first write (empty previous lists) so
+		// fabricated or duplicate incoming IDs cannot slip in unvalidated.
+		var prevServices []llm.ServiceConfig
+		var prevMCP config.MCPConfig
+		if prev != nil {
+			prevServices = prev.Services
+			prevMCP = prev.MCP
 		}
-	}
-
-	if err := a.configStore.SaveConfig(cfg); err != nil {
+		reconciledServices, reconcileErr := config.ReconcileServiceIDs(next.Services, prevServices)
+		if reconcileErr != nil {
+			return config.Config{}, reconcileErr
+		}
+		next.Services = reconciledServices
+		reconciledMCP, reconcileErr := config.ReconcileMCPConfigIDs(next.MCP, prevMCP)
+		if reconcileErr != nil {
+			return config.Config{}, reconcileErr
+		}
+		next.MCP = reconciledMCP
+		normalized := normalizeAdminConfig(next)
+		changedKeys = audit.ChangedJSONKeys(prev, normalized)
+		return normalized, nil
+	})
+	switch {
+	case errors.Is(err, config.ErrServiceIDConflict), errors.Is(err, config.ErrMCPServerIDConflict):
+		// Minting fresh IDs here would silently detach existing policies.
+		c.AbortWithError(http.StatusConflict, fmt.Errorf("configuration payload conflicts with the stored service or MCP server identities; reload the System Console and retry: %w", err))
+		return
+	case errors.Is(err, store.ErrStaleLegacyServiceIDs):
+		// A pre-upgrade client echoing UUID service IDs would undo the migration.
+		c.AbortWithError(http.StatusConflict, fmt.Errorf("stale configuration payload; reload the System Console and retry: %w", err))
+		return
+	case err != nil:
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to save config: %w", err))
 		return
 	}
@@ -97,10 +160,11 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 	// From here on the config HAS changed in the database. If a later step
 	// fails (cluster notify), the audit record's fail status would otherwise
 	// hide a real mutation — mark it explicitly.
+	audit.AddParam(auditRec(c), "changed_keys", changedKeys)
 	audit.AddParam(auditRec(c), "persisted", true)
 
 	// Update in-memory config on this node
-	a.configUpdater.Update(&cfg)
+	a.configUpdater.Update(&saved)
 
 	// Notify other cluster nodes to reload config from DB
 	if err := a.clusterNotifier.PublishConfigUpdate(); err != nil {
@@ -108,5 +172,5 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusOK, saved)
 }

--- a/api/api_config.go
+++ b/api/api_config.go
@@ -27,38 +27,31 @@ func normalizeAdminConfig(cfg config.Config) config.Config {
 		}
 	}
 
-	// Backstop for direct API automation and stale webapp bundles: every
-	// persisted service and MCP server (external, embedded, plugin) must
-	// have a stable ID. Minting avoids IDs already occupied across kinds.
+	return cfg
+}
+
+// mintEmptyAdminIDs assigns a stable ID to every service and MCP server
+// (external, embedded, plugin) that arrived without one. Empty IDs are
+// creates; this runs on write only so GET cannot invent unpersisted identities.
+func mintEmptyAdminIDs(cfg config.Config) config.Config {
 	for i := range cfg.Services {
 		if cfg.Services[i].ID == "" {
 			cfg.Services[i].ID = model.NewId()
 		}
 	}
-	occupied := config.OccupiedMCPServerIDs(cfg.MCP)
-	mintMCPID := func() string {
-		for {
-			id := model.NewId()
-			if _, taken := occupied[id]; !taken {
-				occupied[id] = struct{}{}
-				return id
-			}
-		}
-	}
 	for i := range cfg.MCP.Servers {
 		if cfg.MCP.Servers[i].ID == "" {
-			cfg.MCP.Servers[i].ID = mintMCPID()
+			cfg.MCP.Servers[i].ID = model.NewId()
 		}
 	}
 	if cfg.MCP.EmbeddedServer.ID == "" {
-		cfg.MCP.EmbeddedServer.ID = mintMCPID()
+		cfg.MCP.EmbeddedServer.ID = model.NewId()
 	}
 	for i := range cfg.MCP.PluginServers {
 		if cfg.MCP.PluginServers[i].ID == "" {
-			cfg.MCP.PluginServers[i].ID = mintMCPID()
+			cfg.MCP.PluginServers[i].ID = model.NewId()
 		}
 	}
-
 	return cfg
 }
 
@@ -113,44 +106,37 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 		return
 	}
 
-	// Read-previous → reconcile → normalize → save runs atomically under the
-	// config advisory lock. Reconciliation carries stable service and MCP
-	// server IDs forward before normalizeAdminConfig mints fresh ones, so
-	// clients that drop the id field cannot rotate IDs on every save;
-	// identity conflicts abort the save entirely.
+	// Read-previous → identity checks → mint empty IDs → save runs atomically
+	// under the config advisory lock. Duplicate IDs and embedded ID mismatch
+	// abort with 409. Empty list-item IDs represent creates and receive fresh
+	// IDs; they never reclaim an existing identity by name or origin.
 	var changedKeys []string
 	saved, err := a.configStore.UpdateConfig(func(prev *config.Config) (config.Config, error) {
 		next := cfg
-		// Reconcile even on the first write (empty previous lists) so
-		// fabricated or duplicate incoming IDs cannot slip in unvalidated.
-		var prevServices []llm.ServiceConfig
+		if err := config.ValidateServiceIDUniqueness(next.Services); err != nil {
+			return config.Config{}, err
+		}
 		var prevMCP config.MCPConfig
 		if prev != nil {
-			prevServices = prev.Services
 			prevMCP = prev.MCP
 		}
-		reconciledServices, reconcileErr := config.ReconcileServiceIDs(next.Services, prevServices)
-		if reconcileErr != nil {
-			return config.Config{}, reconcileErr
-		}
-		next.Services = reconciledServices
 		reconciledMCP, reconcileErr := config.ReconcileMCPConfigIDs(next.MCP, prevMCP)
 		if reconcileErr != nil {
 			return config.Config{}, reconcileErr
 		}
 		next.MCP = reconciledMCP
-		normalized := normalizeAdminConfig(next)
+		normalized := mintEmptyAdminIDs(normalizeAdminConfig(next))
 		changedKeys = audit.ChangedJSONKeys(prev, normalized)
 		return normalized, nil
 	})
 	switch {
 	case errors.Is(err, config.ErrServiceIDConflict), errors.Is(err, config.ErrMCPServerIDConflict):
-		// Minting fresh IDs here would silently detach existing policies.
-		c.AbortWithError(http.StatusConflict, fmt.Errorf("configuration payload conflicts with the stored service or MCP server identities; reload the System Console and retry: %w", err))
+		// Duplicate payload IDs, or an embedded server ID that does not match storage.
+		c.AbortWithError(http.StatusConflict, fmt.Errorf("configuration payload has duplicate service or MCP server IDs, or an embedded server ID that does not match the stored identity: %w", err))
 		return
-	case errors.Is(err, store.ErrStaleLegacyServiceIDs):
-		// A pre-upgrade client echoing UUID service IDs would undo the migration.
-		c.AbortWithError(http.StatusConflict, fmt.Errorf("stale configuration payload; reload the System Console and retry: %w", err))
+	case errors.Is(err, store.ErrLegacyUUIDServiceID):
+		// After the ABAC ID migration, a dashed UUID is an invalid service ID format.
+		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid service ID format: %w", err))
 		return
 	case err != nil:
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to save config: %w", err))

--- a/api/api_config_ids_test.go
+++ b/api/api_config_ids_test.go
@@ -1,0 +1,594 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAdminConfigDoesNotMintIDs(t *testing.T) {
+	result := normalizeAdminConfig(config.Config{
+		Services: []llm.ServiceConfig{
+			{Name: "no-id", Type: llm.ServiceTypeOpenAI},
+		},
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServerConfig{
+				{Name: "srv-no-id", BaseURL: "https://one.example.com"},
+			},
+			PluginServers: []config.PluginServerConfig{
+				{PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+			},
+		},
+	})
+
+	assert.Empty(t, result.Services[0].ID)
+	assert.True(t, result.Services[0].UseResponsesAPI)
+	assert.Empty(t, result.MCP.Servers[0].ID)
+	assert.Empty(t, result.MCP.EmbeddedServer.ID)
+	assert.Empty(t, result.MCP.PluginServers[0].ID)
+	assert.True(t, result.MCP.Enabled)
+	assert.True(t, result.MCP.EmbeddedServer.Enabled)
+}
+
+func TestMintEmptyAdminIDsAssignsStableIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      config.Config
+		validate func(t *testing.T, result config.Config)
+	}{
+		{
+			name: "empty service and MCP server IDs get fresh valid IDs",
+			cfg: config.Config{
+				Services: []llm.ServiceConfig{
+					{Name: "no-id"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "srv-no-id", BaseURL: "https://one.example.com"},
+					},
+					PluginServers: []config.PluginServerConfig{
+						{PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			validate: func(t *testing.T, result config.Config) {
+				assert.True(t, model.IsValidId(result.Services[0].ID))
+				assert.True(t, model.IsValidId(result.MCP.Servers[0].ID))
+				assert.True(t, model.IsValidId(result.MCP.EmbeddedServer.ID))
+				assert.True(t, model.IsValidId(result.MCP.PluginServers[0].ID))
+			},
+		},
+		{
+			name: "non-empty IDs untouched",
+			cfg: config.Config{
+				Services: []llm.ServiceConfig{
+					{ID: "svc-existing", Name: "has-id"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "mcp-existing", Name: "srv-has-id", BaseURL: "https://one.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-existing", Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{ID: "plugin-existing", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			validate: func(t *testing.T, result config.Config) {
+				assert.Equal(t, "svc-existing", result.Services[0].ID)
+				assert.Equal(t, "mcp-existing", result.MCP.Servers[0].ID)
+				assert.Equal(t, "embedded-existing", result.MCP.EmbeddedServer.ID)
+				assert.Equal(t, "plugin-existing", result.MCP.PluginServers[0].ID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.validate(t, mintEmptyAdminIDs(tt.cfg))
+		})
+	}
+}
+
+// TestHandleSaveConfigMCPServerIDs: incoming uniqueness, then plugin overlay +
+// embedded copy, then mint empty IDs. Duplicate incoming IDs return 409.
+func TestHandleSaveConfigMCPServerIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		storedCfg      *config.Config
+		payloadCfg     config.Config
+		expectedStatus int
+		validate       func(t *testing.T, store *testConfigStore)
+	}{
+		{
+			name: "payload without id mints a new remote server ID",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-stable", Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{ID: "plugin-stable", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{PluginID: "com.example.a", Name: "A", Path: "/mcp/v2"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[0].ID))
+				assert.NotEqual(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+				assert.Equal(t, "embedded-stable", store.cfg.MCP.EmbeddedServer.ID)
+				require.Len(t, store.cfg.MCP.PluginServers, 1)
+				assert.Equal(t, "plugin-stable", store.cfg.MCP.PluginServers[0].ID)
+			},
+		},
+		{
+			name: "renamed ID-less server is treated as create",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Old Name", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "New Name", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[0].ID))
+				assert.NotEqual(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+			},
+		},
+		{
+			name: "add flow: existing ID kept and ID-less sibling minted",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+						{Name: "Brand New", BaseURL: "https://new.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 2)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[1].ID))
+				assert.NotEqual(t, "stable-id", store.cfg.MCP.Servers[1].ID)
+			},
+		},
+		{
+			name: "duplicate incoming remote IDs return 409",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+						{ID: "stable-id", Name: "Copy", BaseURL: "https://copy.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusConflict,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.NotNil(t, store.cfg)
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID, "stored config must be untouched on rejection")
+			},
+		},
+		{
+			name:      "no stored config still assigns ids",
+			storedCfg: nil,
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[0].ID))
+			},
+		},
+		{
+			name: "caller-chosen ID for a same-named stored server is kept",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "invented-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.Equal(t, "invented-by-client", store.cfg.MCP.Servers[0].ID)
+			},
+		},
+		{
+			name:      "caller-chosen ID on first write is kept",
+			storedCfg: nil,
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.Equal(t, "seeded-by-client", store.cfg.MCP.Servers[0].ID)
+			},
+		},
+		{
+			name:      "duplicate IDs on first write return 409",
+			storedCfg: nil,
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+						{ID: "seeded-by-client", Name: "Copy", BaseURL: "https://copy.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusConflict,
+			validate: func(t *testing.T, store *testConfigStore) {
+				assert.Nil(t, store.cfg, "nothing must be persisted on rejection")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: tt.storedCfg}
+			updater := &testConfigUpdater{}
+			notifier := &testClusterNotifier{}
+			router := setupTestRouter(store, updater, notifier)
+
+			body, err := json.Marshal(tt.payloadCfg)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedStatus == http.StatusConflict {
+				assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
+				assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
+			}
+			if tt.validate != nil {
+				tt.validate(t, store)
+			}
+		})
+	}
+}
+
+// TestHandleSaveConfigPreservesOmittedPluginServers: full config save never
+// accepts client-provided plugin_servers — omitted and stale non-empty lists
+// both leave persisted plugin rows (and their IDs) untouched.
+func TestHandleSaveConfigPreservesOmittedPluginServers(t *testing.T) {
+	pluginA := "abcdefghijklmnopqrstuvwx0a"
+	pluginB := "abcdefghijklmnopqrstuvwx0b"
+	embeddedID := "abcdefghijklmnopqrstuvwx0e"
+	remoteID := "abcdefghijklmnopqrstuvwx0r"
+
+	storedPlugins := []config.PluginServerConfig{
+		{ID: pluginA, PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true},
+		{ID: pluginB, PluginID: "com.example.b", Name: "B", Path: "/other", Enabled: false},
+	}
+
+	tests := []struct {
+		name    string
+		mcp     map[string]any
+		wantIDs []string
+	}{
+		{
+			name: "omitted plugin_servers preserves prev",
+			mcp: map[string]any{
+				"enabled": true,
+				"servers": []map[string]any{
+					{"id": remoteID, "name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
+				},
+				"embeddedServer": map[string]any{"enabled": true},
+			},
+			wantIDs: []string{pluginA, pluginB},
+		},
+		{
+			name: "stale non-empty plugin_servers ignored",
+			mcp: map[string]any{
+				"enabled": true,
+				"servers": []map[string]any{
+					{"id": remoteID, "name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
+				},
+				"embeddedServer": map[string]any{"enabled": true},
+				"plugin_servers": []map[string]any{
+					{
+						"id": "attackeridattackeridattack", "plugin_id": "com.example.a",
+						"name": "Hacked", "path": "/evil", "enabled": false,
+					},
+				},
+			},
+			wantIDs: []string{pluginA, pluginB},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: &config.Config{
+				MCP: config.MCPConfig{
+					Enabled: true,
+					Servers: []config.MCPServerConfig{
+						{ID: remoteID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: embeddedID, Enabled: true},
+					PluginServers:  append([]config.PluginServerConfig(nil), storedPlugins...),
+				},
+			}}
+			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+			body, err := json.Marshal(map[string]any{"mcp": tt.mcp})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			require.Len(t, store.cfg.MCP.PluginServers, len(tt.wantIDs))
+			for i, id := range tt.wantIDs {
+				assert.Equal(t, id, store.cfg.MCP.PluginServers[i].ID)
+				assert.Equal(t, storedPlugins[i].PluginID, store.cfg.MCP.PluginServers[i].PluginID)
+				assert.Equal(t, storedPlugins[i].Name, store.cfg.MCP.PluginServers[i].Name)
+				assert.Equal(t, storedPlugins[i].Path, store.cfg.MCP.PluginServers[i].Path)
+				assert.Equal(t, storedPlugins[i].Enabled, store.cfg.MCP.PluginServers[i].Enabled)
+			}
+			assert.Equal(t, remoteID, store.cfg.MCP.Servers[0].ID)
+			assert.Equal(t, embeddedID, store.cfg.MCP.EmbeddedServer.ID)
+		})
+	}
+}
+
+func TestHandleSaveConfigRejectsCrossKindMCPIDConflict(t *testing.T) {
+	sharedID := "abcdefghijklmnopqrstuvwxzz"
+	store := &testConfigStore{cfg: &config.Config{
+		MCP: config.MCPConfig{
+			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+		},
+	}}
+	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+	payload := config.Config{
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServerConfig{
+				{ID: sharedID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
+			},
+			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestHandleSaveConfigMintsServiceIDs: empty service ID means create
+// (mintEmptyAdminIDs); explicit IDs are kept, including a new ID for
+// a same-named stored service. Duplicate incoming IDs return 409.
+func TestHandleSaveConfigMintsServiceIDs(t *testing.T) {
+	stored := func() *config.Config {
+		return &config.Config{
+			Services: []llm.ServiceConfig{
+				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		storedCfg       *config.Config
+		payloadServices []llm.ServiceConfig
+		expectedStatus  int
+		validate        func(t *testing.T, store *testConfigStore)
+	}{
+		{
+			name:      "payload without id mints a new service ID",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.True(t, model.IsValidId(store.cfg.Services[0].ID))
+				assert.NotEqual(t, "stable-svc-id", store.cfg.Services[0].ID)
+			},
+		},
+		{
+			name:      "ID-less payload with field edits is treated as create",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "anthropic", APIURL: "https://edited.example.com"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.True(t, model.IsValidId(store.cfg.Services[0].ID))
+				assert.NotEqual(t, "stable-svc-id", store.cfg.Services[0].ID)
+			},
+		},
+		{
+			name:      "add flow: ID-less sibling is minted",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
+				{Name: "Brand New", Type: "anthropic"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 2)
+				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
+				assert.True(t, model.IsValidId(store.cfg.Services[1].ID))
+			},
+		},
+		{
+			name:      "caller-chosen ID for a same-named service is kept",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{ID: "invented-by-client", Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.Equal(t, "invented-by-client", store.cfg.Services[0].ID)
+			},
+		},
+		{
+			name:      "duplicate incoming IDs return 409",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
+				{ID: "stable-svc-id", Name: "Copy", Type: "openai"},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name:      "no stored config still assigns ids",
+			storedCfg: nil,
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.True(t, model.IsValidId(store.cfg.Services[0].ID))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: tt.storedCfg}
+			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+			body, err := json.Marshal(config.Config{Services: tt.payloadServices})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validate != nil {
+				tt.validate(t, store)
+			}
+		})
+	}
+}
+
+// TestHandleSaveConfigRejectsLegacyUUIDServiceIDs covers a save that carries
+// dashed UUID service IDs after the ABAC ID migration: the save must fail with
+// 400 and leave the migrated config untouched, while a valid payload is accepted.
+func TestHandleSaveConfigRejectsLegacyUUIDServiceIDs(t *testing.T) {
+	migrated := &config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "migrated26charidmigrated26", Name: "OpenAI", Type: "openai"},
+		},
+	}
+	store := &testConfigStore{cfg: migrated, serviceIDMigrationDone: true}
+	updater := &testConfigUpdater{}
+	notifier := &testClusterNotifier{}
+	router := setupTestRouter(store, updater, notifier)
+
+	put := func(cfg config.Config) *httptest.ResponseRecorder {
+		body, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Payload with a dashed UUID service ID (invalid post-migration format).
+	stale := config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "550e8400-e29b-41d4-a716-446655440000", Name: "OpenAI", Type: "openai"},
+		},
+	}
+	w := put(stale)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "migrated26charidmigrated26", store.cfg.Services[0].ID, "migrated ID must survive the rejected save")
+	assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
+	assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
+
+	// Fresh payload with the migrated ID is accepted.
+	fresh := config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "migrated26charidmigrated26", Name: "OpenAI Renamed", Type: "openai"},
+		},
+	}
+	w = put(fresh)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "OpenAI Renamed", store.cfg.Services[0].Name)
+	assert.Equal(t, 1, updater.callCount)
+	assert.Equal(t, 1, notifier.callCount)
+}

--- a/api/api_config_test.go
+++ b/api/api_config_test.go
@@ -28,7 +28,7 @@ type testConfigStore struct {
 	saveErr error
 
 	// serviceIDMigrationDone mirrors the store's migration marker driving the
-	// stale legacy UUID rejection in UpdateConfig.
+	// post-migration UUID format rejection in UpdateConfig.
 	serviceIDMigrationDone bool
 }
 
@@ -59,7 +59,7 @@ func (s *testConfigStore) UpdateConfig(transform func(prev *config.Config) (conf
 	if s.serviceIDMigrationDone {
 		for i := range next.Services {
 			if len(next.Services[i].ID) == 36 {
-				return next, store.ErrStaleLegacyServiceIDs
+				return next, store.ErrLegacyUUIDServiceID
 			}
 		}
 	}
@@ -156,6 +156,31 @@ func TestHandleGetConfig(t *testing.T) {
 				assert.Empty(t, cfg.DefaultBotName)
 				assert.True(t, cfg.MCP.Enabled)
 				assert.True(t, cfg.MCP.EmbeddedServer.Enabled)
+				assert.Empty(t, cfg.MCP.EmbeddedServer.ID, "GET must not mint unpersisted IDs")
+			},
+		},
+		{
+			name: "does not mint IDs for ID-less stored rows",
+			storedConfig: &config.Config{
+				Services: []llm.ServiceConfig{
+					{Name: "OpenAI", Type: "openai"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var cfg config.Config
+				err := json.Unmarshal(body, &cfg)
+				require.NoError(t, err)
+				require.Len(t, cfg.Services, 1)
+				assert.Empty(t, cfg.Services[0].ID)
+				require.Len(t, cfg.MCP.Servers, 1)
+				assert.Empty(t, cfg.MCP.Servers[0].ID)
+				assert.Empty(t, cfg.MCP.EmbeddedServer.ID)
 			},
 		},
 		{
@@ -464,551 +489,6 @@ func TestHandleSaveConfig(t *testing.T) {
 	}
 }
 
-func TestNormalizeAdminConfigAssignsStableIDs(t *testing.T) {
-	tests := []struct {
-		name     string
-		cfg      config.Config
-		validate func(t *testing.T, result config.Config)
-	}{
-		{
-			name: "empty service and MCP server IDs get fresh valid IDs",
-			cfg: config.Config{
-				Services: []llm.ServiceConfig{
-					{Name: "no-id"},
-				},
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{Name: "srv-no-id", BaseURL: "https://one.example.com"},
-					},
-					PluginServers: []config.PluginServerConfig{
-						{PluginID: "com.example.a", Name: "A", Path: "/mcp"},
-					},
-				},
-			},
-			validate: func(t *testing.T, result config.Config) {
-				assert.True(t, model.IsValidId(result.Services[0].ID))
-				assert.True(t, model.IsValidId(result.MCP.Servers[0].ID))
-				assert.True(t, model.IsValidId(result.MCP.EmbeddedServer.ID))
-				assert.True(t, model.IsValidId(result.MCP.PluginServers[0].ID))
-			},
-		},
-		{
-			name: "non-empty IDs untouched",
-			cfg: config.Config{
-				Services: []llm.ServiceConfig{
-					{ID: "svc-existing", Name: "has-id"},
-				},
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{ID: "mcp-existing", Name: "srv-has-id", BaseURL: "https://one.example.com"},
-					},
-					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-existing", Enabled: true},
-					PluginServers: []config.PluginServerConfig{
-						{ID: "plugin-existing", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
-					},
-				},
-			},
-			validate: func(t *testing.T, result config.Config) {
-				assert.Equal(t, "svc-existing", result.Services[0].ID)
-				assert.Equal(t, "mcp-existing", result.MCP.Servers[0].ID)
-				assert.Equal(t, "embedded-existing", result.MCP.EmbeddedServer.ID)
-				assert.Equal(t, "plugin-existing", result.MCP.PluginServers[0].ID)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.validate(t, normalizeAdminConfig(tt.cfg))
-		})
-	}
-}
-
-func TestHandleSaveConfigCarriesForwardMCPServerIDs(t *testing.T) {
-	tests := []struct {
-		name       string
-		storedCfg  *config.Config
-		payloadCfg config.Config
-		validate   func(t *testing.T, store *testConfigStore)
-	}{
-		{
-			name: "payload without id keeps stored id (stale bundle)",
-			storedCfg: &config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
-					},
-					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-stable", Enabled: true},
-					PluginServers: []config.PluginServerConfig{
-						{ID: "plugin-stable", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
-					},
-				},
-			},
-			payloadCfg: config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{Name: "Jira", BaseURL: "https://jira.example.com"},
-					},
-					EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
-					PluginServers: []config.PluginServerConfig{
-						{PluginID: "com.example.a", Name: "A", Path: "/mcp/v2"},
-					},
-				},
-			},
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.MCP.Servers, 1)
-				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
-				assert.Equal(t, "embedded-stable", store.cfg.MCP.EmbeddedServer.ID)
-				require.Len(t, store.cfg.MCP.PluginServers, 1)
-				assert.Equal(t, "plugin-stable", store.cfg.MCP.PluginServers[0].ID)
-			},
-		},
-		{
-			name: "renamed server without id matched by BaseURL",
-			storedCfg: &config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{ID: "stable-id", Name: "Old Name", BaseURL: "https://jira.example.com"},
-					},
-				},
-			},
-			payloadCfg: config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{Name: "New Name", BaseURL: "https://jira.example.com"},
-					},
-				},
-			},
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.MCP.Servers, 1)
-				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
-			},
-		},
-		{
-			name: "brand-new server without match gets a fresh id from the backstop",
-			storedCfg: &config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
-					},
-				},
-			},
-			payloadCfg: config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{Name: "Jira", BaseURL: "https://jira.example.com"},
-						{Name: "Brand New", BaseURL: "https://new.example.com"},
-					},
-				},
-			},
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.MCP.Servers, 2)
-				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
-				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[1].ID))
-				assert.NotEqual(t, "stable-id", store.cfg.MCP.Servers[1].ID)
-			},
-		},
-		{
-			name:      "no stored config still assigns ids",
-			storedCfg: nil,
-			payloadCfg: config.Config{
-				MCP: config.MCPConfig{
-					Servers: []config.MCPServerConfig{
-						{Name: "Jira", BaseURL: "https://jira.example.com"},
-					},
-				},
-			},
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.MCP.Servers, 1)
-				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[0].ID))
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{cfg: tt.storedCfg}
-			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
-
-			body, err := json.Marshal(tt.payloadCfg)
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-
-			require.Equal(t, http.StatusOK, w.Code)
-			tt.validate(t, store)
-		})
-	}
-}
-
-// TestHandleSaveConfigPreservesOmittedPluginServers: full config save never
-// accepts client-provided plugin_servers — omitted and stale non-empty lists
-// both leave persisted plugin rows (and their IDs) untouched.
-func TestHandleSaveConfigPreservesOmittedPluginServers(t *testing.T) {
-	pluginA := "abcdefghijklmnopqrstuvwx0a"
-	pluginB := "abcdefghijklmnopqrstuvwx0b"
-	embeddedID := "abcdefghijklmnopqrstuvwx0e"
-	remoteID := "abcdefghijklmnopqrstuvwx0r"
-
-	storedPlugins := []config.PluginServerConfig{
-		{ID: pluginA, PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true},
-		{ID: pluginB, PluginID: "com.example.b", Name: "B", Path: "/other", Enabled: false},
-	}
-
-	tests := []struct {
-		name    string
-		mcp     map[string]any
-		wantIDs []string
-	}{
-		{
-			name: "omitted plugin_servers preserves prev",
-			mcp: map[string]any{
-				"enabled": true,
-				"servers": []map[string]any{
-					{"name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
-				},
-				"embeddedServer": map[string]any{"enabled": true},
-			},
-			wantIDs: []string{pluginA, pluginB},
-		},
-		{
-			name: "stale non-empty plugin_servers ignored",
-			mcp: map[string]any{
-				"enabled": true,
-				"servers": []map[string]any{
-					{"name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
-				},
-				"embeddedServer": map[string]any{"enabled": true},
-				"plugin_servers": []map[string]any{
-					{
-						"id": "attackeridattackeridattack", "plugin_id": "com.example.a",
-						"name": "Hacked", "path": "/evil", "enabled": false,
-					},
-				},
-			},
-			wantIDs: []string{pluginA, pluginB},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{cfg: &config.Config{
-				MCP: config.MCPConfig{
-					Enabled: true,
-					Servers: []config.MCPServerConfig{
-						{ID: remoteID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
-					},
-					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: embeddedID, Enabled: true},
-					PluginServers:  append([]config.PluginServerConfig(nil), storedPlugins...),
-				},
-			}}
-			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
-
-			body, err := json.Marshal(map[string]any{"mcp": tt.mcp})
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-			require.Equal(t, http.StatusOK, w.Code)
-
-			require.Len(t, store.cfg.MCP.PluginServers, len(tt.wantIDs))
-			for i, id := range tt.wantIDs {
-				assert.Equal(t, id, store.cfg.MCP.PluginServers[i].ID)
-				assert.Equal(t, storedPlugins[i].PluginID, store.cfg.MCP.PluginServers[i].PluginID)
-				assert.Equal(t, storedPlugins[i].Name, store.cfg.MCP.PluginServers[i].Name)
-				assert.Equal(t, storedPlugins[i].Path, store.cfg.MCP.PluginServers[i].Path)
-				assert.Equal(t, storedPlugins[i].Enabled, store.cfg.MCP.PluginServers[i].Enabled)
-			}
-			assert.Equal(t, remoteID, store.cfg.MCP.Servers[0].ID)
-			assert.Equal(t, embeddedID, store.cfg.MCP.EmbeddedServer.ID)
-		})
-	}
-}
-
-func TestHandleSaveConfigRejectsCrossKindMCPIDConflict(t *testing.T) {
-	sharedID := "abcdefghijklmnopqrstuvwxzz"
-	store := &testConfigStore{cfg: &config.Config{
-		MCP: config.MCPConfig{
-			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
-		},
-	}}
-	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
-
-	payload := config.Config{
-		MCP: config.MCPConfig{
-			Servers: []config.MCPServerConfig{
-				{ID: sharedID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
-			},
-			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
-		},
-	}
-	body, err := json.Marshal(payload)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusConflict, w.Code)
-}
-
-// TestHandleSaveConfigCarriesForwardServiceIDs mirrors the MCP server ID
-// reconciliation for LLM services: service IDs are ABAC policy identities, so
-// an ID-less payload from a stale client must reclaim the stored ID instead
-// of rotating it (which would silently detach the service's policy), and
-// unresolvable identities must fail with 409.
-func TestHandleSaveConfigCarriesForwardServiceIDs(t *testing.T) {
-	stored := func() *config.Config {
-		return &config.Config{
-			Services: []llm.ServiceConfig{
-				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
-			},
-		}
-	}
-
-	tests := []struct {
-		name            string
-		storedCfg       *config.Config
-		payloadServices []llm.ServiceConfig
-		expectedStatus  int
-		validate        func(t *testing.T, store *testConfigStore)
-	}{
-		{
-			name:      "payload without id keeps stored id (stale client)",
-			storedCfg: stored(),
-			payloadServices: []llm.ServiceConfig{
-				{Name: "OpenAI", Type: "openai"},
-			},
-			expectedStatus: http.StatusOK,
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.Services, 1)
-				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
-			},
-		},
-		{
-			name:      "repeated ID-less saves never rotate the id",
-			storedCfg: stored(),
-			payloadServices: []llm.ServiceConfig{
-				{Name: "OpenAI", Type: "anthropic", APIURL: "https://edited.example.com"},
-			},
-			expectedStatus: http.StatusOK,
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.Services, 1)
-				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
-			},
-		},
-		{
-			name:      "brand-new service without match gets a fresh id from the backstop",
-			storedCfg: stored(),
-			payloadServices: []llm.ServiceConfig{
-				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
-				{Name: "Brand New", Type: "anthropic"},
-			},
-			expectedStatus: http.StatusOK,
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.Services, 2)
-				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
-				assert.True(t, model.IsValidId(store.cfg.Services[1].ID))
-			},
-		},
-		{
-			name:      "fabricated incoming ID returns 409",
-			storedCfg: stored(),
-			payloadServices: []llm.ServiceConfig{
-				{ID: "invented-by-client", Name: "OpenAI", Type: "openai"},
-			},
-			expectedStatus: http.StatusConflict,
-			validate: func(t *testing.T, store *testConfigStore) {
-				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID, "stored config must be untouched on rejection")
-			},
-		},
-		{
-			name:      "no stored config still assigns ids",
-			storedCfg: nil,
-			payloadServices: []llm.ServiceConfig{
-				{Name: "OpenAI", Type: "openai"},
-			},
-			expectedStatus: http.StatusOK,
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.Services, 1)
-				assert.True(t, model.IsValidId(store.cfg.Services[0].ID))
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{cfg: tt.storedCfg}
-			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
-
-			body, err := json.Marshal(config.Config{Services: tt.payloadServices})
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-
-			require.Equal(t, tt.expectedStatus, w.Code)
-			if tt.validate != nil {
-				tt.validate(t, store)
-			}
-		})
-	}
-}
-
-// TestHandleSaveConfigRejectsMCPServerIDConflicts covers stale or corrupt
-// admin payloads whose MCP server identities cannot be reconciled with the
-// stored config: the save must fail with 409 (never silently re-mint IDs,
-// which would detach existing policies), while legitimate add/edit flows
-// still succeed.
-func TestHandleSaveConfigRejectsMCPServerIDConflicts(t *testing.T) {
-	storedServer := config.MCPServerConfig{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"}
-	storedOther := config.MCPServerConfig{ID: "other-id", Name: "Linear", BaseURL: "https://linear.example.com"}
-
-	tests := []struct {
-		name           string
-		payloadServers []config.MCPServerConfig
-		expectedStatus int
-		validate       func(t *testing.T, store *testConfigStore)
-	}{
-		{
-			name: "fabricated incoming ID returns 409",
-			payloadServers: []config.MCPServerConfig{
-				{ID: "invented-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
-			},
-			expectedStatus: http.StatusConflict,
-		},
-		{
-			name: "duplicate incoming IDs return 409",
-			payloadServers: []config.MCPServerConfig{
-				{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
-				{ID: "stable-id", Name: "Copy", BaseURL: "https://copy.example.com"},
-			},
-			expectedStatus: http.StatusConflict,
-		},
-		{
-			name: "ambiguous ID-less identity match returns 409",
-			payloadServers: []config.MCPServerConfig{
-				// Name matches Linear, BaseURL matches Jira: never guess.
-				{Name: "Linear", BaseURL: "https://jira.example.com"},
-			},
-			expectedStatus: http.StatusConflict,
-		},
-		{
-			name: "add flow: new ID-less server minted server-side",
-			payloadServers: []config.MCPServerConfig{
-				{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
-				{ID: "other-id", Name: "Linear", BaseURL: "https://linear.example.com"},
-				{Name: "Brand New", BaseURL: "https://new.example.com"},
-			},
-			expectedStatus: http.StatusOK,
-			validate: func(t *testing.T, store *testConfigStore) {
-				require.Len(t, store.cfg.MCP.Servers, 3)
-				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
-				assert.Equal(t, "other-id", store.cfg.MCP.Servers[1].ID)
-				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[2].ID), "new server gets a server-minted ID")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stored := &config.Config{
-				MCP: config.MCPConfig{Servers: []config.MCPServerConfig{storedServer, storedOther}},
-			}
-			store := &testConfigStore{cfg: stored}
-			updater := &testConfigUpdater{}
-			notifier := &testClusterNotifier{}
-			router := setupTestRouter(store, updater, notifier)
-
-			body, err := json.Marshal(config.Config{
-				MCP: config.MCPConfig{Servers: tt.payloadServers},
-			})
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-
-			require.Equal(t, tt.expectedStatus, w.Code)
-			if tt.expectedStatus == http.StatusConflict {
-				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID, "stored config must be untouched on rejection")
-				assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
-				assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
-			}
-			if tt.validate != nil {
-				tt.validate(t, store)
-			}
-		})
-	}
-}
-
-// TestHandleSaveConfigFirstWriteIncomingMCPIDs covers the first-write path
-// (no stored config yet): reconciliation must still run against an empty
-// previous list, so duplicate incoming MCP server IDs are rejected, while
-// caller-chosen IDs for genuinely new servers (API automation seeding a
-// fresh install) are kept.
-func TestHandleSaveConfigFirstWriteIncomingMCPIDs(t *testing.T) {
-	tests := []struct {
-		name           string
-		payloadServers []config.MCPServerConfig
-		expectedStatus int
-	}{
-		{
-			name: "caller-chosen ID on first write is kept",
-			payloadServers: []config.MCPServerConfig{
-				{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
-			},
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name: "duplicate IDs on first write",
-			payloadServers: []config.MCPServerConfig{
-				{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
-				{ID: "seeded-by-client", Name: "Copy", BaseURL: "https://copy.example.com"},
-			},
-			expectedStatus: http.StatusConflict,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{cfg: nil}
-			updater := &testConfigUpdater{}
-			notifier := &testClusterNotifier{}
-			router := setupTestRouter(store, updater, notifier)
-
-			body, err := json.Marshal(config.Config{
-				MCP: config.MCPConfig{Servers: tt.payloadServers},
-			})
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-
-			require.Equal(t, tt.expectedStatus, w.Code)
-			if tt.expectedStatus == http.StatusConflict {
-				assert.Nil(t, store.cfg, "nothing must be persisted on rejection")
-				assert.Equal(t, 0, updater.callCount)
-				assert.Equal(t, 0, notifier.callCount)
-			} else {
-				require.NotNil(t, store.cfg)
-				require.Len(t, store.cfg.MCP.Servers, len(tt.payloadServers))
-				assert.Equal(t, tt.payloadServers[0].ID, store.cfg.MCP.Servers[0].ID)
-			}
-		})
-	}
-}
-
 // TestHandleSaveConfigReturnsNormalizedConfig verifies the PUT response body
 // carries the normalized saved config, so the webapp can adopt server-minted
 // service and MCP server IDs immediately instead of waiting for a reload.
@@ -1045,56 +525,6 @@ func TestHandleSaveConfigReturnsNormalizedConfig(t *testing.T) {
 	assert.True(t, resp.Services[0].UseResponsesAPI, "response must reflect normalization")
 }
 
-// TestHandleSaveConfigRejectsStaleLegacyServiceIDs covers the interleaving
-// where a pre-upgrade webapp bundle loaded the config before the ID migration
-// ran and then saves UUID service IDs back: the save must fail with 409 and
-// leave the migrated config untouched, while a fresh payload is accepted.
-func TestHandleSaveConfigRejectsStaleLegacyServiceIDs(t *testing.T) {
-	migrated := &config.Config{
-		Services: []llm.ServiceConfig{
-			{ID: "migrated26charidmigrated26", Name: "OpenAI", Type: "openai"},
-		},
-	}
-	store := &testConfigStore{cfg: migrated, serviceIDMigrationDone: true}
-	updater := &testConfigUpdater{}
-	notifier := &testClusterNotifier{}
-	router := setupTestRouter(store, updater, notifier)
-
-	put := func(cfg config.Config) *httptest.ResponseRecorder {
-		body, err := json.Marshal(cfg)
-		require.NoError(t, err)
-		req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-		return w
-	}
-
-	// Stale payload echoing a pre-migration UUID service ID.
-	stale := config.Config{
-		Services: []llm.ServiceConfig{
-			{ID: "550e8400-e29b-41d4-a716-446655440000", Name: "OpenAI", Type: "openai"},
-		},
-	}
-	w := put(stale)
-	assert.Equal(t, http.StatusConflict, w.Code)
-	assert.Equal(t, "migrated26charidmigrated26", store.cfg.Services[0].ID, "migrated ID must survive the stale save")
-	assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
-	assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
-
-	// Fresh payload with the migrated ID is accepted.
-	fresh := config.Config{
-		Services: []llm.ServiceConfig{
-			{ID: "migrated26charidmigrated26", Name: "OpenAI Renamed", Type: "openai"},
-		},
-	}
-	w = put(fresh)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "OpenAI Renamed", store.cfg.Services[0].Name)
-	assert.Equal(t, 1, updater.callCount)
-	assert.Equal(t, 1, notifier.callCount)
-}
-
 func TestSaveAndGetConfigRoundTrip(t *testing.T) {
 	store := &testConfigStore{}
 	updater := &testConfigUpdater{}
@@ -1113,7 +543,7 @@ func TestSaveAndGetConfigRoundTrip(t *testing.T) {
 	assert.Empty(t, emptyCfg.Services)
 
 	// Step 2: PUT a config. The new service arrives ID-less (the backend
-	// mints the stable ID); an unknown incoming ID would be rejected.
+	// mints the stable ID).
 	saveCfg := config.Config{
 		DefaultBotName: "ai",
 		Services: []llm.ServiceConfig{

--- a/api/api_config_test.go
+++ b/api/api_config_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +26,10 @@ type testConfigStore struct {
 	cfg     *config.Config
 	getErr  error
 	saveErr error
+
+	// serviceIDMigrationDone mirrors the store's migration marker driving the
+	// stale legacy UUID rejection in UpdateConfig.
+	serviceIDMigrationDone bool
 }
 
 func (s *testConfigStore) GetConfig() (*config.Config, error) {
@@ -40,6 +46,27 @@ func (s *testConfigStore) SaveConfig(cfg config.Config) error {
 	clone := cfg
 	s.cfg = &clone
 	return nil
+}
+
+func (s *testConfigStore) UpdateConfig(transform func(prev *config.Config) (config.Config, error)) (config.Config, error) {
+	if s.getErr != nil {
+		return config.Config{}, s.getErr
+	}
+	next, err := transform(s.cfg)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if s.serviceIDMigrationDone {
+		for i := range next.Services {
+			if len(next.Services[i].ID) == 36 {
+				return next, store.ErrStaleLegacyServiceIDs
+			}
+		}
+	}
+	if err := s.SaveConfig(next); err != nil {
+		return next, err
+	}
+	return next, nil
 }
 
 // testConfigUpdater tracks whether Update was called and with what config.
@@ -213,6 +240,7 @@ func TestHandleGetConfigDoesNotMutateStoredServices(t *testing.T) {
 func TestHandleSaveConfig(t *testing.T) {
 	tests := []struct {
 		name                  string
+		storedCfg             *config.Config
 		requestBody           any
 		clusterErr            error
 		expectedStatus        int
@@ -222,6 +250,11 @@ func TestHandleSaveConfig(t *testing.T) {
 	}{
 		{
 			name: "returns error when cluster notify fails after successful save",
+			storedCfg: &config.Config{
+				Services: []llm.ServiceConfig{
+					{ID: "svc-1", Name: "OpenAI", Type: "openai"},
+				},
+			},
 			requestBody: config.Config{
 				DefaultBotName: "ai",
 				Services: []llm.ServiceConfig{
@@ -248,6 +281,11 @@ func TestHandleSaveConfig(t *testing.T) {
 		},
 		{
 			name: "saves valid config",
+			storedCfg: &config.Config{
+				Services: []llm.ServiceConfig{
+					{ID: "svc-1", Name: "OpenAI", Type: "openai"},
+				},
+			},
 			requestBody: config.Config{
 				DefaultBotName: "ai",
 				Services: []llm.ServiceConfig{
@@ -390,7 +428,7 @@ func TestHandleSaveConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{}
+			store := &testConfigStore{cfg: tt.storedCfg}
 			updater := &testConfigUpdater{}
 			notifier := &testClusterNotifier{err: tt.clusterErr}
 
@@ -426,6 +464,637 @@ func TestHandleSaveConfig(t *testing.T) {
 	}
 }
 
+func TestNormalizeAdminConfigAssignsStableIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      config.Config
+		validate func(t *testing.T, result config.Config)
+	}{
+		{
+			name: "empty service and MCP server IDs get fresh valid IDs",
+			cfg: config.Config{
+				Services: []llm.ServiceConfig{
+					{Name: "no-id"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "srv-no-id", BaseURL: "https://one.example.com"},
+					},
+					PluginServers: []config.PluginServerConfig{
+						{PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			validate: func(t *testing.T, result config.Config) {
+				assert.True(t, model.IsValidId(result.Services[0].ID))
+				assert.True(t, model.IsValidId(result.MCP.Servers[0].ID))
+				assert.True(t, model.IsValidId(result.MCP.EmbeddedServer.ID))
+				assert.True(t, model.IsValidId(result.MCP.PluginServers[0].ID))
+			},
+		},
+		{
+			name: "non-empty IDs untouched",
+			cfg: config.Config{
+				Services: []llm.ServiceConfig{
+					{ID: "svc-existing", Name: "has-id"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "mcp-existing", Name: "srv-has-id", BaseURL: "https://one.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-existing", Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{ID: "plugin-existing", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			validate: func(t *testing.T, result config.Config) {
+				assert.Equal(t, "svc-existing", result.Services[0].ID)
+				assert.Equal(t, "mcp-existing", result.MCP.Servers[0].ID)
+				assert.Equal(t, "embedded-existing", result.MCP.EmbeddedServer.ID)
+				assert.Equal(t, "plugin-existing", result.MCP.PluginServers[0].ID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.validate(t, normalizeAdminConfig(tt.cfg))
+		})
+	}
+}
+
+func TestHandleSaveConfigCarriesForwardMCPServerIDs(t *testing.T) {
+	tests := []struct {
+		name       string
+		storedCfg  *config.Config
+		payloadCfg config.Config
+		validate   func(t *testing.T, store *testConfigStore)
+	}{
+		{
+			name: "payload without id keeps stored id (stale bundle)",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded-stable", Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{ID: "plugin-stable", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
+					PluginServers: []config.PluginServerConfig{
+						{PluginID: "com.example.a", Name: "A", Path: "/mcp/v2"},
+					},
+				},
+			},
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+				assert.Equal(t, "embedded-stable", store.cfg.MCP.EmbeddedServer.ID)
+				require.Len(t, store.cfg.MCP.PluginServers, 1)
+				assert.Equal(t, "plugin-stable", store.cfg.MCP.PluginServers[0].ID)
+			},
+		},
+		{
+			name: "renamed server without id matched by BaseURL",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Old Name", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "New Name", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+			},
+		},
+		{
+			name: "brand-new server without match gets a fresh id from the backstop",
+			storedCfg: &config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+						{Name: "Brand New", BaseURL: "https://new.example.com"},
+					},
+				},
+			},
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 2)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[1].ID))
+				assert.NotEqual(t, "stable-id", store.cfg.MCP.Servers[1].ID)
+			},
+		},
+		{
+			name:      "no stored config still assigns ids",
+			storedCfg: nil,
+			payloadCfg: config.Config{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "Jira", BaseURL: "https://jira.example.com"},
+					},
+				},
+			},
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 1)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[0].ID))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: tt.storedCfg}
+			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+			body, err := json.Marshal(tt.payloadCfg)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			tt.validate(t, store)
+		})
+	}
+}
+
+// TestHandleSaveConfigPreservesOmittedPluginServers: full config save never
+// accepts client-provided plugin_servers — omitted and stale non-empty lists
+// both leave persisted plugin rows (and their IDs) untouched.
+func TestHandleSaveConfigPreservesOmittedPluginServers(t *testing.T) {
+	pluginA := "abcdefghijklmnopqrstuvwx0a"
+	pluginB := "abcdefghijklmnopqrstuvwx0b"
+	embeddedID := "abcdefghijklmnopqrstuvwx0e"
+	remoteID := "abcdefghijklmnopqrstuvwx0r"
+
+	storedPlugins := []config.PluginServerConfig{
+		{ID: pluginA, PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true},
+		{ID: pluginB, PluginID: "com.example.b", Name: "B", Path: "/other", Enabled: false},
+	}
+
+	tests := []struct {
+		name    string
+		mcp     map[string]any
+		wantIDs []string
+	}{
+		{
+			name: "omitted plugin_servers preserves prev",
+			mcp: map[string]any{
+				"enabled": true,
+				"servers": []map[string]any{
+					{"name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
+				},
+				"embeddedServer": map[string]any{"enabled": true},
+			},
+			wantIDs: []string{pluginA, pluginB},
+		},
+		{
+			name: "stale non-empty plugin_servers ignored",
+			mcp: map[string]any{
+				"enabled": true,
+				"servers": []map[string]any{
+					{"name": "Remote", "baseURL": "https://mcp.example.com", "enabled": true},
+				},
+				"embeddedServer": map[string]any{"enabled": true},
+				"plugin_servers": []map[string]any{
+					{
+						"id": "attackeridattackeridattack", "plugin_id": "com.example.a",
+						"name": "Hacked", "path": "/evil", "enabled": false,
+					},
+				},
+			},
+			wantIDs: []string{pluginA, pluginB},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: &config.Config{
+				MCP: config.MCPConfig{
+					Enabled: true,
+					Servers: []config.MCPServerConfig{
+						{ID: remoteID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
+					},
+					EmbeddedServer: config.MCPEmbeddedServerConfig{ID: embeddedID, Enabled: true},
+					PluginServers:  append([]config.PluginServerConfig(nil), storedPlugins...),
+				},
+			}}
+			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+			body, err := json.Marshal(map[string]any{"mcp": tt.mcp})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			require.Len(t, store.cfg.MCP.PluginServers, len(tt.wantIDs))
+			for i, id := range tt.wantIDs {
+				assert.Equal(t, id, store.cfg.MCP.PluginServers[i].ID)
+				assert.Equal(t, storedPlugins[i].PluginID, store.cfg.MCP.PluginServers[i].PluginID)
+				assert.Equal(t, storedPlugins[i].Name, store.cfg.MCP.PluginServers[i].Name)
+				assert.Equal(t, storedPlugins[i].Path, store.cfg.MCP.PluginServers[i].Path)
+				assert.Equal(t, storedPlugins[i].Enabled, store.cfg.MCP.PluginServers[i].Enabled)
+			}
+			assert.Equal(t, remoteID, store.cfg.MCP.Servers[0].ID)
+			assert.Equal(t, embeddedID, store.cfg.MCP.EmbeddedServer.ID)
+		})
+	}
+}
+
+func TestHandleSaveConfigRejectsCrossKindMCPIDConflict(t *testing.T) {
+	sharedID := "abcdefghijklmnopqrstuvwxzz"
+	store := &testConfigStore{cfg: &config.Config{
+		MCP: config.MCPConfig{
+			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+		},
+	}}
+	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+	payload := config.Config{
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServerConfig{
+				{ID: sharedID, Name: "Remote", BaseURL: "https://mcp.example.com", Enabled: true},
+			},
+			EmbeddedServer: config.MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestHandleSaveConfigCarriesForwardServiceIDs mirrors the MCP server ID
+// reconciliation for LLM services: service IDs are ABAC policy identities, so
+// an ID-less payload from a stale client must reclaim the stored ID instead
+// of rotating it (which would silently detach the service's policy), and
+// unresolvable identities must fail with 409.
+func TestHandleSaveConfigCarriesForwardServiceIDs(t *testing.T) {
+	stored := func() *config.Config {
+		return &config.Config{
+			Services: []llm.ServiceConfig{
+				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		storedCfg       *config.Config
+		payloadServices []llm.ServiceConfig
+		expectedStatus  int
+		validate        func(t *testing.T, store *testConfigStore)
+	}{
+		{
+			name:      "payload without id keeps stored id (stale client)",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
+			},
+		},
+		{
+			name:      "repeated ID-less saves never rotate the id",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "anthropic", APIURL: "https://edited.example.com"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
+			},
+		},
+		{
+			name:      "brand-new service without match gets a fresh id from the backstop",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{ID: "stable-svc-id", Name: "OpenAI", Type: "openai"},
+				{Name: "Brand New", Type: "anthropic"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 2)
+				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID)
+				assert.True(t, model.IsValidId(store.cfg.Services[1].ID))
+			},
+		},
+		{
+			name:      "fabricated incoming ID returns 409",
+			storedCfg: stored(),
+			payloadServices: []llm.ServiceConfig{
+				{ID: "invented-by-client", Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusConflict,
+			validate: func(t *testing.T, store *testConfigStore) {
+				assert.Equal(t, "stable-svc-id", store.cfg.Services[0].ID, "stored config must be untouched on rejection")
+			},
+		},
+		{
+			name:      "no stored config still assigns ids",
+			storedCfg: nil,
+			payloadServices: []llm.ServiceConfig{
+				{Name: "OpenAI", Type: "openai"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.Services, 1)
+				assert.True(t, model.IsValidId(store.cfg.Services[0].ID))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: tt.storedCfg}
+			router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+			body, err := json.Marshal(config.Config{Services: tt.payloadServices})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validate != nil {
+				tt.validate(t, store)
+			}
+		})
+	}
+}
+
+// TestHandleSaveConfigRejectsMCPServerIDConflicts covers stale or corrupt
+// admin payloads whose MCP server identities cannot be reconciled with the
+// stored config: the save must fail with 409 (never silently re-mint IDs,
+// which would detach existing policies), while legitimate add/edit flows
+// still succeed.
+func TestHandleSaveConfigRejectsMCPServerIDConflicts(t *testing.T) {
+	storedServer := config.MCPServerConfig{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"}
+	storedOther := config.MCPServerConfig{ID: "other-id", Name: "Linear", BaseURL: "https://linear.example.com"}
+
+	tests := []struct {
+		name           string
+		payloadServers []config.MCPServerConfig
+		expectedStatus int
+		validate       func(t *testing.T, store *testConfigStore)
+	}{
+		{
+			name: "fabricated incoming ID returns 409",
+			payloadServers: []config.MCPServerConfig{
+				{ID: "invented-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name: "duplicate incoming IDs return 409",
+			payloadServers: []config.MCPServerConfig{
+				{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+				{ID: "stable-id", Name: "Copy", BaseURL: "https://copy.example.com"},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name: "ambiguous ID-less identity match returns 409",
+			payloadServers: []config.MCPServerConfig{
+				// Name matches Linear, BaseURL matches Jira: never guess.
+				{Name: "Linear", BaseURL: "https://jira.example.com"},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name: "add flow: new ID-less server minted server-side",
+			payloadServers: []config.MCPServerConfig{
+				{ID: "stable-id", Name: "Jira", BaseURL: "https://jira.example.com"},
+				{ID: "other-id", Name: "Linear", BaseURL: "https://linear.example.com"},
+				{Name: "Brand New", BaseURL: "https://new.example.com"},
+			},
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, store *testConfigStore) {
+				require.Len(t, store.cfg.MCP.Servers, 3)
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID)
+				assert.Equal(t, "other-id", store.cfg.MCP.Servers[1].ID)
+				assert.True(t, model.IsValidId(store.cfg.MCP.Servers[2].ID), "new server gets a server-minted ID")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := &config.Config{
+				MCP: config.MCPConfig{Servers: []config.MCPServerConfig{storedServer, storedOther}},
+			}
+			store := &testConfigStore{cfg: stored}
+			updater := &testConfigUpdater{}
+			notifier := &testClusterNotifier{}
+			router := setupTestRouter(store, updater, notifier)
+
+			body, err := json.Marshal(config.Config{
+				MCP: config.MCPConfig{Servers: tt.payloadServers},
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedStatus == http.StatusConflict {
+				assert.Equal(t, "stable-id", store.cfg.MCP.Servers[0].ID, "stored config must be untouched on rejection")
+				assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
+				assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
+			}
+			if tt.validate != nil {
+				tt.validate(t, store)
+			}
+		})
+	}
+}
+
+// TestHandleSaveConfigFirstWriteIncomingMCPIDs covers the first-write path
+// (no stored config yet): reconciliation must still run against an empty
+// previous list, so duplicate incoming MCP server IDs are rejected, while
+// caller-chosen IDs for genuinely new servers (API automation seeding a
+// fresh install) are kept.
+func TestHandleSaveConfigFirstWriteIncomingMCPIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		payloadServers []config.MCPServerConfig
+		expectedStatus int
+	}{
+		{
+			name: "caller-chosen ID on first write is kept",
+			payloadServers: []config.MCPServerConfig{
+				{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "duplicate IDs on first write",
+			payloadServers: []config.MCPServerConfig{
+				{ID: "seeded-by-client", Name: "Jira", BaseURL: "https://jira.example.com"},
+				{ID: "seeded-by-client", Name: "Copy", BaseURL: "https://copy.example.com"},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &testConfigStore{cfg: nil}
+			updater := &testConfigUpdater{}
+			notifier := &testClusterNotifier{}
+			router := setupTestRouter(store, updater, notifier)
+
+			body, err := json.Marshal(config.Config{
+				MCP: config.MCPConfig{Servers: tt.payloadServers},
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedStatus == http.StatusConflict {
+				assert.Nil(t, store.cfg, "nothing must be persisted on rejection")
+				assert.Equal(t, 0, updater.callCount)
+				assert.Equal(t, 0, notifier.callCount)
+			} else {
+				require.NotNil(t, store.cfg)
+				require.Len(t, store.cfg.MCP.Servers, len(tt.payloadServers))
+				assert.Equal(t, tt.payloadServers[0].ID, store.cfg.MCP.Servers[0].ID)
+			}
+		})
+	}
+}
+
+// TestHandleSaveConfigReturnsNormalizedConfig verifies the PUT response body
+// carries the normalized saved config, so the webapp can adopt server-minted
+// service and MCP server IDs immediately instead of waiting for a reload.
+func TestHandleSaveConfigReturnsNormalizedConfig(t *testing.T) {
+	store := &testConfigStore{}
+	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+	payload := config.Config{
+		Services: []llm.ServiceConfig{{Name: "OpenAI", Type: "openai"}},
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServerConfig{{Name: "Jira", BaseURL: "https://jira.example.com"}},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp config.Config
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Services, 1)
+	assert.True(t, model.IsValidId(resp.Services[0].ID), "response must carry the server-minted service ID")
+	assert.Equal(t, store.cfg.Services[0].ID, resp.Services[0].ID, "response ID must match the persisted one")
+
+	require.Len(t, resp.MCP.Servers, 1)
+	assert.True(t, model.IsValidId(resp.MCP.Servers[0].ID), "response must carry the server-minted MCP server ID")
+	assert.Equal(t, store.cfg.MCP.Servers[0].ID, resp.MCP.Servers[0].ID, "response ID must match the persisted one")
+
+	assert.True(t, resp.Services[0].UseResponsesAPI, "response must reflect normalization")
+}
+
+// TestHandleSaveConfigRejectsStaleLegacyServiceIDs covers the interleaving
+// where a pre-upgrade webapp bundle loaded the config before the ID migration
+// ran and then saves UUID service IDs back: the save must fail with 409 and
+// leave the migrated config untouched, while a fresh payload is accepted.
+func TestHandleSaveConfigRejectsStaleLegacyServiceIDs(t *testing.T) {
+	migrated := &config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "migrated26charidmigrated26", Name: "OpenAI", Type: "openai"},
+		},
+	}
+	store := &testConfigStore{cfg: migrated, serviceIDMigrationDone: true}
+	updater := &testConfigUpdater{}
+	notifier := &testClusterNotifier{}
+	router := setupTestRouter(store, updater, notifier)
+
+	put := func(cfg config.Config) *httptest.ResponseRecorder {
+		body, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Stale payload echoing a pre-migration UUID service ID.
+	stale := config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "550e8400-e29b-41d4-a716-446655440000", Name: "OpenAI", Type: "openai"},
+		},
+	}
+	w := put(stale)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Equal(t, "migrated26charidmigrated26", store.cfg.Services[0].ID, "migrated ID must survive the stale save")
+	assert.Equal(t, 0, updater.callCount, "in-memory config must not be updated on rejection")
+	assert.Equal(t, 0, notifier.callCount, "cluster must not be notified on rejection")
+
+	// Fresh payload with the migrated ID is accepted.
+	fresh := config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: "migrated26charidmigrated26", Name: "OpenAI Renamed", Type: "openai"},
+		},
+	}
+	w = put(fresh)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "OpenAI Renamed", store.cfg.Services[0].Name)
+	assert.Equal(t, 1, updater.callCount)
+	assert.Equal(t, 1, notifier.callCount)
+}
+
 func TestSaveAndGetConfigRoundTrip(t *testing.T) {
 	store := &testConfigStore{}
 	updater := &testConfigUpdater{}
@@ -443,11 +1112,12 @@ func TestSaveAndGetConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, emptyCfg.Services)
 
-	// Step 2: PUT a config
+	// Step 2: PUT a config. The new service arrives ID-less (the backend
+	// mints the stable ID); an unknown incoming ID would be rejected.
 	saveCfg := config.Config{
 		DefaultBotName: "ai",
 		Services: []llm.ServiceConfig{
-			{ID: "svc-1", Name: "OpenAI", Type: "openai", APIKey: "sk-test"},
+			{Name: "OpenAI", Type: "openai", APIKey: "sk-test"},
 		},
 		Bots: []llm.BotConfig{
 			{ID: "bot-1", Name: "ai", ServiceID: "svc-1"},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -151,7 +151,7 @@ type mockMCPClientManager struct {
 	ensureSessionCreated          bool
 
 	registerCalls   []mcp.PluginServerConfig
-	updateCalls     []mcp.PluginServerConfig
+	adminPatchCalls []mcp.PluginServerConfig
 	unregisterCalls []string
 	pluginServers   []mcp.PluginServerConfig
 	// orphanPluginIDs simulates entries present in pluginServers but with
@@ -168,6 +168,8 @@ type mockMCPClientManager struct {
 	// Plugin discovery runs concurrently, so its bookkeeping is guarded.
 	discoverMu                   sync.Mutex
 	discoverPluginToolsCallCount int
+
+	httpClient *http.Client
 }
 
 func newTestMCPClientManager(t *testing.T) *mockMCPClientManager {
@@ -250,12 +252,9 @@ func (m *mockMCPClientManager) GetConfig() mcp.Config {
 
 func (m *mockMCPClientManager) RegisterPluginServer(cfg mcp.PluginServerConfig) {
 	m.registerCalls = append(m.registerCalls, cfg)
-	delete(m.orphanPluginIDs, cfg.PluginID)
-	m.storePluginServer(cfg)
-}
-
-func (m *mockMCPClientManager) UpdatePluginServer(cfg mcp.PluginServerConfig) {
-	m.updateCalls = append(m.updateCalls, cfg)
+	if m.orphanPluginIDs != nil {
+		delete(m.orphanPluginIDs, cfg.PluginID)
+	}
 	m.storePluginServer(cfg)
 }
 
@@ -269,6 +268,20 @@ func (m *mockMCPClientManager) storePluginServer(cfg mcp.PluginServerConfig) {
 	m.pluginServers = append(m.pluginServers, cfg)
 }
 
+func (m *mockMCPClientManager) UpdatePluginServerAdminFields(pluginID string, enabled bool, toolConfigs []mcp.ToolConfig) (mcp.PluginServerConfig, bool) {
+	// Mirror real ClientManager: patch only admin-owned fields on the live entry.
+	for i, existing := range m.pluginServers {
+		if existing.PluginID == pluginID {
+			existing.Enabled = enabled
+			existing.ToolConfigs = toolConfigs
+			m.pluginServers[i] = existing
+			m.adminPatchCalls = append(m.adminPatchCalls, existing)
+			return existing, true
+		}
+	}
+	return mcp.PluginServerConfig{}, false
+}
+
 func (m *mockMCPClientManager) UnregisterPluginServer(pluginID string) {
 	m.unregisterCalls = append(m.unregisterCalls, pluginID)
 	for i, existing := range m.pluginServers {
@@ -280,8 +293,13 @@ func (m *mockMCPClientManager) UnregisterPluginServer(pluginID string) {
 }
 
 func (m *mockMCPClientManager) ListPluginServers() []mcp.PluginServerConfig {
-	out := make([]mcp.PluginServerConfig, len(m.pluginServers))
-	copy(out, m.pluginServers)
+	out := make([]mcp.PluginServerConfig, 0, len(m.pluginServers))
+	for _, cfg := range m.pluginServers {
+		if m.orphanPluginIDs != nil && m.orphanPluginIDs[cfg.PluginID] {
+			continue
+		}
+		out = append(out, cfg)
+	}
 	return out
 }
 
@@ -292,18 +310,6 @@ func (m *mockMCPClientManager) GetPluginServer(pluginID string) (mcp.PluginServe
 		}
 	}
 	return mcp.PluginServerConfig{}, false
-}
-
-func (m *mockMCPClientManager) IsPluginRegistered(pluginID string) bool {
-	if m.orphanPluginIDs[pluginID] {
-		return false
-	}
-	for _, existing := range m.pluginServers {
-		if existing.PluginID == pluginID {
-			return true
-		}
-	}
-	return false
 }
 
 func (m *mockMCPClientManager) DiscoverPluginServerTools(ctx context.Context, userID string, cfg mcp.PluginServerConfig) ([]mcp.ToolInfo, error) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -168,8 +168,6 @@ type mockMCPClientManager struct {
 	// Plugin discovery runs concurrently, so its bookkeeping is guarded.
 	discoverMu                   sync.Mutex
 	discoverPluginToolsCallCount int
-
-	httpClient *http.Client
 }
 
 func newTestMCPClientManager(t *testing.T) *mockMCPClientManager {

--- a/api/audit_middleware_test.go
+++ b/api/audit_middleware_test.go
@@ -129,17 +129,22 @@ func TestAuditMiddlewareSaveConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "prior-config read failure still saves and audits, omitting changed_keys",
+			// Atomic UpdateConfig must read the prior config to reconcile
+			// stable service/MCP server IDs. A blind save would risk rotating
+			// identities and detaching ABAC policies, so fail closed.
+			name:           "prior-config read failure records a 500 fail, omitting changed_keys",
 			userID:         "userid",
 			isAdmin:        true,
 			body:           requestBody,
 			getErr:         errors.New("kv read exploded"),
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusInternalServerError,
 			validateRecord: func(t *testing.T, rec *model.AuditRecord) {
-				assert.Equal(t, model.AuditStatusSuccess, rec.Status)
+				assert.Equal(t, model.AuditStatusFail, rec.Status)
+				assert.Equal(t, http.StatusInternalServerError, rec.Error.Code)
 				assert.NotContains(t, rec.EventData.Parameters, "changed_keys",
-					"best-effort diff must be omitted, not fabricated, when the prior config is unreadable")
-				assert.Equal(t, true, rec.EventData.Parameters["persisted"])
+					"diff must be omitted when the prior config is unreadable")
+				assert.NotContains(t, rec.EventData.Parameters, "persisted",
+					"a save that never landed must not claim persistence")
 			},
 		},
 		{

--- a/config/legacy_migrations.go
+++ b/config/legacy_migrations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // LegacyServiceConfig represents the old config.json format with the legacy service fields.
@@ -75,7 +76,7 @@ func MigrateServicesToBots(cfg Config, loadLegacyConfig func() (LegacyServiceCon
 	existingConfig.Services = make([]llm.ServiceConfig, 0, len(oldConfig.Config.Services))
 	for _, service := range oldConfig.Config.Services {
 		existingConfig.Services = append(existingConfig.Services, llm.ServiceConfig{
-			ID:              uuid.New().String(),
+			ID:              model.NewId(),
 			Name:            service.Name,
 			Type:            service.ServiceName,
 			DefaultModel:    service.DefaultModel,
@@ -149,7 +150,7 @@ func MigrateSeparateServicesFromBots(cfg Config) (Config, bool, error) {
 		}
 
 		// Generate service ID
-		serviceID := uuid.New().String()
+		serviceID := generateServiceID()
 
 		// Check if similar service already exists (deduplication)
 		existingID := findIdenticalService(serviceMap, bot.Service)
@@ -209,6 +210,12 @@ func RunAllLegacyMigrations(cfg Config, loadLegacyConfig func() (LegacyServiceCo
 	}
 
 	return cfg, changed, nil
+}
+
+// generateServiceID returns a Mattermost-style 26-char service ID. Service IDs
+// are ABAC policy identities; config-bot IDs (below) intentionally stay UUIDs.
+func generateServiceID() string {
+	return model.NewId()
 }
 
 // findIdenticalService checks if a service with identical configuration already exists.

--- a/config/legacy_migrations_test.go
+++ b/config/legacy_migrations_test.go
@@ -9,9 +9,16 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateServiceID(t *testing.T) {
+	id := generateServiceID()
+	assert.True(t, model.IsValidId(id), "generated service ID %q must be a valid Mattermost ID", id)
+	assert.NotEqual(t, id, generateServiceID(), "IDs must be unique")
+}
 
 func TestMigrateSeparateServicesFromBots(t *testing.T) {
 	tests := []struct {
@@ -116,6 +123,7 @@ func TestMigrateSeparateServicesFromBots(t *testing.T) {
 				assert.Equal(t, llm.ServiceTypeOpenAI, result.Services[0].Type)
 				assert.Equal(t, "key1", result.Services[0].APIKey)
 				assert.Equal(t, "gpt-4", result.Services[0].DefaultModel)
+				assert.True(t, model.IsValidId(result.Services[0].ID), "extracted service ID must be a valid Mattermost ID")
 
 				require.Len(t, result.Bots, 1)
 				assert.Equal(t, result.Services[0].ID, result.Bots[0].ServiceID)
@@ -922,7 +930,7 @@ func TestMigrateServicesToBots(t *testing.T) {
 				assert.Equal(t, "org-123", result.Services[0].OrgID)
 				assert.Equal(t, "sk-test-key", result.Services[0].APIKey)
 				assert.Equal(t, 4000, result.Services[0].InputTokenLimit)
-				assert.NotEmpty(t, result.Services[0].ID)
+				assert.True(t, model.IsValidId(result.Services[0].ID), "migrated service ID must be a valid Mattermost ID")
 
 				require.Len(t, result.Bots, 1)
 				assert.Equal(t, "ai1", result.Bots[0].Name)

--- a/config/mcp_config.go
+++ b/config/mcp_config.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"net/textproto"
 	"strings"
 )
@@ -12,7 +14,17 @@ const (
 	MCPToolPolicyAsk               = "ask"
 	MCPToolPolicyAutoRunInDM       = "auto_run_in_dm"
 	MCPToolPolicyAutoRunEverywhere = "auto_run_everywhere"
+
+	// MCPEmbeddedServerOrigin is the runtime ServerOrigin for the embedded
+	// Mattermost MCP server (matches mcp.EmbeddedClientKey).
+	MCPEmbeddedServerOrigin = "embedded://mattermost"
 )
+
+// PluginServerOrigin returns the runtime ServerOrigin for a plugin-registered
+// MCP server. Identity is keyed by PluginID only — Path is not part of the origin.
+func PluginServerOrigin(pluginID string) string {
+	return "plugin://" + pluginID
+}
 
 // MCPToolConfig represents per-tool configuration for an MCP server.
 type MCPToolConfig struct {
@@ -37,6 +49,10 @@ func IsToolPolicyAutoRunEverywhere(policy string) bool {
 
 // MCPEmbeddedServerConfig contains configuration for the embedded MCP server
 type MCPEmbeddedServerConfig struct {
+	// ID is the immutable plugin-assigned ABAC policy identity. It survives
+	// enablement/tool-config edits and is never reused. Runtime tool origin
+	// is MCPEmbeddedServerOrigin.
+	ID          string          `json:"id,omitempty"`
 	Enabled     bool            `json:"enabled"`
 	ToolConfigs []MCPToolConfig `json:"tool_configs,omitempty"`
 }
@@ -53,6 +69,10 @@ type MCPConfig struct {
 
 // MCPServerConfig contains the configuration for a single MCP server
 type MCPServerConfig struct {
+	// ID is the immutable plugin-assigned ABAC policy identity: it survives
+	// Name/BaseURL edits and is never reused. OAuth keying (Name) and runtime
+	// tool origin (BaseURL) are separate identity systems.
+	ID      string            `json:"id,omitempty"`
 	Name    string            `json:"name"`
 	Enabled bool              `json:"enabled"`
 	BaseURL string            `json:"baseURL"`
@@ -153,8 +173,310 @@ func (s *MCPServerConfig) HasServiceAccountAuth() bool {
 	return len(s.EffectiveServiceAccountHeaders()) > 0
 }
 
+// ServerIDByOrigin maps a runtime ServerOrigin to the stable server ID.
+// Origins are BaseURL (external), MCPEmbeddedServerOrigin (embedded), or
+// PluginServerOrigin(PluginID) (plugin). ID-less servers are omitted; on
+// duplicate origins the last entry wins (matching filterToolsByConfig);
+// disabled servers are included because policy CRUD needs the mapping
+// regardless of enablement.
+func (c *MCPConfig) ServerIDByOrigin() map[string]string {
+	out := make(map[string]string, len(c.Servers)+len(c.PluginServers)+1)
+	for i := range c.Servers {
+		if c.Servers[i].ID == "" {
+			continue
+		}
+		out[c.Servers[i].BaseURL] = c.Servers[i].ID
+	}
+	if c.EmbeddedServer.ID != "" {
+		out[MCPEmbeddedServerOrigin] = c.EmbeddedServer.ID
+	}
+	for i := range c.PluginServers {
+		if c.PluginServers[i].ID == "" || c.PluginServers[i].PluginID == "" {
+			continue
+		}
+		out[PluginServerOrigin(c.PluginServers[i].PluginID)] = c.PluginServers[i].ID
+	}
+	return out
+}
+
+// OriginByServerID is the inverse of ServerIDByOrigin: stable ID -> current origin.
+func (c *MCPConfig) OriginByServerID() map[string]string {
+	out := make(map[string]string, len(c.Servers)+len(c.PluginServers)+1)
+	for i := range c.Servers {
+		if c.Servers[i].ID == "" {
+			continue
+		}
+		out[c.Servers[i].ID] = c.Servers[i].BaseURL
+	}
+	if c.EmbeddedServer.ID != "" {
+		out[c.EmbeddedServer.ID] = MCPEmbeddedServerOrigin
+	}
+	for i := range c.PluginServers {
+		if c.PluginServers[i].ID == "" || c.PluginServers[i].PluginID == "" {
+			continue
+		}
+		out[c.PluginServers[i].ID] = PluginServerOrigin(c.PluginServers[i].PluginID)
+	}
+	return out
+}
+
+// ErrMCPServerIDConflict is the base error for every identity problem
+// ReconcileMCPConfigIDs / kind-specific reconcilers can detect; callers map
+// it to a client error (stale or corrupt admin console payload).
+var ErrMCPServerIDConflict = errors.New("MCP server identity conflict")
+
+// ReconcileMCPConfigIDs is the single entry point for MCP identity on config
+// save. It:
+//
+//  1. Treats PluginServers as server-owned: prev is carried forward
+//     unconditionally. Full config save never accepts client-provided plugin
+//     rows (bridge register/unregister and PUT /admin/mcp/plugin-servers/:id
+//     are the only writers).
+//  2. Runs kind-specific ID carry-forward for remote and embedded servers.
+//  3. Rejects any ID shared by two MCP resources of any kind.
+func ReconcileMCPConfigIDs(next, prev MCPConfig) (MCPConfig, error) {
+	next.PluginServers = append([]PluginServerConfig(nil), prev.PluginServers...)
+
+	servers, err := ReconcileMCPServerIDs(next.Servers, prev.Servers)
+	if err != nil {
+		return MCPConfig{}, err
+	}
+	next.Servers = servers
+
+	embedded, err := ReconcileEmbeddedMCPServerID(next.EmbeddedServer, prev.EmbeddedServer)
+	if err != nil {
+		return MCPConfig{}, err
+	}
+	next.EmbeddedServer = embedded
+
+	if err := ValidateMCPServerIDUniqueness(next); err != nil {
+		return MCPConfig{}, err
+	}
+	return next, nil
+}
+
+// OccupiedMCPServerIDs returns every non-empty MCP resource ID across remote,
+// embedded, and plugin entries. Used by mint paths to avoid cross-kind collisions.
+func OccupiedMCPServerIDs(cfg MCPConfig) map[string]struct{} {
+	out := make(map[string]struct{}, len(cfg.Servers)+len(cfg.PluginServers)+1)
+	for i := range cfg.Servers {
+		if id := cfg.Servers[i].ID; id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	if id := cfg.EmbeddedServer.ID; id != "" {
+		out[id] = struct{}{}
+	}
+	for i := range cfg.PluginServers {
+		if id := cfg.PluginServers[i].ID; id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
+// ValidateMCPServerIDUniqueness returns ErrMCPServerIDConflict when any two
+// MCP resources (remote, embedded, or plugin) share the same non-empty ID.
+func ValidateMCPServerIDUniqueness(cfg MCPConfig) error {
+	seen := make(map[string]string, len(cfg.Servers)+len(cfg.PluginServers)+1)
+	claim := func(id, label string) error {
+		if id == "" {
+			return nil
+		}
+		if other, ok := seen[id]; ok {
+			return fmt.Errorf("%w: %s and %s share ID %q", ErrMCPServerIDConflict, other, label, id)
+		}
+		seen[id] = label
+		return nil
+	}
+	for i := range cfg.Servers {
+		label := fmt.Sprintf("remote server %q", cfg.Servers[i].Name)
+		if err := claim(cfg.Servers[i].ID, label); err != nil {
+			return err
+		}
+	}
+	if err := claim(cfg.EmbeddedServer.ID, "embedded server"); err != nil {
+		return err
+	}
+	for i := range cfg.PluginServers {
+		label := fmt.Sprintf("plugin server %q", cfg.PluginServers[i].PluginID)
+		if err := claim(cfg.PluginServers[i].ID, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReconcileMCPServerIDs carries stable IDs forward from prev onto ID-less
+// entries in next (e.g. from webapp bundles predating the ID field). Server
+// IDs are ABAC policy identities, so identity mistakes are never papered
+// over: minting a fresh ID for an existing server detaches its policy (which
+// fails open). Matching runs in global phases over the whole payload so the
+// outcome cannot depend on payload order; anything suspicious errors:
+//
+//  1. Explicit-ID claims: an ID found in prev claims that entry. An ID
+//     unknown to prev is accepted as a caller-chosen ID for a genuinely new
+//     server (admin-API automation seeds its own IDs) — unless the entry's
+//     Name or BaseURL matches a stored server, which means a stale or
+//     corrupt client is trying to swap an existing server's policy identity.
+//  2. Exact (Name, BaseURL) claims against the full stored list; claiming an
+//     already-claimed prev entry is an error, never a silent fallback.
+//  3. Weak claims against the unclaimed remainder: by unique Name or unique
+//     BaseURL; any ambiguity or double-claim is an error.
+//  4. Entries matching nothing stay ID-less; the caller mints a fresh ID.
+//
+// Each prev entry is claimed at most once across all phases.
+func ReconcileMCPServerIDs(next []MCPServerConfig, prev []MCPServerConfig) ([]MCPServerConfig, error) {
+	// Duplicate stored IDs mean the persisted config is already corrupt;
+	// keeping the last row would let two servers share one policy ID.
+	prevByID := make(map[string]int, len(prev))
+	for j := range prev {
+		id := prev[j].ID
+		if id == "" {
+			continue
+		}
+		if _, dup := prevByID[id]; dup {
+			return nil, fmt.Errorf("%w: stored configuration contains two servers with ID %q", ErrMCPServerIDConflict, id)
+		}
+		prevByID[id] = j
+	}
+
+	claimed := make([]bool, len(prev))
+
+	// Phase 1: entries arriving with an ID claim the prev entry holding it.
+	seenIncoming := make(map[string]bool, len(next))
+	for i := range next {
+		id := next[i].ID
+		if id == "" {
+			continue
+		}
+		if seenIncoming[id] {
+			return nil, fmt.Errorf("%w: server %q duplicates the ID of another entry in the payload", ErrMCPServerIDConflict, next[i].Name)
+		}
+		seenIncoming[id] = true
+		if j, ok := prevByID[id]; ok {
+			claimed[j] = true
+			continue
+		}
+		// Unknown ID: legitimate for a genuinely new server seeded by API
+		// automation. A Name or BaseURL collision with a stored
+		// (ID-carrying) server instead means a stale client is swapping
+		// that server's policy identity, which would detach its policy.
+		for k := range prev {
+			if prev[k].ID == "" {
+				continue
+			}
+			if prev[k].Name == next[i].Name || prev[k].BaseURL == next[i].BaseURL {
+				return nil, fmt.Errorf("%w: server %q carries ID %q that the stored configuration never issued", ErrMCPServerIDConflict, next[i].Name, id)
+			}
+		}
+	}
+
+	// Phase 2: exact (Name, BaseURL) claims, resolved for the whole payload
+	// before any weak claim so a weak match can never shadow an exact one.
+	exactMatch := make([]int, len(next))
+	for i := range next {
+		exactMatch[i] = -1
+		if next[i].ID != "" {
+			continue
+		}
+		candidate := -1
+		for j := range prev {
+			if prev[j].ID == "" || prev[j].Name != next[i].Name || prev[j].BaseURL != next[i].BaseURL {
+				continue
+			}
+			if candidate >= 0 {
+				return nil, fmt.Errorf("%w: server %q matches multiple identical stored servers", ErrMCPServerIDConflict, next[i].Name)
+			}
+			candidate = j
+		}
+		if candidate < 0 {
+			continue
+		}
+		if claimed[candidate] {
+			return nil, fmt.Errorf("%w: server %q claims a stored server another entry in the payload already claims", ErrMCPServerIDConflict, next[i].Name)
+		}
+		claimed[candidate] = true
+		exactMatch[i] = candidate
+	}
+	for i, j := range exactMatch {
+		if j >= 0 {
+			next[i].ID = prev[j].ID
+		}
+	}
+
+	// Phase 3: weak claims against the unclaimed remainder; every entry sees
+	// the same post-phase-2 snapshot, so this phase is order-independent too.
+	weakClaimed := make(map[int]bool, len(prev))
+	weakMatch := make([]int, len(next))
+	for i := range next {
+		weakMatch[i] = -1
+		if next[i].ID != "" {
+			continue
+		}
+
+		var nameMatches, urlMatches []int
+		for j := range prev {
+			if claimed[j] || prev[j].ID == "" {
+				continue
+			}
+			if prev[j].Name == next[i].Name {
+				nameMatches = append(nameMatches, j)
+			}
+			if prev[j].BaseURL == next[i].BaseURL {
+				urlMatches = append(urlMatches, j)
+			}
+		}
+
+		var match int
+		switch {
+		case len(nameMatches) == 0 && len(urlMatches) == 0:
+			// Genuinely new: no identity claim to resolve.
+			continue
+		case len(nameMatches) == 1 && len(urlMatches) == 0:
+			match = nameMatches[0]
+		case len(nameMatches) == 0 && len(urlMatches) == 1:
+			match = urlMatches[0]
+		default:
+			return nil, fmt.Errorf("%w: server %q ambiguously matches more than one stored server", ErrMCPServerIDConflict, next[i].Name)
+		}
+		if weakClaimed[match] {
+			return nil, fmt.Errorf("%w: server %q claims a stored server another entry in the payload already claims", ErrMCPServerIDConflict, next[i].Name)
+		}
+		weakClaimed[match] = true
+		weakMatch[i] = match
+	}
+	for i, j := range weakMatch {
+		if j >= 0 {
+			next[i].ID = prev[j].ID
+		}
+	}
+
+	return next, nil
+}
+
+// ReconcileEmbeddedMCPServerID carries the embedded server's stable ID forward
+// from prev onto an ID-less next. A non-empty next ID that differs from a
+// non-empty prev ID is a conflict (same ErrMCPServerIDConflict contract as
+// remote servers). Caller-chosen IDs on a previously ID-less embedded server
+// are kept; both empty leaves next ID-less for the caller to mint.
+func ReconcileEmbeddedMCPServerID(next, prev MCPEmbeddedServerConfig) (MCPEmbeddedServerConfig, error) {
+	if next.ID == "" {
+		next.ID = prev.ID
+		return next, nil
+	}
+	if prev.ID != "" && next.ID != prev.ID {
+		return MCPEmbeddedServerConfig{}, fmt.Errorf("%w: embedded server carries ID %q that differs from the stored ID %q", ErrMCPServerIDConflict, next.ID, prev.ID)
+	}
+	return next, nil
+}
+
 // PluginServerConfig describes an MCP server registered by another plugin.
 type PluginServerConfig struct {
+	// ID is the immutable plugin-assigned ABAC policy identity. Identity is
+	// keyed by PluginID: it survives re-registration and Path changes and is
+	// never reused. Runtime tool origin is PluginServerOrigin(PluginID).
+	ID             string          `json:"id,omitempty"`
 	PluginID       string          `json:"plugin_id"`
 	Name           string          `json:"name"`
 	Path           string          `json:"path"`

--- a/config/mcp_config.go
+++ b/config/mcp_config.go
@@ -220,9 +220,9 @@ func (c *MCPConfig) OriginByServerID() map[string]string {
 	return out
 }
 
-// ErrMCPServerIDConflict is the base error for every identity problem
-// ReconcileMCPConfigIDs / kind-specific reconcilers can detect; callers map
-// it to a client error (stale or corrupt admin console payload).
+// ErrMCPServerIDConflict is returned when the config being written contains
+// duplicate non-empty MCP server IDs, or when an incoming embedded server ID
+// differs from the stored ID.
 var ErrMCPServerIDConflict = errors.New("MCP server identity conflict")
 
 // ReconcileMCPConfigIDs is the single entry point for MCP identity on config
@@ -232,16 +232,13 @@ var ErrMCPServerIDConflict = errors.New("MCP server identity conflict")
 //     unconditionally. Full config save never accepts client-provided plugin
 //     rows (bridge register/unregister and PUT /admin/mcp/plugin-servers/:id
 //     are the only writers).
-//  2. Runs kind-specific ID carry-forward for remote and embedded servers.
-//  3. Rejects any ID shared by two MCP resources of any kind.
+//  2. Copies the embedded server ID from prev when next is empty. A
+//     non-empty next ID that differs from a non-empty prev ID is a conflict.
+//     Empty remote IDs stay empty for the caller to mint.
+//  3. Rejects any ID shared by two MCP resources of any kind on the config
+//     being written. Duplicate IDs in prev alone are not a conflict.
 func ReconcileMCPConfigIDs(next, prev MCPConfig) (MCPConfig, error) {
 	next.PluginServers = append([]PluginServerConfig(nil), prev.PluginServers...)
-
-	servers, err := ReconcileMCPServerIDs(next.Servers, prev.Servers)
-	if err != nil {
-		return MCPConfig{}, err
-	}
-	next.Servers = servers
 
 	embedded, err := ReconcileEmbeddedMCPServerID(next.EmbeddedServer, prev.EmbeddedServer)
 	if err != nil {
@@ -253,26 +250,6 @@ func ReconcileMCPConfigIDs(next, prev MCPConfig) (MCPConfig, error) {
 		return MCPConfig{}, err
 	}
 	return next, nil
-}
-
-// OccupiedMCPServerIDs returns every non-empty MCP resource ID across remote,
-// embedded, and plugin entries. Used by mint paths to avoid cross-kind collisions.
-func OccupiedMCPServerIDs(cfg MCPConfig) map[string]struct{} {
-	out := make(map[string]struct{}, len(cfg.Servers)+len(cfg.PluginServers)+1)
-	for i := range cfg.Servers {
-		if id := cfg.Servers[i].ID; id != "" {
-			out[id] = struct{}{}
-		}
-	}
-	if id := cfg.EmbeddedServer.ID; id != "" {
-		out[id] = struct{}{}
-	}
-	for i := range cfg.PluginServers {
-		if id := cfg.PluginServers[i].ID; id != "" {
-			out[id] = struct{}{}
-		}
-	}
-	return out
 }
 
 // ValidateMCPServerIDUniqueness returns ErrMCPServerIDConflict when any two
@@ -307,159 +284,11 @@ func ValidateMCPServerIDUniqueness(cfg MCPConfig) error {
 	return nil
 }
 
-// ReconcileMCPServerIDs carries stable IDs forward from prev onto ID-less
-// entries in next (e.g. from webapp bundles predating the ID field). Server
-// IDs are ABAC policy identities, so identity mistakes are never papered
-// over: minting a fresh ID for an existing server detaches its policy (which
-// fails open). Matching runs in global phases over the whole payload so the
-// outcome cannot depend on payload order; anything suspicious errors:
-//
-//  1. Explicit-ID claims: an ID found in prev claims that entry. An ID
-//     unknown to prev is accepted as a caller-chosen ID for a genuinely new
-//     server (admin-API automation seeds its own IDs) — unless the entry's
-//     Name or BaseURL matches a stored server, which means a stale or
-//     corrupt client is trying to swap an existing server's policy identity.
-//  2. Exact (Name, BaseURL) claims against the full stored list; claiming an
-//     already-claimed prev entry is an error, never a silent fallback.
-//  3. Weak claims against the unclaimed remainder: by unique Name or unique
-//     BaseURL; any ambiguity or double-claim is an error.
-//  4. Entries matching nothing stay ID-less; the caller mints a fresh ID.
-//
-// Each prev entry is claimed at most once across all phases.
-func ReconcileMCPServerIDs(next []MCPServerConfig, prev []MCPServerConfig) ([]MCPServerConfig, error) {
-	// Duplicate stored IDs mean the persisted config is already corrupt;
-	// keeping the last row would let two servers share one policy ID.
-	prevByID := make(map[string]int, len(prev))
-	for j := range prev {
-		id := prev[j].ID
-		if id == "" {
-			continue
-		}
-		if _, dup := prevByID[id]; dup {
-			return nil, fmt.Errorf("%w: stored configuration contains two servers with ID %q", ErrMCPServerIDConflict, id)
-		}
-		prevByID[id] = j
-	}
-
-	claimed := make([]bool, len(prev))
-
-	// Phase 1: entries arriving with an ID claim the prev entry holding it.
-	seenIncoming := make(map[string]bool, len(next))
-	for i := range next {
-		id := next[i].ID
-		if id == "" {
-			continue
-		}
-		if seenIncoming[id] {
-			return nil, fmt.Errorf("%w: server %q duplicates the ID of another entry in the payload", ErrMCPServerIDConflict, next[i].Name)
-		}
-		seenIncoming[id] = true
-		if j, ok := prevByID[id]; ok {
-			claimed[j] = true
-			continue
-		}
-		// Unknown ID: legitimate for a genuinely new server seeded by API
-		// automation. A Name or BaseURL collision with a stored
-		// (ID-carrying) server instead means a stale client is swapping
-		// that server's policy identity, which would detach its policy.
-		for k := range prev {
-			if prev[k].ID == "" {
-				continue
-			}
-			if prev[k].Name == next[i].Name || prev[k].BaseURL == next[i].BaseURL {
-				return nil, fmt.Errorf("%w: server %q carries ID %q that the stored configuration never issued", ErrMCPServerIDConflict, next[i].Name, id)
-			}
-		}
-	}
-
-	// Phase 2: exact (Name, BaseURL) claims, resolved for the whole payload
-	// before any weak claim so a weak match can never shadow an exact one.
-	exactMatch := make([]int, len(next))
-	for i := range next {
-		exactMatch[i] = -1
-		if next[i].ID != "" {
-			continue
-		}
-		candidate := -1
-		for j := range prev {
-			if prev[j].ID == "" || prev[j].Name != next[i].Name || prev[j].BaseURL != next[i].BaseURL {
-				continue
-			}
-			if candidate >= 0 {
-				return nil, fmt.Errorf("%w: server %q matches multiple identical stored servers", ErrMCPServerIDConflict, next[i].Name)
-			}
-			candidate = j
-		}
-		if candidate < 0 {
-			continue
-		}
-		if claimed[candidate] {
-			return nil, fmt.Errorf("%w: server %q claims a stored server another entry in the payload already claims", ErrMCPServerIDConflict, next[i].Name)
-		}
-		claimed[candidate] = true
-		exactMatch[i] = candidate
-	}
-	for i, j := range exactMatch {
-		if j >= 0 {
-			next[i].ID = prev[j].ID
-		}
-	}
-
-	// Phase 3: weak claims against the unclaimed remainder; every entry sees
-	// the same post-phase-2 snapshot, so this phase is order-independent too.
-	weakClaimed := make(map[int]bool, len(prev))
-	weakMatch := make([]int, len(next))
-	for i := range next {
-		weakMatch[i] = -1
-		if next[i].ID != "" {
-			continue
-		}
-
-		var nameMatches, urlMatches []int
-		for j := range prev {
-			if claimed[j] || prev[j].ID == "" {
-				continue
-			}
-			if prev[j].Name == next[i].Name {
-				nameMatches = append(nameMatches, j)
-			}
-			if prev[j].BaseURL == next[i].BaseURL {
-				urlMatches = append(urlMatches, j)
-			}
-		}
-
-		var match int
-		switch {
-		case len(nameMatches) == 0 && len(urlMatches) == 0:
-			// Genuinely new: no identity claim to resolve.
-			continue
-		case len(nameMatches) == 1 && len(urlMatches) == 0:
-			match = nameMatches[0]
-		case len(nameMatches) == 0 && len(urlMatches) == 1:
-			match = urlMatches[0]
-		default:
-			return nil, fmt.Errorf("%w: server %q ambiguously matches more than one stored server", ErrMCPServerIDConflict, next[i].Name)
-		}
-		if weakClaimed[match] {
-			return nil, fmt.Errorf("%w: server %q claims a stored server another entry in the payload already claims", ErrMCPServerIDConflict, next[i].Name)
-		}
-		weakClaimed[match] = true
-		weakMatch[i] = match
-	}
-	for i, j := range weakMatch {
-		if j >= 0 {
-			next[i].ID = prev[j].ID
-		}
-	}
-
-	return next, nil
-}
-
-// ReconcileEmbeddedMCPServerID carries the embedded server's stable ID forward
-// from prev onto an ID-less next. A non-empty next ID that differs from a
-// non-empty prev ID is a conflict (same ErrMCPServerIDConflict contract as
-// remote servers). Caller-chosen IDs on a previously ID-less embedded server
-// are kept; both empty leaves next ID-less for the caller to mint.
+// ReconcileEmbeddedMCPServerID copies prev.ID onto an ID-less next (one
+// embedded server, not a list heuristic). A non-empty next ID that differs
+// from a non-empty prev ID is a conflict. Caller-chosen IDs on a previously
+// ID-less embedded server are kept; both empty leaves next ID-less for the
+// caller to mint.
 func ReconcileEmbeddedMCPServerID(next, prev MCPEmbeddedServerConfig) (MCPEmbeddedServerConfig, error) {
 	if next.ID == "" {
 		next.ID = prev.ID

--- a/config/mcp_config_test.go
+++ b/config/mcp_config_test.go
@@ -76,12 +76,9 @@ func TestMCPServerConfigServiceAccountHeaderFiltering(t *testing.T) {
 					"  X-Api-Key ":  " secret-token\n",
 				},
 			},
-			// Untrimmed names/values make Go's HTTP transport reject the request.
 			wantHeaders: map[string]string{"Authorization": "Bearer pat", "X-Api-Key": "secret-token"},
 		},
 		{
-			// Fail closed: an ambiguous pair has no deterministic winner, so the
-			// server ends up with no service account auth at all.
 			name: "names colliding after trim are all dropped",
 			serverConfig: &MCPServerConfig{
 				Enabled:               true,
@@ -97,8 +94,6 @@ func TestMCPServerConfigServiceAccountHeaderFiltering(t *testing.T) {
 			wantHeaders: map[string]string{"X-Api-Key": "secret-token"},
 		},
 		{
-			// http.Header.Set canonicalizes names, so a case-only pair is the same
-			// header on the wire and just as ambiguous as a whitespace-only pair.
 			name: "names colliding only by case are all dropped",
 			serverConfig: &MCPServerConfig{
 				Enabled:               true,
@@ -138,7 +133,6 @@ func TestMCPServerConfigServiceAccountHeaderFiltering(t *testing.T) {
 	}
 }
 
-// A broken JSON tag would make Config.Clone silently drop SA credentials cluster-wide.
 func TestConfigClonePreservesServiceAccountHeaders(t *testing.T) {
 	original := &Config{
 		MCP: MCPConfig{
@@ -154,12 +148,547 @@ func TestConfigClonePreservesServiceAccountHeaders(t *testing.T) {
 		},
 	}
 
-	// No Config-wide equality: the JSON deep copy normalizes nil json.RawMessage fields to "null".
 	clone := original.Clone()
 	require.Equal(t, original.MCP.Servers, clone.MCP.Servers)
 
 	clone.MCP.Servers[0].ServiceAccountHeaders["Authorization"] = "Bearer tampered"
 	require.Equal(t, "Bearer service-pat", original.MCP.Servers[0].ServiceAccountHeaders["Authorization"])
+}
+
+func TestMCPConfigServerIDMaps(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              MCPConfig
+		expectByOrigin   map[string]string
+		expectByServerID map[string]string
+	}{
+		{
+			name:             "empty servers",
+			cfg:              MCPConfig{},
+			expectByOrigin:   map[string]string{},
+			expectByServerID: map[string]string{},
+		},
+		{
+			name: "servers without IDs omitted",
+			cfg: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "id-one", Name: "one", BaseURL: "https://one.example.com"},
+					{Name: "no-id", BaseURL: "https://two.example.com"},
+				},
+			},
+			expectByOrigin:   map[string]string{"https://one.example.com": "id-one"},
+			expectByServerID: map[string]string{"id-one": "https://one.example.com"},
+		},
+		{
+			name: "duplicate BaseURL last entry wins",
+			cfg: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "id-first", Name: "first", BaseURL: "https://dup.example.com"},
+					{ID: "id-last", Name: "last", BaseURL: "https://dup.example.com"},
+				},
+			},
+			expectByOrigin: map[string]string{"https://dup.example.com": "id-last"},
+			expectByServerID: map[string]string{
+				"id-first": "https://dup.example.com",
+				"id-last":  "https://dup.example.com",
+			},
+		},
+		{
+			name: "disabled server included",
+			cfg: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "id-disabled", Name: "off", Enabled: false, BaseURL: "https://off.example.com"},
+				},
+			},
+			expectByOrigin:   map[string]string{"https://off.example.com": "id-disabled"},
+			expectByServerID: map[string]string{"id-disabled": "https://off.example.com"},
+		},
+		{
+			name: "embedded and plugin origins included",
+			cfg: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "id-remote", Name: "remote", BaseURL: "https://remote.example.com"},
+				},
+				EmbeddedServer: MCPEmbeddedServerConfig{ID: "id-embedded", Enabled: true},
+				PluginServers: []PluginServerConfig{
+					{ID: "id-plugin", PluginID: "com.example.mcp", Name: "Plugin", Path: "/mcp"},
+					{PluginID: "com.example.noid", Name: "No ID", Path: "/mcp"},
+				},
+			},
+			expectByOrigin: map[string]string{
+				"https://remote.example.com":          "id-remote",
+				MCPEmbeddedServerOrigin:               "id-embedded",
+				PluginServerOrigin("com.example.mcp"): "id-plugin",
+			},
+			expectByServerID: map[string]string{
+				"id-remote":   "https://remote.example.com",
+				"id-embedded": MCPEmbeddedServerOrigin,
+				"id-plugin":   PluginServerOrigin("com.example.mcp"),
+			},
+		},
+		{
+			name: "ID-less embedded omitted",
+			cfg: MCPConfig{
+				EmbeddedServer: MCPEmbeddedServerConfig{Enabled: true},
+			},
+			expectByOrigin:   map[string]string{},
+			expectByServerID: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectByOrigin, tt.cfg.ServerIDByOrigin())
+			require.Equal(t, tt.expectByServerID, tt.cfg.OriginByServerID())
+		})
+	}
+}
+
+func TestReconcileMCPServerIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		next      []MCPServerConfig
+		prev      []MCPServerConfig
+		expectIDs []string
+		expectErr bool
+	}{
+		{
+			name: "round-trip payload keeps existing ID",
+			next: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "match by name when URL edited",
+			next: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://new-url.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://old-url.example.com"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "match by BaseURL when renamed",
+			next: []MCPServerConfig{
+				{Name: "renamed", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "each prev entry consumed at most once",
+			next: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+				{Name: "other", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{"prev-id", ""},
+		},
+		{
+			name: "add flow: genuinely new entry stays ID-less for the caller to mint",
+			next: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://old.example.com"},
+				{Name: "brand-new", BaseURL: "https://new.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://old.example.com"},
+			},
+			expectIDs: []string{"prev-id", ""},
+		},
+		{
+			name: "delete flow: fewer entries than prev is not an error",
+			next: []MCPServerConfig{
+				{ID: "id-one", Name: "keep", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "id-one", Name: "keep", BaseURL: "https://one.example.com"},
+				{ID: "id-two", Name: "delete-me", BaseURL: "https://two.example.com"},
+			},
+			expectIDs: []string{"id-one"},
+		},
+		{
+			name: "prev entries without IDs cannot be claimed",
+			next: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{""},
+		},
+		{
+			name: "duplicate names reordered resolve by exact (Name, BaseURL)",
+			next: []MCPServerConfig{
+				{Name: "dup", BaseURL: "https://two.example.com"},
+				{Name: "dup", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
+				{ID: "id-two", Name: "dup", BaseURL: "https://two.example.com"},
+			},
+			expectIDs: []string{"id-two", "id-one"},
+		},
+		{
+			name: "explicit-ID claim and exact match competing across phases rejected",
+			next: []MCPServerConfig{
+				// The ID-less entry exactly matches the stored server the
+				// ID-bearing entry still holds: two entries strongly claiming
+				// one identity is a corrupt payload, never a guess.
+				{Name: "srv", BaseURL: "https://one.example.com"},
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "weak match earlier in the payload cannot steal a later exact match",
+			next: []MCPServerConfig{
+				// Payload order: the unique-Name weak match comes first, but
+				// the second entry is an exact (Name, BaseURL) round-trip of
+				// the stored server. Exact claims resolve globally before any
+				// weak claim, so the first entry stays new.
+				{Name: "srv", BaseURL: "https://moved.example.com"},
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{"", "prev-id"},
+		},
+		{
+			name: "two identical ID-less entries competing for one stored server rejected",
+			next: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "two weak claims resolving to the same stored server rejected",
+			next: []MCPServerConfig{
+				// First entry matches by unique Name, second by unique
+				// BaseURL — both resolve to the single stored server, and
+				// which one deserves the identity cannot be decided.
+				{Name: "srv", BaseURL: "https://a.example.com"},
+				{Name: "other", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "first write: ID-less entries stay ID-less for the caller to mint",
+			next: []MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev:      nil,
+			expectIDs: []string{""},
+		},
+		{
+			name: "duplicate incoming IDs rejected",
+			next: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+				{ID: "prev-id", Name: "copy", BaseURL: "https://two.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "unknown ID colliding with a stored server identity rejected",
+			next: []MCPServerConfig{
+				{ID: "never-issued-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "unknown ID with unique name and URL is kept (API automation)",
+			next: []MCPServerConfig{
+				{ID: "seeded-by-automation", Name: "new-srv", BaseURL: "https://new.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			expectIDs: []string{"seeded-by-automation"},
+		},
+		{
+			name: "caller-chosen IDs on first write are kept",
+			next: []MCPServerConfig{
+				{ID: "seeded-by-automation", Name: "srv", BaseURL: "https://one.example.com"},
+			},
+			prev:      nil,
+			expectIDs: []string{"seeded-by-automation"},
+		},
+		{
+			name: "rename plus URL-change crossing two prev servers rejected",
+			next: []MCPServerConfig{
+				// Name matches prev B, BaseURL matches prev A: never guess.
+				{Name: "beta", BaseURL: "https://alpha.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "id-alpha", Name: "alpha", BaseURL: "https://alpha.example.com"},
+				{ID: "id-beta", Name: "beta", BaseURL: "https://beta.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "multiple name matches with no exact match rejected",
+			next: []MCPServerConfig{
+				{Name: "dup", BaseURL: "https://three.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
+				{ID: "id-two", Name: "dup", BaseURL: "https://two.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "duplicate non-empty stored IDs rejected",
+			next: []MCPServerConfig{
+				// One entry claims the ID explicitly, the other by exact
+				// (Name, BaseURL) match: with two stored rows sharing the ID,
+				// both claims could be satisfied by different rows, leaving
+				// two servers guarded by one policy identity.
+				{ID: "shared-id", Name: "srv", BaseURL: "https://one.example.com"},
+				{Name: "copy", BaseURL: "https://two.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "shared-id", Name: "srv", BaseURL: "https://one.example.com"},
+				{ID: "shared-id", Name: "copy", BaseURL: "https://two.example.com"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "multiple exact (Name, BaseURL) duplicates in prev rejected",
+			next: []MCPServerConfig{
+				{Name: "dup", BaseURL: "https://one.example.com"},
+			},
+			prev: []MCPServerConfig{
+				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
+				{ID: "id-two", Name: "dup", BaseURL: "https://one.example.com"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ReconcileMCPServerIDs(tt.next, tt.prev)
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrMCPServerIDConflict)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, result, len(tt.expectIDs))
+			for i, id := range tt.expectIDs {
+				require.Equal(t, id, result[i].ID, "server %d", i)
+			}
+		})
+	}
+}
+
+func TestReconcileEmbeddedMCPServerID(t *testing.T) {
+	tests := []struct {
+		name      string
+		next      MCPEmbeddedServerConfig
+		prev      MCPEmbeddedServerConfig
+		expectID  string
+		expectErr bool
+	}{
+		{
+			name:     "empty incoming keeps prev ID",
+			next:     MCPEmbeddedServerConfig{Enabled: true},
+			prev:     MCPEmbeddedServerConfig{ID: "embedded-prev", Enabled: true},
+			expectID: "embedded-prev",
+		},
+		{
+			name:     "matching IDs kept",
+			next:     MCPEmbeddedServerConfig{ID: "embedded-prev", Enabled: false},
+			prev:     MCPEmbeddedServerConfig{ID: "embedded-prev", Enabled: true},
+			expectID: "embedded-prev",
+		},
+		{
+			name:      "conflicting IDs rejected",
+			next:      MCPEmbeddedServerConfig{ID: "incoming-id", Enabled: true},
+			prev:      MCPEmbeddedServerConfig{ID: "embedded-prev", Enabled: true},
+			expectErr: true,
+		},
+		{
+			name:     "caller-chosen ID on previously ID-less kept",
+			next:     MCPEmbeddedServerConfig{ID: "seeded-id", Enabled: true},
+			prev:     MCPEmbeddedServerConfig{Enabled: true},
+			expectID: "seeded-id",
+		},
+		{
+			name:     "both empty stays ID-less",
+			next:     MCPEmbeddedServerConfig{Enabled: true},
+			prev:     MCPEmbeddedServerConfig{},
+			expectID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ReconcileEmbeddedMCPServerID(tt.next, tt.prev)
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrMCPServerIDConflict)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectID, result.ID)
+		})
+	}
+}
+
+func TestReconcileMCPConfigIDs(t *testing.T) {
+	const sharedID = "sharedidsharedidsharedidsha"
+
+	prevPlugins := []PluginServerConfig{
+		{ID: "plugin-a", PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true},
+		{ID: "plugin-b", PluginID: "com.example.b", Name: "B", Path: "/other", Enabled: false},
+	}
+
+	tests := []struct {
+		name      string
+		next      MCPConfig
+		prev      MCPConfig
+		expectErr bool
+		validate  func(t *testing.T, got MCPConfig)
+	}{
+		{
+			name: "happy path carries remote/embedded IDs and prev plugin rows",
+			next: MCPConfig{
+				Servers:        []MCPServerConfig{{Name: "Jira", BaseURL: "https://jira.example.com"}},
+				EmbeddedServer: MCPEmbeddedServerConfig{Enabled: true},
+				PluginServers:  []PluginServerConfig{{PluginID: "com.example.stale", Name: "Stale", Path: "/stale"}},
+			},
+			prev: MCPConfig{
+				Servers:        []MCPServerConfig{{ID: "remote-id", Name: "Jira", BaseURL: "https://jira.example.com"}},
+				EmbeddedServer: MCPEmbeddedServerConfig{ID: "embedded-id", Enabled: true},
+				PluginServers:  []PluginServerConfig{{ID: "plugin-id", PluginID: "com.example.a", Name: "A", Path: "/mcp"}},
+			},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Equal(t, "remote-id", got.Servers[0].ID)
+				require.Equal(t, "embedded-id", got.EmbeddedServer.ID)
+				require.Len(t, got.PluginServers, 1)
+				require.Equal(t, "plugin-id", got.PluginServers[0].ID)
+				require.Equal(t, "com.example.a", got.PluginServers[0].PluginID)
+			},
+		},
+		{
+			name: "nil PluginServers carries prev wholesale",
+			next: MCPConfig{
+				Servers:        []MCPServerConfig{{ID: "remote-id", Name: "Jira", BaseURL: "https://jira.example.com"}},
+				EmbeddedServer: MCPEmbeddedServerConfig{ID: "embedded-id", Enabled: true},
+				PluginServers:  nil,
+			},
+			prev: MCPConfig{PluginServers: prevPlugins},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Equal(t, prevPlugins, got.PluginServers)
+			},
+		},
+		{
+			name: "empty PluginServers carries prev wholesale",
+			next: MCPConfig{
+				PluginServers: []PluginServerConfig{},
+			},
+			prev: MCPConfig{
+				PluginServers: []PluginServerConfig{
+					{ID: "plugin-a", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+				},
+			},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Len(t, got.PluginServers, 1)
+				require.Equal(t, "plugin-a", got.PluginServers[0].ID)
+			},
+		},
+		{
+			name: "non-empty stale PluginServers in next ignored",
+			next: MCPConfig{
+				PluginServers: []PluginServerConfig{
+					{ID: "attacker-id", PluginID: "com.example.a", Name: "Hacked", Path: "/evil", Enabled: false},
+				},
+			},
+			prev: MCPConfig{PluginServers: prevPlugins},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Equal(t, prevPlugins, got.PluginServers)
+			},
+		},
+		{
+			name: "remote and embedded share ID",
+			next: MCPConfig{
+				Servers:        []MCPServerConfig{{ID: sharedID, Name: "Remote", BaseURL: "https://r.example.com"}},
+				EmbeddedServer: MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+			},
+			expectErr: true,
+		},
+		{
+			name: "remote and carried-forward plugin share ID",
+			next: MCPConfig{
+				Servers: []MCPServerConfig{{ID: sharedID, Name: "Remote", BaseURL: "https://r.example.com"}},
+			},
+			prev: MCPConfig{
+				PluginServers: []PluginServerConfig{{ID: sharedID, PluginID: "com.example.a", Name: "A", Path: "/mcp"}},
+			},
+			expectErr: true,
+		},
+		{
+			name: "embedded and carried-forward plugin share ID",
+			next: MCPConfig{
+				EmbeddedServer: MCPEmbeddedServerConfig{ID: sharedID, Enabled: true},
+			},
+			prev: MCPConfig{
+				PluginServers: []PluginServerConfig{{ID: sharedID, PluginID: "com.example.a", Name: "A", Path: "/mcp"}},
+			},
+			expectErr: true,
+		},
+		{
+			name: "stale next plugin ID cannot free prev plugin ID for remote reuse",
+			next: MCPConfig{
+				Servers: []MCPServerConfig{{ID: sharedID, Name: "Remote", BaseURL: "https://r.example.com"}},
+				PluginServers: []PluginServerConfig{
+					{ID: "other-id", PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+				},
+			},
+			prev: MCPConfig{
+				PluginServers: []PluginServerConfig{{ID: sharedID, PluginID: "com.example.a", Name: "A", Path: "/mcp"}},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReconcileMCPConfigIDs(tt.next, tt.prev)
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrMCPServerIDConflict)
+				return
+			}
+			require.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, got)
+			}
+		})
+	}
 }
 
 func TestServerConfigGetToolPolicyIgnoresRetrievalOverride(t *testing.T) {

--- a/config/mcp_config_test.go
+++ b/config/mcp_config_test.go
@@ -244,268 +244,6 @@ func TestMCPConfigServerIDMaps(t *testing.T) {
 	}
 }
 
-func TestReconcileMCPServerIDs(t *testing.T) {
-	tests := []struct {
-		name      string
-		next      []MCPServerConfig
-		prev      []MCPServerConfig
-		expectIDs []string
-		expectErr bool
-	}{
-		{
-			name: "round-trip payload keeps existing ID",
-			next: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{"prev-id"},
-		},
-		{
-			name: "match by name when URL edited",
-			next: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://new-url.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://old-url.example.com"},
-			},
-			expectIDs: []string{"prev-id"},
-		},
-		{
-			name: "match by BaseURL when renamed",
-			next: []MCPServerConfig{
-				{Name: "renamed", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{"prev-id"},
-		},
-		{
-			name: "each prev entry consumed at most once",
-			next: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://one.example.com"},
-				{Name: "other", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{"prev-id", ""},
-		},
-		{
-			name: "add flow: genuinely new entry stays ID-less for the caller to mint",
-			next: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://old.example.com"},
-				{Name: "brand-new", BaseURL: "https://new.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://old.example.com"},
-			},
-			expectIDs: []string{"prev-id", ""},
-		},
-		{
-			name: "delete flow: fewer entries than prev is not an error",
-			next: []MCPServerConfig{
-				{ID: "id-one", Name: "keep", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "id-one", Name: "keep", BaseURL: "https://one.example.com"},
-				{ID: "id-two", Name: "delete-me", BaseURL: "https://two.example.com"},
-			},
-			expectIDs: []string{"id-one"},
-		},
-		{
-			name: "prev entries without IDs cannot be claimed",
-			next: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{""},
-		},
-		{
-			name: "duplicate names reordered resolve by exact (Name, BaseURL)",
-			next: []MCPServerConfig{
-				{Name: "dup", BaseURL: "https://two.example.com"},
-				{Name: "dup", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
-				{ID: "id-two", Name: "dup", BaseURL: "https://two.example.com"},
-			},
-			expectIDs: []string{"id-two", "id-one"},
-		},
-		{
-			name: "explicit-ID claim and exact match competing across phases rejected",
-			next: []MCPServerConfig{
-				// The ID-less entry exactly matches the stored server the
-				// ID-bearing entry still holds: two entries strongly claiming
-				// one identity is a corrupt payload, never a guess.
-				{Name: "srv", BaseURL: "https://one.example.com"},
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "weak match earlier in the payload cannot steal a later exact match",
-			next: []MCPServerConfig{
-				// Payload order: the unique-Name weak match comes first, but
-				// the second entry is an exact (Name, BaseURL) round-trip of
-				// the stored server. Exact claims resolve globally before any
-				// weak claim, so the first entry stays new.
-				{Name: "srv", BaseURL: "https://moved.example.com"},
-				{Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{"", "prev-id"},
-		},
-		{
-			name: "two identical ID-less entries competing for one stored server rejected",
-			next: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://one.example.com"},
-				{Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "two weak claims resolving to the same stored server rejected",
-			next: []MCPServerConfig{
-				// First entry matches by unique Name, second by unique
-				// BaseURL — both resolve to the single stored server, and
-				// which one deserves the identity cannot be decided.
-				{Name: "srv", BaseURL: "https://a.example.com"},
-				{Name: "other", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "first write: ID-less entries stay ID-less for the caller to mint",
-			next: []MCPServerConfig{
-				{Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev:      nil,
-			expectIDs: []string{""},
-		},
-		{
-			name: "duplicate incoming IDs rejected",
-			next: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-				{ID: "prev-id", Name: "copy", BaseURL: "https://two.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "unknown ID colliding with a stored server identity rejected",
-			next: []MCPServerConfig{
-				{ID: "never-issued-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "unknown ID with unique name and URL is kept (API automation)",
-			next: []MCPServerConfig{
-				{ID: "seeded-by-automation", Name: "new-srv", BaseURL: "https://new.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			expectIDs: []string{"seeded-by-automation"},
-		},
-		{
-			name: "caller-chosen IDs on first write are kept",
-			next: []MCPServerConfig{
-				{ID: "seeded-by-automation", Name: "srv", BaseURL: "https://one.example.com"},
-			},
-			prev:      nil,
-			expectIDs: []string{"seeded-by-automation"},
-		},
-		{
-			name: "rename plus URL-change crossing two prev servers rejected",
-			next: []MCPServerConfig{
-				// Name matches prev B, BaseURL matches prev A: never guess.
-				{Name: "beta", BaseURL: "https://alpha.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "id-alpha", Name: "alpha", BaseURL: "https://alpha.example.com"},
-				{ID: "id-beta", Name: "beta", BaseURL: "https://beta.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "multiple name matches with no exact match rejected",
-			next: []MCPServerConfig{
-				{Name: "dup", BaseURL: "https://three.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
-				{ID: "id-two", Name: "dup", BaseURL: "https://two.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "duplicate non-empty stored IDs rejected",
-			next: []MCPServerConfig{
-				// One entry claims the ID explicitly, the other by exact
-				// (Name, BaseURL) match: with two stored rows sharing the ID,
-				// both claims could be satisfied by different rows, leaving
-				// two servers guarded by one policy identity.
-				{ID: "shared-id", Name: "srv", BaseURL: "https://one.example.com"},
-				{Name: "copy", BaseURL: "https://two.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "shared-id", Name: "srv", BaseURL: "https://one.example.com"},
-				{ID: "shared-id", Name: "copy", BaseURL: "https://two.example.com"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "multiple exact (Name, BaseURL) duplicates in prev rejected",
-			next: []MCPServerConfig{
-				{Name: "dup", BaseURL: "https://one.example.com"},
-			},
-			prev: []MCPServerConfig{
-				{ID: "id-one", Name: "dup", BaseURL: "https://one.example.com"},
-				{ID: "id-two", Name: "dup", BaseURL: "https://one.example.com"},
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := ReconcileMCPServerIDs(tt.next, tt.prev)
-			if tt.expectErr {
-				require.ErrorIs(t, err, ErrMCPServerIDConflict)
-				return
-			}
-			require.NoError(t, err)
-			require.Len(t, result, len(tt.expectIDs))
-			for i, id := range tt.expectIDs {
-				require.Equal(t, id, result[i].ID, "server %d", i)
-			}
-		})
-	}
-}
-
 func TestReconcileEmbeddedMCPServerID(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -575,9 +313,9 @@ func TestReconcileMCPConfigIDs(t *testing.T) {
 		validate  func(t *testing.T, got MCPConfig)
 	}{
 		{
-			name: "happy path carries remote/embedded IDs and prev plugin rows",
+			name: "happy path keeps explicit remote ID, copies embedded/plugin from prev",
 			next: MCPConfig{
-				Servers:        []MCPServerConfig{{Name: "Jira", BaseURL: "https://jira.example.com"}},
+				Servers:        []MCPServerConfig{{ID: "remote-id", Name: "Jira", BaseURL: "https://jira.example.com"}},
 				EmbeddedServer: MCPEmbeddedServerConfig{Enabled: true},
 				PluginServers:  []PluginServerConfig{{PluginID: "com.example.stale", Name: "Stale", Path: "/stale"}},
 			},
@@ -673,6 +411,53 @@ func TestReconcileMCPConfigIDs(t *testing.T) {
 				PluginServers: []PluginServerConfig{{ID: sharedID, PluginID: "com.example.a", Name: "A", Path: "/mcp"}},
 			},
 			expectErr: true,
+		},
+		{
+			name: "duplicate incoming remote IDs rejected",
+			next: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: sharedID, Name: "srv", BaseURL: "https://one.example.com"},
+					{ID: sharedID, Name: "copy", BaseURL: "https://two.example.com"},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "unique next succeeds even when prev has duplicate stored remote IDs",
+			next: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "unique-id", Name: "srv", BaseURL: "https://one.example.com"},
+				},
+			},
+			prev: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: sharedID, Name: "srv", BaseURL: "https://one.example.com"},
+					{ID: sharedID, Name: "copy", BaseURL: "https://two.example.com"},
+				},
+			},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Len(t, got.Servers, 1)
+				require.Equal(t, "unique-id", got.Servers[0].ID)
+			},
+		},
+		{
+			name: "ID-less remotes stay empty for the caller to mint",
+			next: MCPConfig{
+				Servers: []MCPServerConfig{
+					{Name: "srv", BaseURL: "https://one.example.com"},
+					{Name: "brand-new", BaseURL: "https://new.example.com"},
+				},
+			},
+			prev: MCPConfig{
+				Servers: []MCPServerConfig{
+					{ID: "prev-id", Name: "srv", BaseURL: "https://one.example.com"},
+				},
+			},
+			validate: func(t *testing.T, got MCPConfig) {
+				require.Len(t, got.Servers, 2)
+				require.Empty(t, got.Servers[0].ID)
+				require.Empty(t, got.Servers[1].ID)
+			},
 		},
 	}
 

--- a/config/service_ids.go
+++ b/config/service_ids.go
@@ -10,107 +10,23 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 )
 
-// ErrServiceIDConflict is the base error for every identity problem
-// ReconcileServiceIDs can detect; callers map it to a client error (stale
-// or corrupt admin console payload).
+// ErrServiceIDConflict is returned when two non-empty service IDs in the
+// incoming payload collide.
 var ErrServiceIDConflict = errors.New("LLM service identity conflict")
 
-// ReconcileServiceIDs carries stable IDs forward from prev onto ID-less
-// entries in next (e.g. from webapp bundles or API automation predating the
-// ID field). Service IDs are ABAC policy identities, so minting a fresh ID
-// for an existing service silently detaches its policy (which fails open).
-// Matching runs in global phases over the whole payload so the outcome cannot
-// depend on payload order; anything suspicious errors:
-//
-//  1. Explicit-ID claims: an ID found in prev claims that entry. An ID
-//     unknown to prev is accepted as a caller-chosen ID for a genuinely new
-//     service (admin-API automation seeds its own IDs) — unless the entry's
-//     Name matches a stored service, which means a stale or corrupt client
-//     is trying to swap an existing service's policy identity.
-//  2. Name claims against the unclaimed remainder: an ID-less entry claims
-//     the single unclaimed prev entry with its Name; any ambiguity or
-//     double-claim is an error.
-//  3. Entries matching nothing stay ID-less; the caller mints a fresh ID.
-//
-// Each prev entry is claimed at most once across both phases.
-func ReconcileServiceIDs(next []llm.ServiceConfig, prev []llm.ServiceConfig) ([]llm.ServiceConfig, error) {
-	// Duplicate stored IDs mean the persisted config is already corrupt;
-	// keeping the last row would let two services share one policy ID.
-	prevByID := make(map[string]int, len(prev))
-	for j := range prev {
-		id := prev[j].ID
+// ValidateServiceIDUniqueness reports ErrServiceIDConflict when two non-empty
+// IDs in services collide. Empty IDs are ignored so the caller can mint.
+func ValidateServiceIDUniqueness(services []llm.ServiceConfig) error {
+	seen := make(map[string]struct{}, len(services))
+	for i := range services {
+		id := services[i].ID
 		if id == "" {
 			continue
 		}
-		if _, dup := prevByID[id]; dup {
-			return nil, fmt.Errorf("%w: stored configuration contains two services with ID %q", ErrServiceIDConflict, id)
+		if _, dup := seen[id]; dup {
+			return fmt.Errorf("%w: service %q duplicates the ID of another entry in the payload", ErrServiceIDConflict, services[i].Name)
 		}
-		prevByID[id] = j
+		seen[id] = struct{}{}
 	}
-
-	claimed := make([]bool, len(prev))
-
-	// Phase 1: entries arriving with an ID claim the prev entry holding it.
-	seenIncoming := make(map[string]bool, len(next))
-	for i := range next {
-		id := next[i].ID
-		if id == "" {
-			continue
-		}
-		if seenIncoming[id] {
-			return nil, fmt.Errorf("%w: service %q duplicates the ID of another entry in the payload", ErrServiceIDConflict, next[i].Name)
-		}
-		seenIncoming[id] = true
-		if j, ok := prevByID[id]; ok {
-			claimed[j] = true
-			continue
-		}
-		// Unknown ID: legitimate for a genuinely new service seeded by API
-		// automation. A Name collision with a stored (ID-carrying) service
-		// instead means a stale client is swapping that service's policy
-		// identity, which would detach its policy.
-		for k := range prev {
-			if prev[k].ID != "" && prev[k].Name == next[i].Name {
-				return nil, fmt.Errorf("%w: service %q carries ID %q but a stored service with that name has ID %q", ErrServiceIDConflict, next[i].Name, id, prev[k].ID)
-			}
-		}
-	}
-
-	// Phase 2: Name claims against the unclaimed remainder; every entry sees
-	// the same post-phase-1 snapshot, so this phase is order-independent.
-	nameClaimed := make(map[int]bool, len(prev))
-	nameMatch := make([]int, len(next))
-	for i := range next {
-		nameMatch[i] = -1
-		if next[i].ID != "" {
-			continue
-		}
-
-		candidate := -1
-		for j := range prev {
-			if claimed[j] || prev[j].ID == "" || prev[j].Name != next[i].Name {
-				continue
-			}
-			if candidate >= 0 {
-				return nil, fmt.Errorf("%w: service %q ambiguously matches more than one stored service", ErrServiceIDConflict, next[i].Name)
-			}
-			candidate = j
-		}
-		if candidate < 0 {
-			// Genuinely new: no identity claim to resolve.
-			continue
-		}
-		if nameClaimed[candidate] {
-			return nil, fmt.Errorf("%w: service %q claims a stored service another entry in the payload already claims", ErrServiceIDConflict, next[i].Name)
-		}
-		nameClaimed[candidate] = true
-		nameMatch[i] = candidate
-	}
-	for i, j := range nameMatch {
-		if j >= 0 {
-			next[i].ID = prev[j].ID
-		}
-	}
-
-	return next, nil
+	return nil
 }

--- a/config/service_ids.go
+++ b/config/service_ids.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+)
+
+// ErrServiceIDConflict is the base error for every identity problem
+// ReconcileServiceIDs can detect; callers map it to a client error (stale
+// or corrupt admin console payload).
+var ErrServiceIDConflict = errors.New("LLM service identity conflict")
+
+// ReconcileServiceIDs carries stable IDs forward from prev onto ID-less
+// entries in next (e.g. from webapp bundles or API automation predating the
+// ID field). Service IDs are ABAC policy identities, so minting a fresh ID
+// for an existing service silently detaches its policy (which fails open).
+// Matching runs in global phases over the whole payload so the outcome cannot
+// depend on payload order; anything suspicious errors:
+//
+//  1. Explicit-ID claims: an ID found in prev claims that entry. An ID
+//     unknown to prev is accepted as a caller-chosen ID for a genuinely new
+//     service (admin-API automation seeds its own IDs) — unless the entry's
+//     Name matches a stored service, which means a stale or corrupt client
+//     is trying to swap an existing service's policy identity.
+//  2. Name claims against the unclaimed remainder: an ID-less entry claims
+//     the single unclaimed prev entry with its Name; any ambiguity or
+//     double-claim is an error.
+//  3. Entries matching nothing stay ID-less; the caller mints a fresh ID.
+//
+// Each prev entry is claimed at most once across both phases.
+func ReconcileServiceIDs(next []llm.ServiceConfig, prev []llm.ServiceConfig) ([]llm.ServiceConfig, error) {
+	// Duplicate stored IDs mean the persisted config is already corrupt;
+	// keeping the last row would let two services share one policy ID.
+	prevByID := make(map[string]int, len(prev))
+	for j := range prev {
+		id := prev[j].ID
+		if id == "" {
+			continue
+		}
+		if _, dup := prevByID[id]; dup {
+			return nil, fmt.Errorf("%w: stored configuration contains two services with ID %q", ErrServiceIDConflict, id)
+		}
+		prevByID[id] = j
+	}
+
+	claimed := make([]bool, len(prev))
+
+	// Phase 1: entries arriving with an ID claim the prev entry holding it.
+	seenIncoming := make(map[string]bool, len(next))
+	for i := range next {
+		id := next[i].ID
+		if id == "" {
+			continue
+		}
+		if seenIncoming[id] {
+			return nil, fmt.Errorf("%w: service %q duplicates the ID of another entry in the payload", ErrServiceIDConflict, next[i].Name)
+		}
+		seenIncoming[id] = true
+		if j, ok := prevByID[id]; ok {
+			claimed[j] = true
+			continue
+		}
+		// Unknown ID: legitimate for a genuinely new service seeded by API
+		// automation. A Name collision with a stored (ID-carrying) service
+		// instead means a stale client is swapping that service's policy
+		// identity, which would detach its policy.
+		for k := range prev {
+			if prev[k].ID != "" && prev[k].Name == next[i].Name {
+				return nil, fmt.Errorf("%w: service %q carries ID %q but a stored service with that name has ID %q", ErrServiceIDConflict, next[i].Name, id, prev[k].ID)
+			}
+		}
+	}
+
+	// Phase 2: Name claims against the unclaimed remainder; every entry sees
+	// the same post-phase-1 snapshot, so this phase is order-independent.
+	nameClaimed := make(map[int]bool, len(prev))
+	nameMatch := make([]int, len(next))
+	for i := range next {
+		nameMatch[i] = -1
+		if next[i].ID != "" {
+			continue
+		}
+
+		candidate := -1
+		for j := range prev {
+			if claimed[j] || prev[j].ID == "" || prev[j].Name != next[i].Name {
+				continue
+			}
+			if candidate >= 0 {
+				return nil, fmt.Errorf("%w: service %q ambiguously matches more than one stored service", ErrServiceIDConflict, next[i].Name)
+			}
+			candidate = j
+		}
+		if candidate < 0 {
+			// Genuinely new: no identity claim to resolve.
+			continue
+		}
+		if nameClaimed[candidate] {
+			return nil, fmt.Errorf("%w: service %q claims a stored service another entry in the payload already claims", ErrServiceIDConflict, next[i].Name)
+		}
+		nameClaimed[candidate] = true
+		nameMatch[i] = candidate
+	}
+	for i, j := range nameMatch {
+		if j >= 0 {
+			next[i].ID = prev[j].ID
+		}
+	}
+
+	return next, nil
+}

--- a/config/service_ids_test.go
+++ b/config/service_ids_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+)
+
+func TestReconcileServiceIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		next      []llm.ServiceConfig
+		prev      []llm.ServiceConfig
+		expectIDs []string
+		expectErr bool
+	}{
+		{
+			name: "round-trip payload keeps existing ID",
+			next: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "ID-less payload reclaims existing service by name",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "ID-less reclaim survives unrelated field edits",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "anthropic", APIURL: "https://new.example.com"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{"prev-id"},
+		},
+		{
+			name: "genuinely new service stays ID-less",
+			next: []llm.ServiceConfig{
+				{Name: "brand-new", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{""},
+		},
+		{
+			name: "explicit ID beats a name claim for the same prev entry",
+			next: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "renamed", Type: "openai"},
+				{Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{"prev-id", ""},
+		},
+		{
+			name: "unknown ID colliding with a stored service name errors",
+			next: []llm.ServiceConfig{
+				{ID: "made-up", Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "unknown ID with a unique name is kept (API automation)",
+			next: []llm.ServiceConfig{
+				{ID: "seeded-by-automation", Name: "new-svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectIDs: []string{"seeded-by-automation"},
+		},
+		{
+			name: "caller-chosen IDs on first write are kept",
+			next: []llm.ServiceConfig{
+				{ID: "seeded-by-automation", Name: "svc", Type: "openai"},
+			},
+			prev:      nil,
+			expectIDs: []string{"seeded-by-automation"},
+		},
+		{
+			name: "duplicate incoming IDs error",
+			next: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+				{ID: "prev-id", Name: "copy", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "duplicate stored IDs error",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "dup", Name: "svc", Type: "openai"},
+				{ID: "dup", Name: "other", Type: "openai"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "ambiguous name match errors",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "openai"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-a", Name: "svc", Type: "openai"},
+				{ID: "prev-b", Name: "svc", Type: "anthropic"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "two ID-less entries claiming one prev service error",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "openai"},
+				{Name: "svc", Type: "anthropic"},
+			},
+			prev: []llm.ServiceConfig{
+				{ID: "prev-id", Name: "svc", Type: "openai"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty previous list leaves new entries ID-less",
+			next: []llm.ServiceConfig{
+				{Name: "svc", Type: "openai"},
+			},
+			prev:      nil,
+			expectIDs: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReconcileServiceIDs(tt.next, tt.prev)
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrServiceIDConflict)
+				return
+			}
+			require.NoError(t, err)
+			ids := make([]string, len(got))
+			for i := range got {
+				ids[i] = got[i].ID
+			}
+			require.Equal(t, tt.expectIDs, ids)
+		})
+	}
+}

--- a/config/service_ids_test.go
+++ b/config/service_ids_test.go
@@ -11,160 +11,44 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 )
 
-func TestReconcileServiceIDs(t *testing.T) {
+func TestValidateServiceIDUniqueness(t *testing.T) {
 	tests := []struct {
 		name      string
-		next      []llm.ServiceConfig
-		prev      []llm.ServiceConfig
-		expectIDs []string
+		services  []llm.ServiceConfig
 		expectErr bool
 	}{
 		{
-			name: "round-trip payload keeps existing ID",
-			next: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
+			name: "unique IDs",
+			services: []llm.ServiceConfig{
+				{ID: "a", Name: "svc", Type: "openai"},
+				{ID: "b", Name: "other", Type: "anthropic"},
 			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{"prev-id"},
 		},
 		{
-			name: "ID-less payload reclaims existing service by name",
-			next: []llm.ServiceConfig{
+			name: "empty IDs ignored",
+			services: []llm.ServiceConfig{
 				{Name: "svc", Type: "openai"},
+				{Name: "other", Type: "anthropic"},
 			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{"prev-id"},
 		},
 		{
-			name: "ID-less reclaim survives unrelated field edits",
-			next: []llm.ServiceConfig{
-				{Name: "svc", Type: "anthropic", APIURL: "https://new.example.com"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{"prev-id"},
-		},
-		{
-			name: "genuinely new service stays ID-less",
-			next: []llm.ServiceConfig{
-				{Name: "brand-new", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{""},
-		},
-		{
-			name: "explicit ID beats a name claim for the same prev entry",
-			next: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "renamed", Type: "openai"},
-				{Name: "svc", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{"prev-id", ""},
-		},
-		{
-			name: "unknown ID colliding with a stored service name errors",
-			next: []llm.ServiceConfig{
-				{ID: "made-up", Name: "svc", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "unknown ID with a unique name is kept (API automation)",
-			next: []llm.ServiceConfig{
-				{ID: "seeded-by-automation", Name: "new-svc", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectIDs: []string{"seeded-by-automation"},
-		},
-		{
-			name: "caller-chosen IDs on first write are kept",
-			next: []llm.ServiceConfig{
-				{ID: "seeded-by-automation", Name: "svc", Type: "openai"},
-			},
-			prev:      nil,
-			expectIDs: []string{"seeded-by-automation"},
-		},
-		{
-			name: "duplicate incoming IDs error",
-			next: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-				{ID: "prev-id", Name: "copy", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "duplicate stored IDs error",
-			next: []llm.ServiceConfig{
-				{Name: "svc", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
+			name: "duplicate non-empty IDs error",
+			services: []llm.ServiceConfig{
 				{ID: "dup", Name: "svc", Type: "openai"},
-				{ID: "dup", Name: "other", Type: "openai"},
+				{ID: "dup", Name: "copy", Type: "openai"},
 			},
 			expectErr: true,
-		},
-		{
-			name: "ambiguous name match errors",
-			next: []llm.ServiceConfig{
-				{Name: "svc", Type: "openai"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-a", Name: "svc", Type: "openai"},
-				{ID: "prev-b", Name: "svc", Type: "anthropic"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "two ID-less entries claiming one prev service error",
-			next: []llm.ServiceConfig{
-				{Name: "svc", Type: "openai"},
-				{Name: "svc", Type: "anthropic"},
-			},
-			prev: []llm.ServiceConfig{
-				{ID: "prev-id", Name: "svc", Type: "openai"},
-			},
-			expectErr: true,
-		},
-		{
-			name: "empty previous list leaves new entries ID-less",
-			next: []llm.ServiceConfig{
-				{Name: "svc", Type: "openai"},
-			},
-			prev:      nil,
-			expectIDs: []string{""},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReconcileServiceIDs(tt.next, tt.prev)
+			err := ValidateServiceIDUniqueness(tt.services)
 			if tt.expectErr {
 				require.ErrorIs(t, err, ErrServiceIDConflict)
 				return
 			}
 			require.NoError(t, err)
-			ids := make([]string, len(got))
-			for i := range got {
-				ids[i] = got[i].ID
-			}
-			require.Equal(t, tt.expectIDs, ids)
 		})
 	}
 }

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -547,6 +547,8 @@ This separation allows multiple agents to share the same LLM service configurati
 }
 ```
 
+Service IDs are Mattermost-style 26-character IDs. Configurations created before this format was adopted used UUIDs; those are rewritten once on upgrade, so external automation that hard-coded UUID service IDs must re-read `GET /plugins/mattermost-ai/admin/config` to pick up the new IDs.
+
 **Supported service types:** `openai`, `anthropic`, `azure`, `openaicompatible`, `asage`, `cohere`, `mistral`, `scale`
 
 **Legacy format:** Older configurations that stored bots in `config.bots`, or embedded service objects within bots, are migrated on plugin startup. After legacy bot migration completes, stored `config.bots` entries are removed to avoid duplicate bot registration.

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -26,7 +26,7 @@ import (
 const (
 	MMUserIDHeader     = "X-Mattermost-UserID"
 	EmbeddedServerName = "Mattermost"
-	EmbeddedClientKey  = "embedded://mattermost"
+	EmbeddedClientKey  = config.MCPEmbeddedServerOrigin
 
 	listToolsMethod = "tools/list"
 

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mmapi"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -24,6 +25,11 @@ import (
 const pluginRegistrationsKVKey = "mcp_plugin_registrations_v1"
 
 var ErrOAuthNotConfigured = errors.New("oauth not configured")
+
+// ServerAccessChecker gates per-user visibility of MCP servers by stable ID.
+type ServerAccessChecker interface {
+	CanUseMCPServer(ctx context.Context, userID, serverID string) error
+}
 
 // clientKind is the structural role of a pooled bag. Remote bags cannot
 // share sessions across user and service-account authentication modes.
@@ -80,13 +86,20 @@ type ClientManager struct {
 	// admission caps overlapping remote/plugin connection sequences on this
 	// manager instance. It outlives ReInit and is closed only by Close.
 	admission *connectionAdmission
+	// accessChecker filters servers for the invoking user (nil = no filtering).
+	accessChecker ServerAccessChecker
 	// closed is set by Close and makes ReInit a no-op so shutdown stays permanent.
 	closed bool
 }
 
 // NewClientManager creates a new MCP client manager. embeddedServer may be nil.
 // sourcePluginAPI routes PluginHTTP to source plugins; may be nil.
-func NewClientManager(config Config, log pluginapi.LogService, pluginAPI *pluginapi.Client, oauthManager *OAuthManager, embeddedServer EmbeddedMCPServer, httpClient *http.Client, sourcePluginAPI mmapi.Client) *ClientManager {
+// accessChecker filters external servers per user; nil disables filtering.
+func NewClientManager(config Config, log pluginapi.LogService, pluginAPI *pluginapi.Client, oauthManager *OAuthManager, embeddedServer EmbeddedMCPServer, httpClient *http.Client, sourcePluginAPI mmapi.Client, accessCheckers ...ServerAccessChecker) *ClientManager {
+	var accessChecker ServerAccessChecker
+	if len(accessCheckers) > 0 {
+		accessChecker = accessCheckers[0]
+	}
 	manager := &ClientManager{
 		log:              log,
 		pluginAPI:        pluginAPI,
@@ -97,6 +110,7 @@ func NewClientManager(config Config, log pluginapi.LogService, pluginAPI *plugin
 		pluginRegistered: make(map[string]bool),
 		sourcePluginAPI:  sourcePluginAPI,
 		admission:        newConnectionAdmission(maxNodeConnections),
+		accessChecker:    accessChecker,
 	}
 	manager.hydratePluginRegistrations()
 	// PluginMCPHandlers is constructed later and builds the external aggregate
@@ -287,7 +301,7 @@ func (m *ClientManager) snapshotRuntime() (Config, *EmbeddedServerClient) {
 	return m.config, m.embeddedClient
 }
 
-func (m *ClientManager) resolveEligibleServers(cfg Config, embeddedClient *EmbeddedServerClient, plugins []PluginServerConfig, selection ToolSelection, serviceAccount bool) eligibleServers {
+func (m *ClientManager) resolveEligibleServers(cfg Config, embeddedClient *EmbeddedServerClient, plugins []PluginServerConfig, selection ToolSelection, deniedOrigins map[string]bool, serviceAccount bool) eligibleServers {
 	resolved := eligibleServers{origins: make(map[string]bool)}
 
 	// A duplicated name or endpoint makes every member of the group ambiguous:
@@ -311,6 +325,8 @@ func (m *ClientManager) resolveEligibleServers(cfg Config, embeddedClient *Embed
 			m.log.Debug("Skipping MCP server without service account headers in service account mode",
 				"serverID", server.Name, "serverOrigin", server.BaseURL)
 			continue
+		case deniedOrigins[llm.NormalizeMCPServerOrigin(server.BaseURL)]:
+			continue
 		case !selection.Allows(server.BaseURL):
 			continue
 		}
@@ -318,14 +334,14 @@ func (m *ClientManager) resolveEligibleServers(cfg Config, embeddedClient *Embed
 		resolved.origins[llm.NormalizeMCPServerOrigin(server.BaseURL)] = true
 	}
 
-	if embeddedClient != nil && cfg.EmbeddedServer.Enabled && selection.Allows(EmbeddedClientKey) {
+	if embeddedClient != nil && cfg.EmbeddedServer.Enabled && !deniedOrigins[EmbeddedClientKey] && selection.Allows(EmbeddedClientKey) {
 		resolved.embedded = true
 		resolved.origins[EmbeddedClientKey] = true
 	}
 
 	for _, pluginCfg := range plugins {
 		origin := pluginServerOriginKey(pluginCfg.PluginID)
-		if !selection.Allows(origin) {
+		if deniedOrigins[origin] || !selection.Allows(origin) {
 			continue
 		}
 		resolved.plugins = append(resolved.plugins, pluginCfg)
@@ -401,7 +417,10 @@ func (m *ClientManager) getTools(ctx context.Context, req CatalogRequest, select
 	cfg := m.config
 	embeddedClient := m.embeddedClient
 	plugins := m.snapshotEnabledPluginServers()
-	servers := m.resolveEligibleServers(cfg, embeddedClient, plugins, selection, req.ServiceAccount)
+	// Service-account remotes are pooled by the bot identity, but authorization
+	// and local MCP connections belong to the human invoking this request.
+	deniedOrigins := m.deniedMCPServerOrigins(ctx, req.InvokingUserID, cfg, embeddedClient, plugins)
+	servers := m.resolveEligibleServers(cfg, embeddedClient, plugins, selection, deniedOrigins, req.ServiceAccount)
 
 	var localClients *UserClients
 	if servers.embedded || len(servers.plugins) > 0 {
@@ -457,6 +476,43 @@ func (m *ClientManager) getTools(ctx context.Context, req CatalogRequest, select
 	rawTools := collectToolsFromSnapshots(req.InvokingUserID, m.log, remoteClients.snapshotClients(), localSnapshot)
 	filtered := filterToolsByConfig(rawTools, cfg, embeddedClient, servers.plugins)
 	return retainToolsFromOrigins(filtered, servers.origins), joinMCPErrors(remoteErrors, localErrors)
+}
+
+// deniedMCPServerOrigins evaluates each configured stable identity once before
+// connection planning. ID-less resources remain available until migration
+// assigns their durable IDs.
+func (m *ClientManager) deniedMCPServerOrigins(ctx context.Context, userID string, cfg Config, embeddedClient *EmbeddedServerClient, plugins []PluginServerConfig) map[string]bool {
+	if m.accessChecker == nil {
+		return nil
+	}
+
+	var denied map[string]bool
+	check := func(origin, serverID string) {
+		if serverID == "" {
+			return
+		}
+		if err := m.accessChecker.CanUseMCPServer(ctx, userID, serverID); err == nil {
+			return
+		}
+		if denied == nil {
+			denied = make(map[string]bool)
+		}
+		denied[llm.NormalizeMCPServerOrigin(origin)] = true
+		m.log.Debug("Omitting MCP server for user by access policy", "userID", userID, "serverID", serverID)
+	}
+
+	for _, server := range cfg.Servers {
+		if server.Enabled && server.BaseURL != "" {
+			check(server.BaseURL, server.ID)
+		}
+	}
+	if embeddedClient != nil {
+		check(EmbeddedClientKey, cfg.EmbeddedServer.ID)
+	}
+	for _, server := range plugins {
+		check(pluginServerOriginKey(server.PluginID), server.ID)
+	}
+	return denied
 }
 
 func joinMCPErrors(groups ...*Errors) *Errors {
@@ -571,6 +627,14 @@ func (m *ClientManager) GetToolRetrievalOverrides() map[string]ToolRetrievalOver
 
 	for _, server := range cfg.PluginServers {
 		if !server.Enabled || server.PluginID == "" {
+			continue
+		}
+		for _, toolConfig := range server.ToolConfigs {
+			addOverride(pluginServerOriginKey(server.PluginID), toolConfig)
+		}
+	}
+	for _, server := range m.ListPluginServers() {
+		if !m.IsPluginRegistered(server.PluginID) || !server.Enabled {
 			continue
 		}
 		for _, toolConfig := range server.ToolConfigs {
@@ -742,6 +806,13 @@ func (m *ClientManager) pluginIdentityLocked(pluginID string) originIdentity {
 	return pluginOriginIdentity(m.pluginServers[pluginID])
 }
 
+// MCPServerIDByOrigin snapshots the stable-ID mapping for the manager's current
+// config. See config.MCPConfig.ServerIDByOrigin.
+func (m *ClientManager) MCPServerIDByOrigin() map[string]string {
+	cfg, _ := m.snapshotRuntime()
+	return cfg.ServerIDByOrigin()
+}
+
 // RegisterPluginServer stores or overwrites a plugin-server registration.
 // Callers must ensure cfg.PluginID is non-empty. Identity-affecting changes
 // (name, path, enabled, registration) invalidate that origin immediately;
@@ -756,7 +827,28 @@ func (m *ClientManager) RegisterPluginServer(cfg PluginServerConfig) {
 	})
 }
 
-// UpdatePluginServer applies admin-owned fields without changing registration state.
+// UpdatePluginServerAdminFields applies admin-owned fields without replacing
+// plugin-owned registration identity. It reports false for a non-live entry.
+func (m *ClientManager) UpdatePluginServerAdminFields(pluginID string, enabled bool, toolConfigs []ToolConfig) (PluginServerConfig, bool) {
+	var (
+		updated PluginServerConfig
+		found   bool
+	)
+	m.updatePluginRegistry(pluginID, func() {
+		updated, found = m.pluginServers[pluginID]
+		if !found || !m.pluginRegistered[pluginID] {
+			found = false
+			return
+		}
+		updated.Enabled = enabled
+		updated.ToolConfigs = toolConfigs
+		m.pluginServers[pluginID] = updated
+	})
+	return updated, found
+}
+
+// UpdatePluginServer replaces a live registration and preserves the
+// identity-change invalidation used by existing registry callers.
 func (m *ClientManager) UpdatePluginServer(cfg PluginServerConfig) {
 	m.updatePluginRegistry(cfg.PluginID, func() {
 		m.pluginServers[cfg.PluginID] = cfg
@@ -937,8 +1029,22 @@ func (m *ClientManager) loadPersistedPluginRegistrationsLocked() (map[string]Plu
 	return registrations, true
 }
 
+// ApplyPersistedPluginServerFields overlays admin-owned persisted fields
+// (Enabled, ToolConfigs, ID) onto a live registration. Name/Path/ExposeExternal
+// remain plugin-owned.
+func ApplyPersistedPluginServerFields(live, persisted PluginServerConfig) PluginServerConfig {
+	live.Enabled = persisted.Enabled
+	live.ToolConfigs = persisted.ToolConfigs
+	if persisted.ID != "" {
+		live.ID = persisted.ID
+	}
+	return live
+}
+
 // syncPluginServersFromConfig merges persisted admin-owned plugin-server fields
-// onto live plugin registrations. Callers must not hold pluginServersMu.
+// onto live registrations and hydrates config-only rows without marking them
+// registered. Runtime snapshots exclude those orphan rows.
+// Callers must not hold pluginServersMu.
 func (m *ClientManager) syncPluginServersFromConfig(cfg Config) {
 	m.pluginServersMu.Lock()
 	defer m.pluginServersMu.Unlock()
@@ -955,14 +1061,10 @@ func (m *ClientManager) syncPluginServersFromConfig(cfg Config) {
 			continue
 		}
 		if existing, ok := m.pluginServers[persisted.PluginID]; ok {
-			// Merge admin-owned fields onto the live entry; keep runtime identity
-			// and the plugin-controlled external exposure flag.
-			existing.Enabled = persisted.Enabled
-			existing.ToolConfigs = persisted.ToolConfigs
-			m.pluginServers[persisted.PluginID] = existing
-			continue
+			m.pluginServers[persisted.PluginID] = ApplyPersistedPluginServerFields(existing, persisted)
+		} else {
+			m.pluginServers[persisted.PluginID] = persisted
 		}
-		m.pluginServers[persisted.PluginID] = persisted
 	}
 }
 
@@ -1008,7 +1110,7 @@ func filterToolsByConfig(rawTools []llm.Tool, cfg Config, embeddedClient *Embedd
 		if !ps.Enabled {
 			continue
 		}
-		origin := "plugin://" + ps.PluginID
+		origin := config.PluginServerOrigin(ps.PluginID)
 		serverByOrigin[origin] = &ServerConfig{
 			Name:        ps.Name,
 			Enabled:     true,

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -916,14 +916,17 @@ func (m *ClientManager) snapshotUserClients() []*UserClients {
 	return users
 }
 
-// ListPluginServers returns a stable snapshot without holding the registry lock
-// during caller work.
+// ListPluginServers returns a stable snapshot of live-registered plugin MCP
+// servers without holding the registry lock during caller work.
 func (m *ClientManager) ListPluginServers() []PluginServerConfig {
 	m.pluginServersMu.RLock()
 	defer m.pluginServersMu.RUnlock()
 
 	out := make([]PluginServerConfig, 0, len(m.pluginServers))
 	for _, cfg := range m.pluginServers {
+		if !m.pluginRegistered[cfg.PluginID] {
+			continue
+		}
 		out = append(out, cfg)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -1042,29 +1045,23 @@ func ApplyPersistedPluginServerFields(live, persisted PluginServerConfig) Plugin
 }
 
 // syncPluginServersFromConfig merges persisted admin-owned plugin-server fields
-// onto live registrations and hydrates config-only rows without marking them
-// registered. Runtime snapshots exclude those orphan rows.
+// onto live-registered entries only. Config-only orphan rows keep their
+// identity/policy in config but never become runtime registry members —
+// hydratePluginRegistrations (KV) and RegisterPluginServer own membership.
 // Callers must not hold pluginServersMu.
 func (m *ClientManager) syncPluginServersFromConfig(cfg Config) {
 	m.pluginServersMu.Lock()
 	defer m.pluginServersMu.Unlock()
 
-	if m.pluginServers == nil {
-		m.pluginServers = make(map[string]PluginServerConfig)
-	}
-	if m.pluginRegistered == nil {
-		m.pluginRegistered = make(map[string]bool)
-	}
-
 	for _, persisted := range cfg.PluginServers {
 		if persisted.PluginID == "" {
 			continue
 		}
-		if existing, ok := m.pluginServers[persisted.PluginID]; ok {
-			m.pluginServers[persisted.PluginID] = ApplyPersistedPluginServerFields(existing, persisted)
-		} else {
-			m.pluginServers[persisted.PluginID] = persisted
+		existing, ok := m.pluginServers[persisted.PluginID]
+		if !ok || !m.pluginRegistered[persisted.PluginID] {
+			continue
 		}
+		m.pluginServers[persisted.PluginID] = ApplyPersistedPluginServerFields(existing, persisted)
 	}
 }
 

--- a/mcp/client_manager_reinit_test.go
+++ b/mcp/client_manager_reinit_test.go
@@ -403,8 +403,10 @@ func TestGetToolsForUserSkipsUnregisteredPluginServers(t *testing.T) {
 	manager := harness.newManagerWithoutPluginRegister()
 
 	require.False(t, manager.IsPluginRegistered(plugin.PluginID))
+	require.Equal(t, []PluginServerConfig{plugin}, manager.GetConfig().PluginServers,
+		"config-only plugin row must remain persisted in config")
 	_, ok := manager.GetPluginServer(plugin.PluginID)
-	require.True(t, ok, "config still hydrates the plugin row")
+	require.False(t, ok, "config-only plugin row must not be hydrated into the live registry")
 
 	tools, mcpErrors := manager.GetToolsForUser(context.Background(), "alice", ToolSelection{})
 	require.Nil(t, mcpErrors)

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -480,11 +480,9 @@ func TestClientManager_ConfigOnlyPluginServersAreNotRuntimeMembers(t *testing.T)
 	)
 	t.Cleanup(m.Close)
 
-	require.Len(t, m.ListPluginServers(), 1, "config-only rows remain visible to registry management")
-	got, ok := m.GetPluginServer("com.example.orphan")
-	require.True(t, ok)
-	require.Equal(t, orphanID, got.ID)
-	require.False(t, m.IsPluginRegistered("com.example.orphan"))
+	require.Empty(t, m.ListPluginServers(), "config-only rows must not appear in the live registry")
+	_, ok := m.GetPluginServer("com.example.orphan")
+	require.False(t, ok)
 	require.Empty(t, m.snapshotEnabledPluginServers())
 	require.Equal(t, orphanID, m.GetConfig().PluginServers[0].ID, "identity must survive in config")
 }
@@ -583,7 +581,7 @@ func TestApplyPersistedPluginServerFields(t *testing.T) {
 	}
 }
 
-func TestClientManager_ReInitHydratesConfigOnlyEntriesWithoutRegistering(t *testing.T) {
+func TestClientManager_ReInitDoesNotInsertConfigOnlyEntries(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
@@ -608,11 +606,9 @@ func TestClientManager_ReInitHydratesConfigOnlyEntriesWithoutRegistering(t *test
 
 	m.ReInit(cfg, nil)
 
-	require.Len(t, m.ListPluginServers(), 1)
-	got, ok := m.GetPluginServer("com.example.mcp")
-	require.True(t, ok)
-	require.Equal(t, orphanID, got.ID)
-	require.False(t, m.IsPluginRegistered("com.example.mcp"))
+	require.Empty(t, m.ListPluginServers())
+	_, ok := m.GetPluginServer("com.example.mcp")
+	require.False(t, ok, "ReInit must not fabricate registry entries from config")
 	require.Equal(t, orphanID, m.GetConfig().PluginServers[0].ID)
 }
 
@@ -644,8 +640,7 @@ func TestClientManager_ReInitPreservesUnpersistedRuntimeEntries(t *testing.T) {
 	}
 	m.ReInit(cfg, nil)
 
-	require.Len(t, m.ListPluginServers(), 2, "config-only rows remain available for management")
-	require.False(t, m.IsPluginRegistered("com.example.other"))
+	require.Len(t, m.ListPluginServers(), 1, "config-only other must not join the registry")
 	stillLive, ok := m.GetPluginServer("com.example.live")
 	require.True(t, ok, "runtime registration must survive ReInit")
 	require.Equal(t, live, stillLive)

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -33,6 +33,20 @@ type fakePluginHTTPClient struct {
 	pluginHTTP func(*http.Request) *http.Response
 }
 
+type serverAccessCall struct {
+	userID   string
+	serverID string
+}
+
+type recordingServerAccessChecker struct {
+	calls []serverAccessCall
+}
+
+func (c *recordingServerAccessChecker) CanUseMCPServer(_ context.Context, userID, serverID string) error {
+	c.calls = append(c.calls, serverAccessCall{userID: userID, serverID: serverID})
+	return assert.AnError
+}
+
 func (f *fakePluginHTTPClient) PluginHTTP(req *http.Request) *http.Response {
 	return f.pluginHTTP(req)
 }
@@ -163,11 +177,39 @@ func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
 	}
 }
 
+func TestClientManagerServiceAccountAccessUsesInvokingUser(t *testing.T) {
+	pluginTestAPI := &plugintest.API{}
+	setupClientManagerTestAPI(t, pluginTestAPI)
+	client := pluginapi.NewClient(pluginTestAPI, nil)
+	checker := &recordingServerAccessChecker{}
+
+	manager := NewClientManager(Config{
+		IdleTimeoutMinutes: 30,
+		Servers: []ServerConfig{{
+			ID:                    "abcdefghijklmnopqrstuvwxyz",
+			Name:                  "Denied",
+			Enabled:               true,
+			BaseURL:               "https://must-not-connect.invalid",
+			ServiceAccountHeaders: map[string]string{"Authorization": "Bearer secret"},
+		}},
+	}, client.Log, client, nil, nil, nil, nil, checker)
+	t.Cleanup(manager.Close)
+
+	tools, mcpErrors := manager.GetTools(context.Background(), ServiceAccountCatalogRequest("bot-user", "invoking-user"))
+
+	require.Empty(t, tools)
+	require.Nil(t, mcpErrors, "policy denial is silent and must prevent dialing")
+	require.Equal(t, []serverAccessCall{{
+		userID:   "invoking-user",
+		serverID: "abcdefghijklmnopqrstuvwxyz",
+	}}, checker.calls)
+}
+
 func TestClientManager_PluginServerRegistry_RegisterUnregisterList(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	cfgA := PluginServerConfig{PluginID: "a", Name: "A", Path: "/mcp", Enabled: true}
@@ -203,13 +245,77 @@ func TestClientManager_PluginServerRegistry_RegisterUnregisterList(t *testing.T)
 	require.Len(t, m.ListPluginServers(), 1)
 }
 
+func TestClientManager_UpdatePluginServerAdminFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		pluginID    string
+		enabled     bool
+		toolConfigs []ToolConfig
+		expectFound bool
+	}{
+		{
+			name:        "patches admin fields on a registered entry",
+			pluginID:    "com.example.mcp",
+			enabled:     false,
+			toolConfigs: []ToolConfig{{Name: "echo", Policy: "ask", Enabled: false}},
+			expectFound: true,
+		},
+		{
+			name:        "unregistered plugin reports not found",
+			pluginID:    "com.example.missing",
+			enabled:     true,
+			expectFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pluginTestAPI := &plugintest.API{}
+			setupClientManagerTestAPI(t, pluginTestAPI)
+			client := pluginapi.NewClient(pluginTestAPI, nil)
+			m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
+			t.Cleanup(m.Close)
+
+			registered := PluginServerConfig{
+				PluginID:       "com.example.mcp",
+				Name:           "Example v2",
+				Path:           "/mcp/v2",
+				Enabled:        true,
+				ExposeExternal: true,
+			}
+			m.RegisterPluginServer(registered)
+
+			got, ok := m.UpdatePluginServerAdminFields(tc.pluginID, tc.enabled, tc.toolConfigs)
+			require.Equal(t, tc.expectFound, ok)
+			if !tc.expectFound {
+				require.Equal(t, PluginServerConfig{}, got)
+				stored, stillOK := m.GetPluginServer("com.example.mcp")
+				require.True(t, stillOK)
+				require.Equal(t, registered, stored, "a miss must not disturb other entries")
+				return
+			}
+
+			// Plugin-owned fields survive; admin-owned fields are patched.
+			require.Equal(t, "Example v2", got.Name)
+			require.Equal(t, "/mcp/v2", got.Path)
+			require.True(t, got.ExposeExternal)
+			require.Equal(t, tc.enabled, got.Enabled)
+			require.Equal(t, tc.toolConfigs, got.ToolConfigs)
+
+			stored, stillOK := m.GetPluginServer(tc.pluginID)
+			require.True(t, stillOK)
+			require.Equal(t, got, stored, "the patched entry must be stored back")
+		})
+	}
+}
+
 func TestClientManager_PluginRegistrationPersistence(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupTestLogger(pluginTestAPI)
 	fixture := setupPluginRegistrationKV(t, pluginTestAPI, nil)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	first := PluginServerConfig{PluginID: "com.example.first", Name: "First", Path: "/mcp", Enabled: true}
@@ -267,20 +373,21 @@ func TestClientManager_HydratesLivePluginRegistrations(t *testing.T) {
 			ExposeExternal: false,
 			ToolConfigs:    []ToolConfig{adminToolConfig},
 		}},
-	}, client.Log, client, nil, nil, nil, nil)
+	}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	got, ok := m.GetPluginServer(live.PluginID)
 	require.True(t, ok)
-	require.True(t, m.IsPluginRegistered(live.PluginID))
 	require.Equal(t, live.Name, got.Name)
 	require.Equal(t, live.Path, got.Path)
 	require.True(t, got.ExposeExternal)
 	require.True(t, got.Enabled)
 	require.Equal(t, []ToolConfig{adminToolConfig}, got.ToolConfigs)
 
-	require.False(t, m.IsPluginRegistered(disabled.PluginID))
-	require.False(t, m.IsPluginRegistered(absent.PluginID))
+	_, ok = m.GetPluginServer(disabled.PluginID)
+	require.False(t, ok)
+	_, ok = m.GetPluginServer(absent.PluginID)
+	require.False(t, ok)
 	require.Equal(t, map[string]PluginServerConfig{
 		live.PluginID: live,
 	}, fixture.registrations(t))
@@ -300,32 +407,14 @@ func TestClientManager_HydrationKeepsRegistrationsWhenServerConfigUnavailable(t 
 	pluginTestAPI.On("GetConfig").Return((*model.Config)(nil))
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
-	require.True(t, m.IsPluginRegistered(first.PluginID))
-	require.True(t, m.IsPluginRegistered(second.PluginID))
-	require.Equal(t, persisted, fixture.registrations(t))
-	require.Zero(t, fixture.writeCount())
-}
-
-func TestClientManager_UpdatePluginServerPreservesRegistrationStateAndKV(t *testing.T) {
-	pluginTestAPI := &plugintest.API{}
-	setupTestLogger(pluginTestAPI)
-	fixture := setupPluginRegistrationKV(t, pluginTestAPI, nil)
-	client := pluginapi.NewClient(pluginTestAPI, nil)
-
-	orphan := PluginServerConfig{PluginID: "com.example.orphan", Name: "Orphan", Path: "/mcp", Enabled: true}
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30, PluginServers: []PluginServerConfig{orphan}}, client.Log, client, nil, nil, nil, nil)
-	t.Cleanup(m.Close)
-
-	orphan.Enabled = false
-	m.UpdatePluginServer(orphan)
-
-	got, ok := m.GetPluginServer(orphan.PluginID)
+	_, ok := m.GetPluginServer(first.PluginID)
 	require.True(t, ok)
-	require.Equal(t, orphan, got)
-	require.False(t, m.IsPluginRegistered(orphan.PluginID))
+	_, ok = m.GetPluginServer(second.PluginID)
+	require.True(t, ok)
+	require.Equal(t, persisted, fixture.registrations(t))
 	require.Zero(t, fixture.writeCount())
 }
 
@@ -333,7 +422,7 @@ func TestClientManager_GetPluginServer(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	cfg, ok := m.GetPluginServer("missing")
@@ -361,31 +450,23 @@ func TestClientManager_GetPluginServer(t *testing.T) {
 	require.Equal(t, stored, again, "GetPluginServer must return an independent value copy")
 }
 
-func TestClientManager_HydratesPluginServersFromConfig(t *testing.T) {
+func TestClientManager_ConfigOnlyPluginServersAreNotRuntimeMembers(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	persisted := []PluginServerConfig{
-		{
-			PluginID:       "com.example.a",
-			Name:           "A",
-			Path:           "/mcp",
-			Enabled:        true,
-			ExposeExternal: false,
-			ToolConfigs: []ToolConfig{
-				{Name: "tool_a1", Policy: ToolPolicyAsk, Enabled: true},
-				{Name: "tool_a2", Policy: ToolPolicyAsk, Enabled: false},
-			},
+	const orphanID = "abcdefghijklmnopqrstuvwx0o"
+	persisted := []PluginServerConfig{{
+		ID:             orphanID,
+		PluginID:       "com.example.orphan",
+		Name:           "Orphan",
+		Path:           "/mcp",
+		Enabled:        true,
+		ExposeExternal: true,
+		ToolConfigs: []ToolConfig{
+			{Name: "tool_a1", Policy: ToolPolicyAsk, Enabled: true},
 		},
-		{
-			PluginID:       "com.example.b",
-			Name:           "B",
-			Path:           "/mcp",
-			Enabled:        false,
-			ExposeExternal: true,
-		},
-	}
+	}}
 
 	m := NewClientManager(
 		Config{IdleTimeoutMinutes: 30, PluginServers: persisted},
@@ -395,32 +476,17 @@ func TestClientManager_HydratesPluginServersFromConfig(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	t.Cleanup(m.Close)
 
-	got := m.ListPluginServers()
-	require.Len(t, got, 2, "both persisted entries must be hydrated synchronously")
-
-	byID := map[string]PluginServerConfig{}
-	for _, c := range got {
-		byID[c.PluginID] = c
-	}
-
-	a := byID["com.example.a"]
-	require.Equal(t, "A", a.Name)
-	require.Equal(t, "/mcp", a.Path)
-	require.True(t, a.Enabled)
-	require.False(t, a.ExposeExternal)
-	require.Len(t, a.ToolConfigs, 2)
-	require.Equal(t, "tool_a1", a.ToolConfigs[0].Name)
-	require.True(t, a.ToolConfigs[0].Enabled)
-	require.False(t, a.ToolConfigs[1].Enabled)
-
-	b := byID["com.example.b"]
-	require.Equal(t, "B", b.Name)
-	require.False(t, b.Enabled)
-	require.True(t, b.ExposeExternal)
-	require.Empty(t, b.ToolConfigs)
+	require.Len(t, m.ListPluginServers(), 1, "config-only rows remain visible to registry management")
+	got, ok := m.GetPluginServer("com.example.orphan")
+	require.True(t, ok)
+	require.Equal(t, orphanID, got.ID)
+	require.False(t, m.IsPluginRegistered("com.example.orphan"))
+	require.Empty(t, m.snapshotEnabledPluginServers())
+	require.Equal(t, orphanID, m.GetConfig().PluginServers[0].ID, "identity must survive in config")
 }
 
 // A config broadcast must merge persisted admin-owned fields (Enabled,
@@ -432,7 +498,7 @@ func TestClientManager_ReInitSyncsPluginServerAdminFields(t *testing.T) {
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	m.RegisterPluginServer(PluginServerConfig{
@@ -443,9 +509,11 @@ func TestClientManager_ReInitSyncsPluginServerAdminFields(t *testing.T) {
 		ExposeExternal: false,
 	})
 
+	const persistedID = "abcdefghijklmnopqrstuvwx0p"
 	newCfg := Config{
 		IdleTimeoutMinutes: 30,
 		PluginServers: []PluginServerConfig{{
+			ID:             persistedID,
 			PluginID:       "com.example.mcp",
 			Name:           "Stale Name From Config", // must be ignored on merge
 			Path:           "/stale-from-config",     // must be ignored on merge
@@ -467,39 +535,85 @@ func TestClientManager_ReInitSyncsPluginServerAdminFields(t *testing.T) {
 	require.Len(t, got.ToolConfigs, 1, "ToolConfigs merged from config")
 	require.Equal(t, "echo", got.ToolConfigs[0].Name)
 	require.False(t, got.ToolConfigs[0].Enabled)
+	require.Equal(t, persistedID, got.ID, "stable ABAC ID synced from config onto live entry")
 
 	require.Equal(t, "Live Name", got.Name)
 	require.Equal(t, "/live-mcp", got.Path)
 }
 
-func TestClientManager_ReInitInsertsConfigOnlyEntries(t *testing.T) {
+func TestApplyPersistedPluginServerFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		live        PluginServerConfig
+		persisted   PluginServerConfig
+		wantID      string
+		wantEnabled bool
+	}{
+		{
+			name: "persisted ID overlays empty live ID",
+			live: PluginServerConfig{PluginID: "com.example.a", Name: "Live", Path: "/mcp", Enabled: false},
+			persisted: PluginServerConfig{
+				ID: "config-id", PluginID: "com.example.a", Enabled: true,
+				ToolConfigs: []ToolConfig{{Name: "t", Enabled: true}},
+			},
+			wantID: "config-id", wantEnabled: true,
+		},
+		{
+			name:      "persisted ID replaces stale live ID",
+			live:      PluginServerConfig{ID: "stale", PluginID: "com.example.a", Enabled: true},
+			persisted: PluginServerConfig{ID: "config-id", PluginID: "com.example.a", Enabled: false},
+			wantID:    "config-id", wantEnabled: false,
+		},
+		{
+			name:      "empty persisted ID keeps live ID",
+			live:      PluginServerConfig{ID: "live-id", PluginID: "com.example.a", Enabled: true},
+			persisted: PluginServerConfig{PluginID: "com.example.a", Enabled: false},
+			wantID:    "live-id", wantEnabled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyPersistedPluginServerFields(tt.live, tt.persisted)
+			assert.Equal(t, tt.wantID, got.ID)
+			assert.Equal(t, tt.wantEnabled, got.Enabled)
+			assert.Equal(t, tt.live.Name, got.Name)
+			assert.Equal(t, tt.live.Path, got.Path)
+			assert.Equal(t, tt.live.ExposeExternal, got.ExposeExternal)
+		})
+	}
+}
+
+func TestClientManager_ReInitHydratesConfigOnlyEntriesWithoutRegistering(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	require.Empty(t, m.ListPluginServers(), "precondition: empty registry")
 
+	const orphanID = "abcdefghijklmnopqrstuvwx0o"
 	cfg := Config{
 		IdleTimeoutMinutes: 30,
 		PluginServers: []PluginServerConfig{{
+			ID:             orphanID,
 			PluginID:       "com.example.mcp",
 			Name:           "From Config",
 			Path:           "/from-config",
 			Enabled:        true,
-			ExposeExternal: false,
+			ExposeExternal: true,
 		}},
 	}
 
 	m.ReInit(cfg, nil)
 
+	require.Len(t, m.ListPluginServers(), 1)
 	got, ok := m.GetPluginServer("com.example.mcp")
 	require.True(t, ok)
-	require.Equal(t, "From Config", got.Name)
-	require.Equal(t, "/from-config", got.Path)
-	require.True(t, got.Enabled)
+	require.Equal(t, orphanID, got.ID)
+	require.False(t, m.IsPluginRegistered("com.example.mcp"))
+	require.Equal(t, orphanID, m.GetConfig().PluginServers[0].ID)
 }
 
 // Live registrations absent from config must survive config broadcasts.
@@ -508,7 +622,7 @@ func TestClientManager_ReInitPreservesUnpersistedRuntimeEntries(t *testing.T) {
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	live := PluginServerConfig{
@@ -530,52 +644,11 @@ func TestClientManager_ReInitPreservesUnpersistedRuntimeEntries(t *testing.T) {
 	}
 	m.ReInit(cfg, nil)
 
-	require.Len(t, m.ListPluginServers(), 2)
+	require.Len(t, m.ListPluginServers(), 2, "config-only rows remain available for management")
+	require.False(t, m.IsPluginRegistered("com.example.other"))
 	stillLive, ok := m.GetPluginServer("com.example.live")
 	require.True(t, ok, "runtime registration must survive ReInit")
 	require.Equal(t, live, stillLive)
-}
-
-func TestClientManager_IsPluginRegistered(t *testing.T) {
-	pluginTestAPI := &plugintest.API{}
-	setupClientManagerTestAPI(t, pluginTestAPI)
-	client := pluginapi.NewClient(pluginTestAPI, nil)
-
-	cfg := Config{
-		IdleTimeoutMinutes: 30,
-		PluginServers: []PluginServerConfig{{
-			PluginID: "com.example.orphan",
-			Name:     "Orphan",
-			Path:     "/mcp",
-			Enabled:  true,
-		}},
-	}
-	m := NewClientManager(cfg, client.Log, client, nil, nil, nil, nil)
-	t.Cleanup(m.Close)
-
-	require.False(t, m.IsPluginRegistered("com.example.orphan"),
-		"entry hydrated only from persisted config must not be reported as registered")
-	require.False(t, m.IsPluginRegistered("com.example.missing"))
-
-	m.RegisterPluginServer(PluginServerConfig{
-		PluginID: "com.example.live",
-		Name:     "Live",
-		Path:     "/live",
-		Enabled:  true,
-	})
-	require.True(t, m.IsPluginRegistered("com.example.live"))
-
-	m.RegisterPluginServer(PluginServerConfig{
-		PluginID: "com.example.orphan",
-		Name:     "Orphan",
-		Path:     "/mcp",
-		Enabled:  true,
-	})
-	require.True(t, m.IsPluginRegistered("com.example.orphan"),
-		"an explicit Register must mark a previously-orphan entry as registered")
-
-	m.UnregisterPluginServer("com.example.live")
-	require.False(t, m.IsPluginRegistered("com.example.live"))
 }
 
 func TestClientManager_SyncPluginServersFromConfig_SkipsEmptyPluginID(t *testing.T) {
@@ -583,20 +656,27 @@ func TestClientManager_SyncPluginServersFromConfig_SkipsEmptyPluginID(t *testing
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	cfg := Config{
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
+	t.Cleanup(m.Close)
+
+	m.RegisterPluginServer(PluginServerConfig{
+		PluginID: "com.example.valid", Name: "Valid", Path: "/mcp", Enabled: true,
+	})
+
+	m.ReInit(Config{
 		IdleTimeoutMinutes: 30,
 		PluginServers: []PluginServerConfig{
 			{PluginID: "", Name: "Empty ID", Path: "/x", Enabled: true},
-			{PluginID: "com.example.valid", Name: "Valid", Path: "/mcp", Enabled: true},
+			{PluginID: "com.example.valid", Name: "Stale", Path: "/stale", Enabled: false, ID: "abcdefghijklmnopqrstuvwx0v"},
 		},
-	}
-
-	m := NewClientManager(cfg, client.Log, client, nil, nil, nil, nil)
-	t.Cleanup(m.Close)
+	}, nil)
 
 	got := m.ListPluginServers()
-	require.Len(t, got, 1, "empty-PluginID entry must be skipped; only valid entry hydrated")
+	require.Len(t, got, 1)
 	require.Equal(t, "com.example.valid", got[0].PluginID)
+	require.Equal(t, "Valid", got[0].Name, "plugin-owned Name must survive sync")
+	require.False(t, got[0].Enabled, "admin Enabled merged from config")
+	require.Equal(t, "abcdefghijklmnopqrstuvwx0v", got[0].ID)
 }
 
 func TestClientManager_GetToolsForUser_PluginEnabled(t *testing.T) {
@@ -609,7 +689,7 @@ func TestClientManager_GetToolsForUser_PluginEnabled(t *testing.T) {
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI, nil)
 	t.Cleanup(m.Close)
 
 	cfg := PluginServerConfig{
@@ -639,7 +719,7 @@ func TestClientManager_GetToolsForUser_PluginDisabled_ZeroTools(t *testing.T) {
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI, nil)
 	t.Cleanup(m.Close)
 
 	cfg := PluginServerConfig{
@@ -690,7 +770,7 @@ func TestClientManager_GetToolsForUser_PluginEnabled_HTTPFailure(t *testing.T) {
 			setupClientManagerTestAPI(t, pluginTestAPI)
 			client := pluginapi.NewClient(pluginTestAPI, nil)
 
-			m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI)
+			m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI, nil)
 			t.Cleanup(m.Close)
 
 			m.RegisterPluginServer(PluginServerConfig{
@@ -739,7 +819,7 @@ func TestClientManager_GetToolsForUser_PluginConnectErrorsAreRequestScoped(t *te
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI, nil)
 	t.Cleanup(m.Close)
 	m.RegisterPluginServer(PluginServerConfig{
 		PluginID: "com.example.mcp",
@@ -786,7 +866,7 @@ func TestClientManager_GetToolsForUser_MultiplePluginServers(t *testing.T) {
 		},
 	}
 
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, mockAPI, nil)
 	t.Cleanup(m.Close)
 
 	m.RegisterPluginServer(PluginServerConfig{PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true})
@@ -811,7 +891,7 @@ func TestClientManager_PluginServerRegistry_RaceSafe(t *testing.T) {
 	pluginTestAPI := &plugintest.API{}
 	setupClientManagerTestAPI(t, pluginTestAPI)
 	client := pluginapi.NewClient(pluginTestAPI, nil)
-	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil)
+	m := NewClientManager(Config{IdleTimeoutMinutes: 30}, client.Log, client, nil, nil, nil, nil, nil)
 	t.Cleanup(m.Close)
 
 	const writers = 8
@@ -909,18 +989,17 @@ func TestClientManagerGetToolRetrievalOverridesEmbedded(t *testing.T) {
 
 func TestClientManagerGetToolRetrievalOverridesPlugin(t *testing.T) {
 	manager := &ClientManager{
-		config: Config{
-			PluginServers: []PluginServerConfig{
-				{
-					PluginID: "com.example.mcp",
-					Enabled:  true,
-					ToolConfigs: []ToolConfig{
-						{Name: "lookup", Policy: ToolPolicyAsk, Enabled: true, RetrievalDescriptionOverride: "Find plugin records"},
-					},
-				},
-			},
+		pluginServers:    make(map[string]PluginServerConfig),
+		pluginRegistered: make(map[string]bool),
+	}
+	manager.pluginServers["com.example.mcp"] = PluginServerConfig{
+		PluginID: "com.example.mcp",
+		Enabled:  true,
+		ToolConfigs: []ToolConfig{
+			{Name: "lookup", Policy: ToolPolicyAsk, Enabled: true, RetrievalDescriptionOverride: "Find plugin records"},
 		},
 	}
+	manager.pluginRegistered["com.example.mcp"] = true
 
 	overrides := manager.GetToolRetrievalOverrides()
 

--- a/mcp/testhelpers_test.go
+++ b/mcp/testhelpers_test.go
@@ -541,7 +541,7 @@ func (s *EmbeddedTestSuite) CreateClientManager(t *testing.T, session *model.Ses
 	}
 
 	// Create ClientManager with nil httpClient for tests (no remote requests in these tests)
-	manager := NewClientManager(config, pluginAPIClient.Log, pluginAPIClient, nil, wrapper, nil, nil)
+	manager := NewClientManager(config, pluginAPIClient.Log, pluginAPIClient, nil, wrapper, nil, nil, nil)
 	require.NotNil(t, manager, "ClientManager should not be nil")
 
 	return manager

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mmapi"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -909,5 +910,5 @@ func shortSlugHash(value string) string {
 // pluginServerOriginKey returns the synthetic origin string for plugin-server
 // tools. Must match the key used by filterToolsByConfig.
 func pluginServerOriginKey(pluginID string) string {
-	return "plugin://" + pluginID
+	return config.PluginServerOrigin(pluginID)
 }

--- a/mcp/user_clients_test.go
+++ b/mcp/user_clients_test.go
@@ -512,6 +512,7 @@ func TestClientManagerGetToolsForUser_ReconnectsAfterStoredSessionRevoked(t *tes
 		&sessionEchoEmbeddedMCPServer{ctx: runCtx},
 		http.DefaultClient,
 		nil,
+		nil,
 	)
 	t.Cleanup(manager.Close)
 

--- a/server/abac_id_migrations.go
+++ b/server/abac_id_migrations.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/store"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -17,8 +16,10 @@ import (
 // service IDs are rewritten to model.NewId() values, and MCP servers (external,
 // embedded, and plugin-registered) get stable IDs assigned. All run in a
 // single idempotent store transaction, guarded by one cluster mutex. Returns
-// whether the migration wrote to the DB.
-func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.Store, cfg *config.Container) (bool, error) {
+// whether the migration wrote to the DB. Callers must load config from the
+// store afterwards — Migrated=false means another node already wrote, not that
+// this process's memory is current.
+func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.Store) (bool, error) {
 	mtx, err := cluster.NewMutex(api, "ai_abac_id_migration")
 	if err != nil {
 		return false, fmt.Errorf("failed to create ABAC ID migration mutex: %w", err)
@@ -32,15 +33,6 @@ func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.
 	}
 
 	if report.Migrated {
-		reloaded, reloadErr := st.GetConfig()
-		if reloadErr != nil {
-			return false, fmt.Errorf("failed to reload config after ID migrations: %w", reloadErr)
-		}
-		if reloaded != nil {
-			if storeErr := cfg.StorePersistedConfigWithoutNotify(reloaded); storeErr != nil {
-				return false, fmt.Errorf("failed to store config after ID migrations: %w", storeErr)
-			}
-		}
 		pluginAPI.Log.Info("ABAC ID migrations applied",
 			"services_remapped", report.ServicesRemapped,
 			"agent_rows_updated", report.AgentRowsUpdated,

--- a/server/abac_id_migrations.go
+++ b/server/abac_id_migrations.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
+)
+
+// runABACIDMigrations runs the one-time ABAC identity migrations: legacy UUID
+// service IDs are rewritten to model.NewId() values, and MCP servers (external,
+// embedded, and plugin-registered) get stable IDs assigned. All run in a
+// single idempotent store transaction, guarded by one cluster mutex. Returns
+// whether the migration wrote to the DB.
+func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.Store, cfg *config.Container) (bool, error) {
+	mtx, err := cluster.NewMutex(api, "ai_abac_id_migration")
+	if err != nil {
+		return false, fmt.Errorf("failed to create ABAC ID migration mutex: %w", err)
+	}
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	report, err := st.MigrateABACIDs()
+	if err != nil {
+		return false, fmt.Errorf("failed to migrate ABAC IDs: %w", err)
+	}
+
+	if report.Migrated {
+		reloaded, reloadErr := st.GetConfig()
+		if reloadErr != nil {
+			return false, fmt.Errorf("failed to reload config after ID migrations: %w", reloadErr)
+		}
+		if reloaded != nil {
+			if storeErr := cfg.StorePersistedConfigWithoutNotify(reloaded); storeErr != nil {
+				return false, fmt.Errorf("failed to store config after ID migrations: %w", storeErr)
+			}
+		}
+		pluginAPI.Log.Info("ABAC ID migrations applied",
+			"services_remapped", report.ServicesRemapped,
+			"agent_rows_updated", report.AgentRowsUpdated,
+			"mcp_ids_assigned", report.MCPServerIDsAssigned,
+			"embedded_plugin_mcp_ids_assigned", report.EmbeddedPluginServerIDsAssigned,
+		)
+	}
+	for _, ref := range report.DanglingServiceRefs {
+		pluginAPI.Log.Warn("Dangling service reference left unchanged by service ID migration", "reference", ref)
+	}
+
+	return report.Migrated, nil
+}

--- a/server/legacy_bot_migration.go
+++ b/server/legacy_bot_migration.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/store"
@@ -114,19 +116,36 @@ func migrateLegacyConfigBotsToUserAgents(api plugin.API, pluginAPI *pluginapi.Cl
 		byUsername[bc.Name] = struct{}{}
 	}
 
-	newCfg := *dbCfg
-	newCfg.Bots = nil
-	if saveErr := st.SaveConfig(newCfg); saveErr != nil {
-		return false, fmt.Errorf("failed to save config after legacy bot migration: %w", saveErr)
-	}
-	reloaded, err := st.GetConfig()
-	if err != nil {
-		return false, fmt.Errorf("failed to reload config: %w", err)
-	}
-	if reloaded != nil {
-		if err := cfg.StorePersistedConfigWithoutNotify(reloaded); err != nil {
-			return false, fmt.Errorf("failed to store config after legacy bot migration: %w", err)
+	// Clear Bots atomically against the freshest persisted config: a blind
+	// SaveConfig of the dbCfg snapshot read above could overwrite a concurrent
+	// writer's changes (e.g. an admin save or the ID migration's remapped IDs).
+	// If Bots itself changed since the snapshot the agents were created from,
+	// defer instead of clearing a list that was never migrated; the created
+	// agents are deduplicated by username on the retry.
+	errBotsChanged := errors.New("config bots changed during legacy bot migration")
+	saved, err := st.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		if prev == nil {
+			return config.Config{}, fmt.Errorf("active config disappeared during legacy bot migration")
 		}
+		if !reflect.DeepEqual(prev.Bots, dbCfg.Bots) {
+			return config.Config{}, errBotsChanged
+		}
+		next := *prev
+		next.Bots = nil
+		return next, nil
+	})
+	if errors.Is(err, errBotsChanged) {
+		// Soft defer (not an error): we retry on the next config update.
+		pluginAPI.Log.Warn("Deferring legacy bot migration: config bots changed concurrently")
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to save config after legacy bot migration: %w", err)
+	}
+	// Deliberately without notify: the caller is already servicing a config
+	// update listener; notifying here would re-enter it.
+	if err := cfg.StorePersistedConfigWithoutNotify(&saved); err != nil {
+		return false, fmt.Errorf("failed to store config after legacy bot migration: %w", err)
 	}
 
 	if err := st.SetSystemValue(legacyConfigBotsMigratedKey, "true"); err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -191,7 +191,15 @@ func (p *Plugin) OnActivate() error {
 	}
 	mtx2.Unlock()
 
-	// Load config from DB into memory and set migrated flag
+	// ABAC ID migrations must run after the config.json->DB migration and
+	// before runtime config is loaded, so no subsystem can observe legacy
+	// service IDs or ID-less MCP servers.
+	idsMigrated, err := runABACIDMigrations(p.API, pluginAPI, p.store, &p.configuration)
+	if err != nil {
+		return fmt.Errorf("failed to run ABAC ID migrations: %w", err)
+	}
+
+	// Load the fully migrated config from DB into memory and set migrated flag.
 	dbConfig, err := p.store.GetConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config from database: %w", err)
@@ -200,6 +208,15 @@ func (p *Plugin) OnActivate() error {
 		p.configuration.Update(dbConfig)
 	}
 	p.configMigrated = true
+
+	if idsMigrated {
+		if pubErr := p.PublishConfigUpdate(); pubErr != nil {
+			pluginAPI.Log.Error("Failed to publish config update after ID migration", "error", pubErr.Error())
+		}
+		if pubErr := p.PublishAgentUpdate(); pubErr != nil {
+			pluginAPI.Log.Error("Failed to publish agent update after ID migration", "error", pubErr.Error())
+		}
+	}
 
 	bots := bots.New(p.API, pluginAPI, licenseChecker, &p.configuration, p.store, llmUpstreamHTTPClient, metricsService)
 

--- a/server/main.go
+++ b/server/main.go
@@ -192,9 +192,9 @@ func (p *Plugin) OnActivate() error {
 	mtx2.Unlock()
 
 	// ABAC ID migrations must run after the config.json->DB migration and
-	// before runtime config is loaded, so no subsystem can observe legacy
-	// service IDs or ID-less MCP servers.
-	idsMigrated, err := runABACIDMigrations(p.API, pluginAPI, p.store, &p.configuration)
+	// before runtime config is loaded. A follower that waited on the cluster
+	// lock must reload the winner's remapped IDs even when Migrated is false.
+	idsMigrated, err := runABACIDMigrations(p.API, pluginAPI, p.store)
 	if err != nil {
 		return fmt.Errorf("failed to run ABAC ID migrations: %w", err)
 	}

--- a/store/config.go
+++ b/store/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -17,6 +18,12 @@ const (
 	configSaveLockNamespace = int32(12457)
 	configSaveLockKey       = int32(1)
 )
+
+// ErrStaleLegacyServiceIDs is returned by any config write that still
+// contains legacy UUID service IDs after the one-time service ID migration
+// has run — a stale client writing pre-migration IDs back. Enforced inside
+// insertActiveConfigTx so every writer is covered.
+var ErrStaleLegacyServiceIDs = errors.New("config contains legacy UUID service IDs from before the ID migration; reload the system console and retry")
 
 // GetConfig retrieves the currently active configuration from the database.
 // Returns nil, nil if no active config exists (e.g., fresh install before migration).
@@ -41,12 +48,11 @@ func (s *Store) GetConfig() (*config.Config, error) {
 // SaveConfig persists a new configuration to the database with history.
 // The previous active config is deactivated and a new active row is inserted.
 // All prior configs are preserved with Active = false.
+//
+// SaveConfig is a blind write, only appropriate for bootstrap/first-write
+// paths. Read-modify-write callers must use UpdateConfig or they can lose a
+// concurrent writer's update.
 func (s *Store) SaveConfig(cfg config.Config) error {
-	configBytes, err := json.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
 	tx, err := s.db.Beginx()
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -63,13 +69,95 @@ func (s *Store) SaveConfig(cfg config.Config) error {
 		return fmt.Errorf("failed to lock config save transaction: %w", err)
 	}
 
-	// Deactivate current active config (at most one row, indexed on Active)
-	if _, err = tx.Exec("UPDATE Agents_ConfigHistory SET Active = false WHERE Active = true"); err != nil {
-		return fmt.Errorf("failed to deactivate current config: %w", err)
+	if err = insertActiveConfigTx(tx, cfg); err != nil {
+		return err
 	}
 
-	// Insert new active config
-	if _, err = tx.Exec(
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit config save: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateConfig atomically reads the active config, applies transform, and
+// persists the result as the new active row — one transaction under the same
+// advisory lock as SaveConfig, so no concurrent save or migration can
+// interleave. transform receives nil when no active config exists; a
+// transform error aborts with nothing written and is returned unwrapped so
+// callers can map their own sentinel errors.
+func (s *Store) UpdateConfig(transform func(prev *config.Config) (config.Config, error)) (config.Config, error) {
+	var next config.Config
+
+	tx, err := s.db.Beginx()
+	if err != nil {
+		return next, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.Exec("SELECT pg_advisory_xact_lock($1, $2)", configSaveLockNamespace, configSaveLockKey); err != nil {
+		return next, fmt.Errorf("failed to lock config update transaction: %w", err)
+	}
+
+	prev, _, err := getActiveConfigTx(tx)
+	if err != nil {
+		return next, err
+	}
+	next, err = transform(prev)
+	if err != nil {
+		return next, err
+	}
+
+	if err = insertActiveConfigTx(tx, next); err != nil {
+		return next, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return next, fmt.Errorf("failed to commit config update: %w", err)
+	}
+
+	return next, nil
+}
+
+// configHasLegacyUUIDServiceIDs reports whether any service entry carries a
+// pre-migration 36-char UUID as its ID.
+func configHasLegacyUUIDServiceIDs(cfg *config.Config) bool {
+	for i := range cfg.Services {
+		if isLegacyUUID(cfg.Services[i].ID) {
+			return true
+		}
+	}
+	return false
+}
+
+// insertActiveConfigTx deactivates the current active config-history row and
+// inserts cfg as the new active one. It enforces the post-migration invariant
+// that no writer can reintroduce legacy UUID service IDs once the service ID
+// migration marker is set (the migration itself rewrites UUIDs before
+// inserting, so it never trips the guard).
+func insertActiveConfigTx(tx *sqlx.Tx, cfg config.Config) error {
+	migrated, err := getSystemValueTx(tx, serviceIDMigrationKey)
+	if err != nil {
+		return err
+	}
+	if migrated == "1" && configHasLegacyUUIDServiceIDs(&cfg) {
+		return ErrStaleLegacyServiceIDs
+	}
+
+	configBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	// Deactivate current active config (at most one row, indexed on Active)
+	if _, err := tx.Exec("UPDATE Agents_ConfigHistory SET Active = false WHERE Active = true"); err != nil {
+		return fmt.Errorf("failed to deactivate current config: %w", err)
+	}
+	if _, err := tx.Exec(
 		"INSERT INTO Agents_ConfigHistory (ID, Config, CreateAt, Active) VALUES ($1, $2, $3, $4)",
 		model.NewId(),
 		string(configBytes),
@@ -78,11 +166,6 @@ func (s *Store) SaveConfig(cfg config.Config) error {
 	); err != nil {
 		return fmt.Errorf("failed to insert new config: %w", err)
 	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit config save: %w", err)
-	}
-
 	return nil
 }
 

--- a/store/config.go
+++ b/store/config.go
@@ -19,11 +19,11 @@ const (
 	configSaveLockKey       = int32(1)
 )
 
-// ErrStaleLegacyServiceIDs is returned by any config write that still
-// contains legacy UUID service IDs after the one-time service ID migration
-// has run — a stale client writing pre-migration IDs back. Enforced inside
-// insertActiveConfigTx so every writer is covered.
-var ErrStaleLegacyServiceIDs = errors.New("config contains legacy UUID service IDs from before the ID migration; reload the system console and retry")
+// ErrLegacyUUIDServiceID is returned by any config write that contains a
+// dashed UUID in Services[].ID after the ABAC ID migration marker is set.
+// That format is invalid post-migration; the write is rejected, not reminted.
+// Enforced inside insertActiveConfigTx so every writer is covered.
+var ErrLegacyUUIDServiceID = errors.New("config contains invalid UUID service IDs after the ID migration")
 
 // GetConfig retrieves the currently active configuration from the database.
 // Returns nil, nil if no active config exists (e.g., fresh install before migration).
@@ -135,17 +135,17 @@ func configHasLegacyUUIDServiceIDs(cfg *config.Config) bool {
 }
 
 // insertActiveConfigTx deactivates the current active config-history row and
-// inserts cfg as the new active one. It enforces the post-migration invariant
-// that no writer can reintroduce legacy UUID service IDs once the service ID
-// migration marker is set (the migration itself rewrites UUIDs before
-// inserting, so it never trips the guard).
+// inserts cfg as the new active one. After the ABAC ID migration marker is
+// set, a dashed UUID in Services[].ID is an invalid ID format and the write
+// is rejected (the migration itself rewrites UUIDs before inserting, so it
+// never trips the guard).
 func insertActiveConfigTx(tx *sqlx.Tx, cfg config.Config) error {
-	migrated, err := getSystemValueTx(tx, serviceIDMigrationKey)
+	migrated, err := getSystemValueTx(tx, abacIDMigrationKey)
 	if err != nil {
 		return err
 	}
 	if migrated == "1" && configHasLegacyUUIDServiceIDs(&cfg) {
-		return ErrStaleLegacyServiceIDs
+		return ErrLegacyUUIDServiceID
 	}
 
 	configBytes, err := json.Marshal(cfg)

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -401,7 +401,7 @@ func TestSaveConfigRejectsLegacyUUIDsAfterMigration(t *testing.T) {
 	err = s.SaveConfig(config.Config{
 		Services: []llm.ServiceConfig{{ID: testUUIDA, Name: "A"}},
 	})
-	require.ErrorIs(t, err, ErrStaleLegacyServiceIDs)
+	require.ErrorIs(t, err, ErrLegacyUUIDServiceID)
 	assert.Equal(t, rowsBefore, configHistoryCount(t, s), "rejected save must not write a config row")
 
 	current, err := s.GetConfig()

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -380,6 +380,107 @@ func TestSaveConfigConcurrent(t *testing.T) {
 	assert.Equal(t, workerCount, totalCount)
 }
 
+// TestSaveConfigRejectsLegacyUUIDsAfterMigration proves the post-migration
+// legacy UUID guard lives inside the shared write primitive: even a direct
+// SaveConfig (not just UpdateConfig) cannot reintroduce pre-migration UUID
+// service IDs once the migration marker is set.
+func TestSaveConfigRejectsLegacyUUIDsAfterMigration(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+
+	require.NoError(t, s.SaveConfig(config.Config{
+		Services: []llm.ServiceConfig{{ID: testUUIDA, Name: "A"}},
+	}))
+	report, err := s.MigrateABACIDs()
+	require.NoError(t, err)
+	require.True(t, report.Migrated)
+	migrated, err := s.GetConfig()
+	require.NoError(t, err)
+
+	rowsBefore := configHistoryCount(t, s)
+	err = s.SaveConfig(config.Config{
+		Services: []llm.ServiceConfig{{ID: testUUIDA, Name: "A"}},
+	})
+	require.ErrorIs(t, err, ErrStaleLegacyServiceIDs)
+	assert.Equal(t, rowsBefore, configHistoryCount(t, s), "rejected save must not write a config row")
+
+	current, err := s.GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, migrated.Services[0].ID, current.Services[0].ID, "migrated ID must survive the rejected save")
+
+	// A payload without UUIDs still saves normally.
+	require.NoError(t, s.SaveConfig(*migrated))
+}
+
+// TestUpdateConfigConcurrentWritersNoLostUpdate is the read-modify-write race
+// regression: two concurrent writers that each modify a different part of the
+// config must both land — the advisory lock serializes them and each
+// transform sees the other's committed write, so no update (including the
+// migrated service IDs the base config carries) can be lost.
+func TestUpdateConfigConcurrentWritersNoLostUpdate(t *testing.T) {
+	baseStore := setupTestStore(t)
+	require.NoError(t, baseStore.RunMigrations())
+
+	var schemaName string
+	require.NoError(t, baseStore.db.Get(&schemaName, "SELECT current_schema()"))
+
+	// Base config as the ID migration left it: migrated 26-char service ID.
+	require.NoError(t, baseStore.SaveConfig(config.Config{
+		Services: []llm.ServiceConfig{{ID: testUUIDA, Name: "A"}},
+	}))
+	report, err := baseStore.MigrateABACIDs()
+	require.NoError(t, err)
+	require.True(t, report.Migrated)
+	migrated, err := baseStore.GetConfig()
+	require.NoError(t, err)
+	migratedID := migrated.Services[0].ID
+
+	writerA := setupSchemaBoundStore(t, schemaName)
+	writerB := setupSchemaBoundStore(t, schemaName)
+
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, updateErr := writerA.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+			next := *prev
+			next.DefaultBotName = "writer-a"
+			return next, nil
+		})
+		errCh <- updateErr
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, updateErr := writerB.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+			next := *prev
+			next.MCP.Servers = append(append([]config.MCPServerConfig(nil), prev.MCP.Servers...),
+				config.MCPServerConfig{ID: "writerbserverwriterbserver", Name: "B", BaseURL: "https://b.example.com"})
+			return next, nil
+		})
+		errCh <- updateErr
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for updateErr := range errCh {
+		require.NoError(t, updateErr)
+	}
+
+	final, err := baseStore.GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "writer-a", final.DefaultBotName, "writer A's change must survive")
+	require.Len(t, final.MCP.Servers, 1, "writer B's change must survive")
+	assert.Equal(t, "writerbserverwriterbserver", final.MCP.Servers[0].ID)
+	require.Len(t, final.Services, 1)
+	assert.Equal(t, migratedID, final.Services[0].ID, "migrated service ID must not be lost")
+}
+
 func TestSaveConfigWaitsForConfigLock(t *testing.T) {
 	baseStore := setupTestStore(t)
 

--- a/store/id_migrations.go
+++ b/store/id_migrations.go
@@ -15,29 +15,13 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
-// Agents_System markers for the one-time ABAC ID migrations (value "1").
-const (
-	serviceIDMigrationKey              = "abac_service_id_migration_done"
-	mcpServerIDMigrationKey            = "abac_mcp_server_id_migration_done"
-	embeddedPluginServerIDMigrationKey = "abac_embedded_plugin_server_id_migration_done"
-)
+// Agents_System marker for the one-time ABAC ID migration (value "1").
+const abacIDMigrationKey = "abac_id_migration_done"
 
 // isLegacyUUID reports whether s is a canonical dashed UUID, the legacy
 // service-ID format that predates model.NewId()-style IDs.
 func isLegacyUUID(s string) bool {
 	return len(s) == 36 && uuid.Validate(s) == nil
-}
-
-// mintUniqueMCPServerID returns a fresh model.NewId not present in occupied
-// and records it so subsequent mints in the same pass stay unique across kinds.
-func mintUniqueMCPServerID(occupied map[string]struct{}) string {
-	for {
-		id := model.NewId()
-		if _, taken := occupied[id]; !taken {
-			occupied[id] = struct{}{}
-			return id
-		}
-	}
 }
 
 // ABACIDMigrationReport summarizes what MigrateABACIDs did so the caller
@@ -54,9 +38,9 @@ type ABACIDMigrationReport struct {
 	DanglingServiceRefs             []string
 }
 
-// MigrateABACIDs runs the one-time ABAC ID migrations in a single transaction
-// that writes at most one new active config row and sets Agents_System markers
-// atomically:
+// MigrateABACIDs runs the one-time ABAC ID migration in a single transaction
+// that writes at most one new active config row and sets the Agents_System
+// marker atomically:
 //
 //   - service IDs: legacy UUID service IDs in the active config and in
 //     Agents_UserAgents.ServiceID are rewritten to model.NewId() values.
@@ -66,26 +50,18 @@ type ABACIDMigrationReport struct {
 //   - embedded/plugin MCP server IDs: EmbeddedServer.ID and every
 //     PluginServers entry with no ID get a stable model.NewId().
 //
-// Idempotent: markers short-circuit re-runs, and the rewrite is content-based
-// (only UUID service IDs / empty MCP IDs are touched), so a crash between the
-// config write and the marker write is recovered safely.
+// Idempotent: the marker short-circuits re-runs, and the rewrite is content-based
+// (only UUID service IDs / empty MCP IDs are touched). Config and marker writes
+// share one Postgres transaction; on failure the transaction is rolled back.
 func (s *Store) MigrateABACIDs() (ABACIDMigrationReport, error) {
 	report := ABACIDMigrationReport{}
 
 	// Fast path; the authoritative re-check happens inside the tx under the lock.
-	serviceDone, err := s.GetSystemValue(serviceIDMigrationKey)
+	done, err := s.GetSystemValue(abacIDMigrationKey)
 	if err != nil {
 		return report, err
 	}
-	mcpDone, err := s.GetSystemValue(mcpServerIDMigrationKey)
-	if err != nil {
-		return report, err
-	}
-	embeddedPluginDone, err := s.GetSystemValue(embeddedPluginServerIDMigrationKey)
-	if err != nil {
-		return report, err
-	}
-	if serviceDone == "1" && mcpDone == "1" && embeddedPluginDone == "1" {
+	if done == "1" {
 		return report, nil
 	}
 
@@ -105,19 +81,11 @@ func (s *Store) MigrateABACIDs() (ABACIDMigrationReport, error) {
 		return report, fmt.Errorf("failed to lock ABAC ID migration transaction: %w", err)
 	}
 
-	serviceDone, err = getSystemValueTx(tx, serviceIDMigrationKey)
+	done, err = getSystemValueTx(tx, abacIDMigrationKey)
 	if err != nil {
 		return report, err
 	}
-	mcpDone, err = getSystemValueTx(tx, mcpServerIDMigrationKey)
-	if err != nil {
-		return report, err
-	}
-	embeddedPluginDone, err = getSystemValueTx(tx, embeddedPluginServerIDMigrationKey)
-	if err != nil {
-		return report, err
-	}
-	if serviceDone == "1" && mcpDone == "1" && embeddedPluginDone == "1" {
+	if done == "1" {
 		// Another node finished between the fast path and the lock.
 		_ = tx.Rollback()
 		return report, nil
@@ -129,31 +97,27 @@ func (s *Store) MigrateABACIDs() (ABACIDMigrationReport, error) {
 	}
 
 	configChanged := false
-	if found && serviceDone != "1" {
+	if found {
 		if err = migrateServiceIDsTx(tx, cfg, &report); err != nil {
 			return report, err
 		}
 		configChanged = configChanged || report.ServicesRemapped > 0
-	}
-	if found && mcpDone != "1" {
-		occupied := config.OccupiedMCPServerIDs(cfg.MCP)
+
 		for i := range cfg.MCP.Servers {
 			if cfg.MCP.Servers[i].ID == "" {
-				cfg.MCP.Servers[i].ID = mintUniqueMCPServerID(occupied)
+				cfg.MCP.Servers[i].ID = model.NewId()
 				report.MCPServerIDsAssigned++
 			}
 		}
 		configChanged = configChanged || report.MCPServerIDsAssigned > 0
-	}
-	if found && embeddedPluginDone != "1" {
-		occupied := config.OccupiedMCPServerIDs(cfg.MCP)
+
 		if cfg.MCP.EmbeddedServer.ID == "" {
-			cfg.MCP.EmbeddedServer.ID = mintUniqueMCPServerID(occupied)
+			cfg.MCP.EmbeddedServer.ID = model.NewId()
 			report.EmbeddedPluginServerIDsAssigned++
 		}
 		for i := range cfg.MCP.PluginServers {
 			if cfg.MCP.PluginServers[i].ID == "" {
-				cfg.MCP.PluginServers[i].ID = mintUniqueMCPServerID(occupied)
+				cfg.MCP.PluginServers[i].ID = model.NewId()
 				report.EmbeddedPluginServerIDsAssigned++
 			}
 		}
@@ -165,20 +129,8 @@ func (s *Store) MigrateABACIDs() (ABACIDMigrationReport, error) {
 			return report, err
 		}
 	}
-	if serviceDone != "1" {
-		if err = setSystemValueTx(tx, serviceIDMigrationKey, "1"); err != nil {
-			return report, err
-		}
-	}
-	if mcpDone != "1" {
-		if err = setSystemValueTx(tx, mcpServerIDMigrationKey, "1"); err != nil {
-			return report, err
-		}
-	}
-	if embeddedPluginDone != "1" {
-		if err = setSystemValueTx(tx, embeddedPluginServerIDMigrationKey, "1"); err != nil {
-			return report, err
-		}
+	if err = setSystemValueTx(tx, abacIDMigrationKey, "1"); err != nil {
+		return report, err
 	}
 	if err = tx.Commit(); err != nil {
 		return report, fmt.Errorf("failed to commit ABAC ID migration: %w", err)

--- a/store/id_migrations.go
+++ b/store/id_migrations.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// Agents_System markers for the one-time ABAC ID migrations (value "1").
+const (
+	serviceIDMigrationKey              = "abac_service_id_migration_done"
+	mcpServerIDMigrationKey            = "abac_mcp_server_id_migration_done"
+	embeddedPluginServerIDMigrationKey = "abac_embedded_plugin_server_id_migration_done"
+)
+
+// isLegacyUUID reports whether s is a canonical dashed UUID, the legacy
+// service-ID format that predates model.NewId()-style IDs.
+func isLegacyUUID(s string) bool {
+	return len(s) == 36 && uuid.Validate(s) == nil
+}
+
+// mintUniqueMCPServerID returns a fresh model.NewId not present in occupied
+// and records it so subsequent mints in the same pass stay unique across kinds.
+func mintUniqueMCPServerID(occupied map[string]struct{}) string {
+	for {
+		id := model.NewId()
+		if _, taken := occupied[id]; !taken {
+			occupied[id] = struct{}{}
+			return id
+		}
+	}
+}
+
+// ABACIDMigrationReport summarizes what MigrateABACIDs did so the caller
+// (server layer) can log it; the store has no logger.
+type ABACIDMigrationReport struct {
+	// Migrated is true when a new active config row was written.
+	Migrated bool
+	// ServicesRemapped counts service entries whose ID was rewritten,
+	// including each occurrence of a duplicated legacy ID.
+	ServicesRemapped                int
+	AgentRowsUpdated                int64
+	MCPServerIDsAssigned            int
+	EmbeddedPluginServerIDsAssigned int
+	DanglingServiceRefs             []string
+}
+
+// MigrateABACIDs runs the one-time ABAC ID migrations in a single transaction
+// that writes at most one new active config row and sets Agents_System markers
+// atomically:
+//
+//   - service IDs: legacy UUID service IDs in the active config and in
+//     Agents_UserAgents.ServiceID are rewritten to model.NewId() values.
+//     Dangling UUID references are left unchanged and reported.
+//   - MCP server IDs: every external MCP server entry with no ID gets a
+//     stable model.NewId().
+//   - embedded/plugin MCP server IDs: EmbeddedServer.ID and every
+//     PluginServers entry with no ID get a stable model.NewId().
+//
+// Idempotent: markers short-circuit re-runs, and the rewrite is content-based
+// (only UUID service IDs / empty MCP IDs are touched), so a crash between the
+// config write and the marker write is recovered safely.
+func (s *Store) MigrateABACIDs() (ABACIDMigrationReport, error) {
+	report := ABACIDMigrationReport{}
+
+	// Fast path; the authoritative re-check happens inside the tx under the lock.
+	serviceDone, err := s.GetSystemValue(serviceIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	mcpDone, err := s.GetSystemValue(mcpServerIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	embeddedPluginDone, err := s.GetSystemValue(embeddedPluginServerIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	if serviceDone == "1" && mcpDone == "1" && embeddedPluginDone == "1" {
+		return report, nil
+	}
+
+	tx, err := s.db.Beginx()
+	if err != nil {
+		return report, fmt.Errorf("failed to begin ABAC ID migration transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Same advisory lock as SaveConfig: serializes against concurrent admin
+	// saves and migration attempts from other nodes.
+	if _, err = tx.Exec("SELECT pg_advisory_xact_lock($1, $2)", configSaveLockNamespace, configSaveLockKey); err != nil {
+		return report, fmt.Errorf("failed to lock ABAC ID migration transaction: %w", err)
+	}
+
+	serviceDone, err = getSystemValueTx(tx, serviceIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	mcpDone, err = getSystemValueTx(tx, mcpServerIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	embeddedPluginDone, err = getSystemValueTx(tx, embeddedPluginServerIDMigrationKey)
+	if err != nil {
+		return report, err
+	}
+	if serviceDone == "1" && mcpDone == "1" && embeddedPluginDone == "1" {
+		// Another node finished between the fast path and the lock.
+		_ = tx.Rollback()
+		return report, nil
+	}
+
+	cfg, found, err := getActiveConfigTx(tx)
+	if err != nil {
+		return report, err
+	}
+
+	configChanged := false
+	if found && serviceDone != "1" {
+		if err = migrateServiceIDsTx(tx, cfg, &report); err != nil {
+			return report, err
+		}
+		configChanged = configChanged || report.ServicesRemapped > 0
+	}
+	if found && mcpDone != "1" {
+		occupied := config.OccupiedMCPServerIDs(cfg.MCP)
+		for i := range cfg.MCP.Servers {
+			if cfg.MCP.Servers[i].ID == "" {
+				cfg.MCP.Servers[i].ID = mintUniqueMCPServerID(occupied)
+				report.MCPServerIDsAssigned++
+			}
+		}
+		configChanged = configChanged || report.MCPServerIDsAssigned > 0
+	}
+	if found && embeddedPluginDone != "1" {
+		occupied := config.OccupiedMCPServerIDs(cfg.MCP)
+		if cfg.MCP.EmbeddedServer.ID == "" {
+			cfg.MCP.EmbeddedServer.ID = mintUniqueMCPServerID(occupied)
+			report.EmbeddedPluginServerIDsAssigned++
+		}
+		for i := range cfg.MCP.PluginServers {
+			if cfg.MCP.PluginServers[i].ID == "" {
+				cfg.MCP.PluginServers[i].ID = mintUniqueMCPServerID(occupied)
+				report.EmbeddedPluginServerIDsAssigned++
+			}
+		}
+		configChanged = configChanged || report.EmbeddedPluginServerIDsAssigned > 0
+	}
+
+	if configChanged {
+		if err = insertActiveConfigTx(tx, *cfg); err != nil {
+			return report, err
+		}
+	}
+	if serviceDone != "1" {
+		if err = setSystemValueTx(tx, serviceIDMigrationKey, "1"); err != nil {
+			return report, err
+		}
+	}
+	if mcpDone != "1" {
+		if err = setSystemValueTx(tx, mcpServerIDMigrationKey, "1"); err != nil {
+			return report, err
+		}
+	}
+	if embeddedPluginDone != "1" {
+		if err = setSystemValueTx(tx, embeddedPluginServerIDMigrationKey, "1"); err != nil {
+			return report, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return report, fmt.Errorf("failed to commit ABAC ID migration: %w", err)
+	}
+
+	report.Migrated = configChanged
+	return report, nil
+}
+
+// migrateServiceIDsTx rewrites legacy UUID service IDs in cfg (in place) and
+// in Agents_UserAgents rows, recording what it did in report. It does not
+// write the config row; the caller commits everything in one transaction.
+func migrateServiceIDsTx(tx *sqlx.Tx, cfg *config.Config, report *ABACIDMigrationReport) error {
+	// Duplicate legacy UUIDs: each occurrence gets its own new ID, but
+	// references remap to the FIRST occurrence's, mirroring GetServiceByID.
+	idMap := make(map[string]string)
+	for i := range cfg.Services {
+		oldID := cfg.Services[i].ID
+		if !isLegacyUUID(oldID) {
+			continue
+		}
+		newID := model.NewId()
+		if _, seen := idMap[oldID]; !seen {
+			idMap[oldID] = newID
+		}
+		cfg.Services[i].ID = newID
+		report.ServicesRemapped++
+	}
+
+	// Even when no service ID was remapped, keep going: dangling UUID
+	// references (fallbacks, bots, agent rows pointing at services absent
+	// from the active config) must still be detected and reported, or the
+	// one-time marker would permanently suppress the diagnosis.
+	for i := range cfg.Services {
+		fb := cfg.Services[i].FallbackServiceID
+		if fb == "" {
+			continue
+		}
+		if newID, ok := idMap[fb]; ok {
+			cfg.Services[i].FallbackServiceID = newID
+		} else if isLegacyUUID(fb) {
+			report.DanglingServiceRefs = append(report.DanglingServiceRefs,
+				fmt.Sprintf("service %q fallback references unknown service %q", cfg.Services[i].ID, fb))
+		}
+	}
+
+	for i := range cfg.Bots {
+		sid := cfg.Bots[i].ServiceID
+		if sid == "" {
+			continue
+		}
+		if newID, ok := idMap[sid]; ok {
+			cfg.Bots[i].ServiceID = newID
+		} else if isLegacyUUID(sid) {
+			report.DanglingServiceRefs = append(report.DanglingServiceRefs,
+				fmt.Sprintf("config bot %q references unknown service %q", cfg.Bots[i].ID, sid))
+		}
+	}
+
+	// Update every agent row, including soft-deleted ones. UpdateAt is
+	// deliberately not bumped (data migration, not a user edit).
+	for oldID, newID := range idMap {
+		res, err := tx.Exec("UPDATE Agents_UserAgents SET ServiceID = $1 WHERE ServiceID = $2", newID, oldID)
+		if err != nil {
+			return fmt.Errorf("failed to update agent service IDs: %w", err)
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to count updated agent rows: %w", err)
+		}
+		report.AgentRowsUpdated += rows
+	}
+
+	// Any agent row still holding a UUID references a service that no longer
+	// exists in the active config; report it, leave it unchanged.
+	var remaining []string
+	if err := tx.Select(&remaining, "SELECT DISTINCT ServiceID FROM Agents_UserAgents WHERE LENGTH(ServiceID) = 36"); err != nil {
+		return fmt.Errorf("failed to check for dangling agent service IDs: %w", err)
+	}
+	for _, sid := range remaining {
+		if isLegacyUUID(sid) {
+			report.DanglingServiceRefs = append(report.DanglingServiceRefs,
+				fmt.Sprintf("agent rows reference unknown service %q", sid))
+		}
+	}
+	return nil
+}
+
+// getSystemValueTx reads an Agents_System value on the transaction.
+func getSystemValueTx(tx *sqlx.Tx, key string) (string, error) {
+	var value string
+	err := tx.Get(&value, "SELECT SValue FROM Agents_System WHERE SKey = $1", key)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get system value for key %q: %w", key, err)
+	}
+	return value, nil
+}
+
+// setSystemValueTx upserts an Agents_System value on the transaction.
+func setSystemValueTx(tx *sqlx.Tx, key, value string) error {
+	_, err := tx.Exec(
+		`INSERT INTO Agents_System (SKey, SValue) VALUES ($1, $2)
+		 ON CONFLICT (SKey) DO UPDATE SET SValue = $2`,
+		key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set system value for key %q: %w", key, err)
+	}
+	return nil
+}
+
+// getActiveConfigTx reads the active config row on the transaction.
+// Returns found == false when no active config exists (fresh install).
+func getActiveConfigTx(tx *sqlx.Tx) (*config.Config, bool, error) {
+	var configJSON string
+	err := tx.Get(&configJSON, "SELECT Config FROM Agents_ConfigHistory WHERE Active = true LIMIT 1")
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get active config: %w", err)
+	}
+
+	var cfg config.Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+	return &cfg, true, nil
+}

--- a/store/id_migrations_test.go
+++ b/store/id_migrations_test.go
@@ -371,14 +371,12 @@ func TestMigrateABACIDs(t *testing.T) {
 				assert.True(t, model.IsValidId(cfg.MCP.PluginServers[0].ID))
 				assert.True(t, cfg.MCP.EmbeddedServer.Enabled)
 				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+				requireMarker(t, s, abacIDMigrationKey)
 			},
 		},
 		{
 			name: "embedded and plugin IDs minted once; existing IDs untouched",
 			seed: func(t *testing.T, s *Store) {
-				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
-				require.NoError(t, s.SetSystemValue(mcpServerIDMigrationKey, "1"))
 				seedConfigRow(t, s, config.Config{
 					MCP: config.MCPConfig{
 						Servers: []config.MCPServerConfig{
@@ -410,14 +408,12 @@ func TestMigrateABACIDs(t *testing.T) {
 				require.Len(t, cfg.MCP.PluginServers, 2)
 				assert.True(t, model.IsValidId(cfg.MCP.PluginServers[0].ID))
 				assert.Equal(t, "plugin26charidplugin26char", cfg.MCP.PluginServers[1].ID)
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+				requireMarker(t, s, abacIDMigrationKey)
 			},
 		},
 		{
-			name: "embedded/plugin marker prevents re-run",
+			name: "second run does not remint embedded/plugin IDs",
 			seed: func(t *testing.T, s *Store) {
-				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
-				require.NoError(t, s.SetSystemValue(mcpServerIDMigrationKey, "1"))
 				seedConfigRow(t, s, config.Config{
 					MCP: config.MCPConfig{
 						EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
@@ -469,9 +465,7 @@ func TestMigrateABACIDs(t *testing.T) {
 				assert.True(t, model.IsValidId(cfg.Services[0].ID))
 				assert.True(t, model.IsValidId(cfg.MCP.Servers[0].ID))
 				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
-				requireMarker(t, s, serviceIDMigrationKey)
-				requireMarker(t, s, mcpServerIDMigrationKey)
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+				requireMarker(t, s, abacIDMigrationKey)
 			},
 		},
 		{
@@ -501,41 +495,7 @@ func TestMigrateABACIDs(t *testing.T) {
 			},
 		},
 		{
-			name: "partial markers: only the unfinished migration runs",
-			seed: func(t *testing.T, s *Store) {
-				// Service migration already done: its marker is set and the
-				// active config carries a migrated (modern) service ID, per
-				// the invariant the atomic migration commit guarantees.
-				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
-				seedConfigRow(t, s, config.Config{
-					Services: []llm.ServiceConfig{
-						{ID: "migrated26charidmigrated26", Name: "A"},
-					},
-					MCP: config.MCPConfig{
-						Servers: []config.MCPServerConfig{
-							{Name: "srv", BaseURL: "https://one.example.com"},
-						},
-						EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded26charidembedded26", Enabled: true},
-					},
-				}, true)
-			},
-			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
-				assert.True(t, report.Migrated)
-				assert.Zero(t, report.ServicesRemapped, "service migration already marked done")
-				assert.Equal(t, 1, report.MCPServerIDsAssigned)
-				assert.Zero(t, report.EmbeddedPluginServerIDsAssigned, "embedded already had an ID")
-
-				cfg, err := s.GetConfig()
-				require.NoError(t, err)
-				assert.Equal(t, "migrated26charidmigrated26", cfg.Services[0].ID, "service IDs untouched when marker already set")
-				assert.True(t, model.IsValidId(cfg.MCP.Servers[0].ID))
-				assert.Equal(t, "embedded26charidembedded26", cfg.MCP.EmbeddedServer.ID)
-				requireMarker(t, s, mcpServerIDMigrationKey)
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
-			},
-		},
-		{
-			name: "content-based no-op sets markers without config write",
+			name: "content-based no-op sets marker without config write",
 			seed: func(t *testing.T, s *Store) {
 				seedConfigRow(t, s, config.Config{
 					Services: []llm.ServiceConfig{
@@ -555,20 +515,16 @@ func TestMigrateABACIDs(t *testing.T) {
 			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
 				assert.False(t, report.Migrated)
 				assert.Equal(t, 1, configHistoryCount(t, s))
-				requireMarker(t, s, serviceIDMigrationKey)
-				requireMarker(t, s, mcpServerIDMigrationKey)
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+				requireMarker(t, s, abacIDMigrationKey)
 			},
 		},
 		{
-			name: "no active config sets markers without error",
+			name: "no active config sets marker without error",
 			seed: func(t *testing.T, s *Store) {},
 			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
 				assert.False(t, report.Migrated)
 				assert.Zero(t, configHistoryCount(t, s))
-				requireMarker(t, s, serviceIDMigrationKey)
-				requireMarker(t, s, mcpServerIDMigrationKey)
-				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+				requireMarker(t, s, abacIDMigrationKey)
 			},
 		},
 		{
@@ -618,7 +574,7 @@ func TestMigrateABACIDsAtomicRollback(t *testing.T) {
 		corrupt func(t *testing.T, s *Store)
 	}{
 		{
-			name: "agent table missing rolls back config write and markers",
+			name: "agent table missing rolls back config write and marker",
 			corrupt: func(t *testing.T, s *Store) {
 				_, err := s.db.Exec("DROP TABLE Agents_UserAgents")
 				require.NoError(t, err)
@@ -654,11 +610,9 @@ func TestMigrateABACIDsAtomicRollback(t *testing.T) {
 			_, err := s.MigrateABACIDs()
 			require.Error(t, err)
 
-			for _, key := range []string{serviceIDMigrationKey, mcpServerIDMigrationKey, embeddedPluginServerIDMigrationKey} {
-				marker, markerErr := s.GetSystemValue(key)
-				require.NoError(t, markerErr)
-				assert.Empty(t, marker, "marker %q must not be set on failure", key)
-			}
+			marker, markerErr := s.GetSystemValue(abacIDMigrationKey)
+			require.NoError(t, markerErr)
+			assert.Empty(t, marker, "marker must not be set on failure")
 
 			assert.Equal(t, 1, configHistoryCount(t, s), "no new config row on failure")
 
@@ -711,29 +665,25 @@ func TestMigrateABACIDsConcurrentIdempotent(t *testing.T) {
 	assert.Equal(t, 1, migratedCount, "exactly one goroutine must perform the migration")
 	assert.Equal(t, 2, configHistoryCount(t, s), "exactly one new config row")
 
-	requireMarker(t, s, serviceIDMigrationKey)
-	requireMarker(t, s, mcpServerIDMigrationKey)
-	requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+	requireMarker(t, s, abacIDMigrationKey)
 }
 
-// TestUpdateConfigRejectsStaleLegacyServiceIDs is the interleaving regression
-// for the migration/stale-save race: once the service ID migration has run, a
-// save echoing pre-migration UUID service IDs (stale webapp bundle) must be
-// rejected, while a fresh payload goes through.
-func TestUpdateConfigRejectsStaleLegacyServiceIDs(t *testing.T) {
+// TestUpdateConfigRejectsLegacyUUIDServiceIDs is the post-migration format
+// guard: once the ABAC ID migration has run, a save with dashed UUID service
+// IDs is rejected as an invalid ID format, while a payload with migrated IDs
+// goes through.
+func TestUpdateConfigRejectsLegacyUUIDServiceIDs(t *testing.T) {
 	s := setupTestStore(t)
 	require.NoError(t, s.RunMigrations())
 
-	// Stale client loads the pre-migration config...
 	seedConfigRow(t, s, config.Config{
 		Services: []llm.ServiceConfig{
 			{ID: testUUIDA, Name: "A"},
 		},
 	}, true)
-	staleSnapshot, err := s.GetConfig()
+	uuidSnapshot, err := s.GetConfig()
 	require.NoError(t, err)
 
-	// ...then the migration runs.
 	report, err := s.MigrateABACIDs()
 	require.NoError(t, err)
 	require.True(t, report.Migrated)
@@ -742,16 +692,16 @@ func TestUpdateConfigRejectsStaleLegacyServiceIDs(t *testing.T) {
 	migratedID := migratedCfg.Services[0].ID
 	require.True(t, model.IsValidId(migratedID))
 
-	// Stale save replays the UUID payload: rejected, active config untouched.
+	// UUID payload after migration: rejected as invalid format, active config untouched.
 	rowsBefore := configHistoryCount(t, s)
 	_, err = s.UpdateConfig(func(prev *config.Config) (config.Config, error) {
-		return *staleSnapshot, nil
+		return *uuidSnapshot, nil
 	})
-	require.ErrorIs(t, err, ErrStaleLegacyServiceIDs)
+	require.ErrorIs(t, err, ErrLegacyUUIDServiceID)
 	assert.Equal(t, rowsBefore, configHistoryCount(t, s), "rejected save must not write a config row")
 	current, err := s.GetConfig()
 	require.NoError(t, err)
-	assert.Equal(t, migratedID, current.Services[0].ID, "migrated ID must survive the stale save")
+	assert.Equal(t, migratedID, current.Services[0].ID, "migrated ID must survive the rejected save")
 
 	// A fresh payload (post-migration IDs) is accepted.
 	fresh := *migratedCfg

--- a/store/id_migrations_test.go
+++ b/store/id_migrations_test.go
@@ -1,0 +1,790 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package store
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testUUIDA = "550e8400-e29b-41d4-a716-446655440000"
+	testUUIDB = "550e8400-e29b-41d4-a716-446655440001"
+	testUUIDC = "550e8400-e29b-41d4-a716-446655440002"
+	// Valid UUID deliberately absent from every seeded service list.
+	testUUIDDangling = "550e8400-e29b-41d4-a716-446655449999"
+)
+
+// seedConfigRow inserts a config history row directly, bypassing SaveConfig.
+func seedConfigRow(t *testing.T, s *Store, cfg config.Config, active bool) {
+	t.Helper()
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	_, err = s.db.Exec(
+		"INSERT INTO Agents_ConfigHistory (ID, Config, CreateAt, Active) VALUES ($1, $2, $3, $4)",
+		model.NewId(), string(data), model.GetMillis(), active,
+	)
+	require.NoError(t, err)
+}
+
+// seedAgentRow inserts an agent row directly so arbitrary ServiceIDs,
+// soft-deletion, and timestamps can be seeded without CreateAgent's ID reset.
+func seedAgentRow(t *testing.T, s *Store, id, serviceID string, updateAt, deleteAt int64) {
+	t.Helper()
+	_, err := s.db.Exec(
+		`INSERT INTO Agents_UserAgents (
+			ID, BotUserID, CreatorID, DisplayName, Username, ServiceID,
+			CreateAt, UpdateAt, DeleteAt
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+		id, "bot-"+id, "creator", "Agent "+id, "agent-"+id, serviceID,
+		int64(1), updateAt, deleteAt,
+	)
+	require.NoError(t, err)
+}
+
+func configHistoryCount(t *testing.T, s *Store) int {
+	t.Helper()
+	var count int
+	require.NoError(t, s.db.Get(&count, "SELECT COUNT(*) FROM Agents_ConfigHistory"))
+	return count
+}
+
+func requireMarker(t *testing.T, s *Store, key string) {
+	t.Helper()
+	marker, err := s.GetSystemValue(key)
+	require.NoError(t, err)
+	assert.Equal(t, "1", marker, "marker %q must be set", key)
+}
+
+type agentServiceRow struct {
+	ServiceID string `db:"serviceid"`
+	UpdateAt  int64  `db:"updateat"`
+}
+
+func getAgentServiceRow(t *testing.T, s *Store, id string) agentServiceRow {
+	t.Helper()
+	var row agentServiceRow
+	require.NoError(t, s.db.Get(&row, "SELECT ServiceID, UpdateAt FROM Agents_UserAgents WHERE ID = $1", id))
+	return row
+}
+
+func TestMigrateABACIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		seed     func(t *testing.T, s *Store)
+		validate func(t *testing.T, s *Store, report ABACIDMigrationReport)
+	}{
+		{
+			name: "all legacy UUIDs remapped",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+						{ID: testUUIDB, Name: "B"},
+					},
+				}, true)
+				seedAgentRow(t, s, "agent1", testUUIDA, 100, 0)
+				seedAgentRow(t, s, "agent2", testUUIDB, 200, 0)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 2, report.ServicesRemapped)
+				assert.Equal(t, int64(2), report.AgentRowsUpdated)
+				assert.Empty(t, report.DanglingServiceRefs)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				byName := map[string]string{}
+				for _, svc := range cfg.Services {
+					assert.True(t, model.IsValidId(svc.ID), "service %q ID %q should be a valid Mattermost ID", svc.Name, svc.ID)
+					byName[svc.Name] = svc.ID
+				}
+				assert.Equal(t, byName["A"], getAgentServiceRow(t, s, "agent1").ServiceID)
+				assert.Equal(t, byName["B"], getAgentServiceRow(t, s, "agent2").ServiceID)
+			},
+		},
+		{
+			name: "mixed IDs only UUIDs rewritten",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "legacy"},
+						{ID: "kept26charidkept26charidke", Name: "modern"},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 1, report.ServicesRemapped)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				byName := map[string]string{}
+				for _, svc := range cfg.Services {
+					byName[svc.Name] = svc.ID
+				}
+				assert.Equal(t, "kept26charidkept26charidke", byName["modern"], "non-UUID ID must be byte-identical")
+				assert.NotEqual(t, testUUIDA, byName["legacy"])
+				assert.True(t, model.IsValidId(byName["legacy"]))
+			},
+		},
+		{
+			name: "fallback reference chain remapped",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A", FallbackServiceID: testUUIDB},
+						{ID: testUUIDB, Name: "B", FallbackServiceID: testUUIDC},
+						{ID: testUUIDC, Name: "C"},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 3, report.ServicesRemapped)
+				assert.Empty(t, report.DanglingServiceRefs)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				byName := map[string]llm.ServiceConfig{}
+				for _, svc := range cfg.Services {
+					byName[svc.Name] = svc
+				}
+				assert.Equal(t, byName["B"].ID, byName["A"].FallbackServiceID)
+				assert.Equal(t, byName["C"].ID, byName["B"].FallbackServiceID)
+				assert.Empty(t, byName["C"].FallbackServiceID)
+			},
+		},
+		{
+			name: "config bot references remapped",
+			seed: func(t *testing.T, s *Store) {
+				// Pre-legacy-bot-migration state: bots still live in config.
+				// Proves the migration handles the state reachable only when it
+				// runs before migrateLegacyConfigBotsToUserAgents.
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+					},
+					Bots: []llm.BotConfig{
+						{ID: "bot1", Name: "ai", ServiceID: testUUIDA},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				require.Len(t, cfg.Bots, 1)
+				assert.Equal(t, cfg.Services[0].ID, cfg.Bots[0].ServiceID)
+				assert.True(t, model.IsValidId(cfg.Bots[0].ServiceID))
+			},
+		},
+		{
+			name: "duplicate legacy IDs: unique new IDs, references keep first occurrence",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "first"},
+						{ID: testUUIDA, Name: "second"},
+						{ID: testUUIDB, Name: "other", FallbackServiceID: testUUIDA},
+					},
+					Bots: []llm.BotConfig{
+						{ID: "bot1", Name: "ai", ServiceID: testUUIDA},
+					},
+				}, true)
+				seedAgentRow(t, s, "agent1", testUUIDA, 100, 0)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 3, report.ServicesRemapped, "every occurrence counts, including duplicates")
+				assert.Empty(t, report.DanglingServiceRefs)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				byName := map[string]llm.ServiceConfig{}
+				for _, svc := range cfg.Services {
+					assert.True(t, model.IsValidId(svc.ID))
+					byName[svc.Name] = svc
+				}
+				assert.NotEqual(t, byName["first"].ID, byName["second"].ID,
+					"duplicated services must each get their own unique new ID")
+
+				// GetServiceByID first-match semantics: all references follow
+				// the FIRST occurrence's new ID.
+				firstID := byName["first"].ID
+				assert.Equal(t, firstID, byName["other"].FallbackServiceID)
+				assert.Equal(t, firstID, cfg.Bots[0].ServiceID)
+				assert.Equal(t, firstID, getAgentServiceRow(t, s, "agent1").ServiceID)
+			},
+		},
+		{
+			name: "active and soft-deleted agents both updated without UpdateAt bump",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+					},
+				}, true)
+				seedAgentRow(t, s, "active-agent", testUUIDA, 111, 0)
+				seedAgentRow(t, s, "deleted-agent", testUUIDA, 222, 999)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, int64(2), report.AgentRowsUpdated)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				newID := cfg.Services[0].ID
+
+				activeRow := getAgentServiceRow(t, s, "active-agent")
+				assert.Equal(t, newID, activeRow.ServiceID)
+				assert.Equal(t, int64(111), activeRow.UpdateAt)
+
+				deletedRow := getAgentServiceRow(t, s, "deleted-agent")
+				assert.Equal(t, newID, deletedRow.ServiceID)
+				assert.Equal(t, int64(222), deletedRow.UpdateAt)
+			},
+		},
+		{
+			name: "dangling references left unchanged and reported",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A", FallbackServiceID: testUUIDDangling},
+					},
+					Bots: []llm.BotConfig{
+						{ID: "bot1", Name: "ai", ServiceID: testUUIDDangling},
+					},
+				}, true)
+				seedAgentRow(t, s, "dangling-agent", testUUIDDangling, 100, 0)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 1, report.ServicesRemapped)
+				assert.Equal(t, int64(0), report.AgentRowsUpdated)
+				assert.Len(t, report.DanglingServiceRefs, 3)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.Equal(t, testUUIDDangling, cfg.Services[0].FallbackServiceID)
+				assert.Equal(t, testUUIDDangling, cfg.Bots[0].ServiceID)
+				assert.Equal(t, testUUIDDangling, getAgentServiceRow(t, s, "dangling-agent").ServiceID)
+			},
+		},
+		{
+			name: "dangling references reported even when no service IDs remapped",
+			seed: func(t *testing.T, s *Store) {
+				// Services already carry modern IDs, so the rewrite is a
+				// no-op — dangling UUID references must still be diagnosed.
+				// Pre-seed embedded/plugin IDs so those migrations are also
+				// content no-ops and do not write a config row.
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: "modern26charidmodern26char", Name: "A", FallbackServiceID: testUUIDDangling},
+					},
+					Bots: []llm.BotConfig{
+						{ID: "bot1", Name: "ai", ServiceID: testUUIDDangling},
+					},
+					MCP: config.MCPConfig{
+						EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded26charidembedded26", Enabled: true},
+					},
+				}, true)
+				seedAgentRow(t, s, "dangling-agent", testUUIDDangling, 100, 0)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.False(t, report.Migrated, "no config rewrite happened")
+				assert.Equal(t, 0, report.ServicesRemapped)
+				assert.Equal(t, int64(0), report.AgentRowsUpdated)
+				assert.Zero(t, report.EmbeddedPluginServerIDsAssigned)
+				assert.Len(t, report.DanglingServiceRefs, 3)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.Equal(t, testUUIDDangling, cfg.Services[0].FallbackServiceID)
+				assert.Equal(t, testUUIDDangling, cfg.Bots[0].ServiceID)
+				assert.Equal(t, testUUIDDangling, getAgentServiceRow(t, s, "dangling-agent").ServiceID)
+			},
+		},
+		{
+			name: "MCP servers get IDs only when missing, other fields preserved",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					MCP: config.MCPConfig{
+						Enabled: true,
+						Servers: []config.MCPServerConfig{
+							{
+								Name:     "no-id",
+								Enabled:  true,
+								BaseURL:  "https://one.example.com",
+								Headers:  map[string]string{"Authorization": "Bearer x"},
+								ClientID: "client-1",
+								ToolConfigs: []config.MCPToolConfig{
+									{Name: "get_issue", Policy: config.MCPToolPolicyAsk, Enabled: true},
+								},
+							},
+							{
+								ID:      "existing26charidexisting26",
+								Name:    "has-id",
+								Enabled: false,
+								BaseURL: "https://two.example.com",
+							},
+						},
+						PluginServers: []config.PluginServerConfig{
+							{PluginID: "com.example.plugin", Name: "Plugin Server", Enabled: true},
+						},
+						EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 1, report.MCPServerIDsAssigned)
+				assert.Equal(t, 2, report.EmbeddedPluginServerIDsAssigned)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				require.Len(t, cfg.MCP.Servers, 2)
+
+				noID := cfg.MCP.Servers[0]
+				assert.True(t, model.IsValidId(noID.ID))
+				assert.Equal(t, "no-id", noID.Name)
+				assert.Equal(t, "https://one.example.com", noID.BaseURL)
+				assert.Equal(t, map[string]string{"Authorization": "Bearer x"}, noID.Headers)
+				assert.Equal(t, "client-1", noID.ClientID)
+				require.Len(t, noID.ToolConfigs, 1)
+				assert.Equal(t, "get_issue", noID.ToolConfigs[0].Name)
+
+				hasID := cfg.MCP.Servers[1]
+				assert.Equal(t, "existing26charidexisting26", hasID.ID, "pre-existing ID must be preserved")
+
+				require.Len(t, cfg.MCP.PluginServers, 1)
+				assert.Equal(t, "com.example.plugin", cfg.MCP.PluginServers[0].PluginID)
+				assert.True(t, model.IsValidId(cfg.MCP.PluginServers[0].ID))
+				assert.True(t, cfg.MCP.EmbeddedServer.Enabled)
+				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "embedded and plugin IDs minted once; existing IDs untouched",
+			seed: func(t *testing.T, s *Store) {
+				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
+				require.NoError(t, s.SetSystemValue(mcpServerIDMigrationKey, "1"))
+				seedConfigRow(t, s, config.Config{
+					MCP: config.MCPConfig{
+						Servers: []config.MCPServerConfig{
+							{ID: "remote26charidremote26chari", Name: "remote", BaseURL: "https://one.example.com"},
+						},
+						EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
+						PluginServers: []config.PluginServerConfig{
+							{PluginID: "com.example.a", Name: "A", Path: "/mcp", Enabled: true},
+							{
+								ID:       "plugin26charidplugin26char",
+								PluginID: "com.example.b",
+								Name:     "B",
+								Path:     "/mcp",
+								Enabled:  false,
+							},
+						},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Zero(t, report.MCPServerIDsAssigned)
+				assert.Equal(t, 2, report.EmbeddedPluginServerIDsAssigned)
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.Equal(t, "remote26charidremote26chari", cfg.MCP.Servers[0].ID)
+				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
+				require.Len(t, cfg.MCP.PluginServers, 2)
+				assert.True(t, model.IsValidId(cfg.MCP.PluginServers[0].ID))
+				assert.Equal(t, "plugin26charidplugin26char", cfg.MCP.PluginServers[1].ID)
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "embedded/plugin marker prevents re-run",
+			seed: func(t *testing.T, s *Store) {
+				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
+				require.NoError(t, s.SetSystemValue(mcpServerIDMigrationKey, "1"))
+				seedConfigRow(t, s, config.Config{
+					MCP: config.MCPConfig{
+						EmbeddedServer: config.MCPEmbeddedServerConfig{Enabled: true},
+						PluginServers: []config.PluginServerConfig{
+							{PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+						},
+					},
+				}, true)
+				report, err := s.MigrateABACIDs()
+				require.NoError(t, err)
+				require.True(t, report.Migrated)
+				require.Equal(t, 2, report.EmbeddedPluginServerIDsAssigned)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.False(t, report.Migrated)
+				assert.Zero(t, report.EmbeddedPluginServerIDsAssigned)
+				assert.Equal(t, 2, configHistoryCount(t, s), "second run must not write another config row")
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
+				assert.True(t, model.IsValidId(cfg.MCP.PluginServers[0].ID))
+			},
+		},
+		{
+			name: "service and MCP migrations commit as one config row",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+					},
+					MCP: config.MCPConfig{
+						Servers: []config.MCPServerConfig{
+							{Name: "srv", BaseURL: "https://one.example.com"},
+						},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Equal(t, 1, report.ServicesRemapped)
+				assert.Equal(t, 1, report.MCPServerIDsAssigned)
+				assert.Equal(t, 1, report.EmbeddedPluginServerIDsAssigned, "empty EmbeddedServer.ID is minted")
+				assert.Equal(t, 2, configHistoryCount(t, s),
+					"all migrations must write exactly one new config row together")
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.True(t, model.IsValidId(cfg.Services[0].ID))
+				assert.True(t, model.IsValidId(cfg.MCP.Servers[0].ID))
+				assert.True(t, model.IsValidId(cfg.MCP.EmbeddedServer.ID))
+				requireMarker(t, s, serviceIDMigrationKey)
+				requireMarker(t, s, mcpServerIDMigrationKey)
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "idempotency second run is a no-op",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+					},
+					MCP: config.MCPConfig{
+						Servers: []config.MCPServerConfig{
+							{Name: "srv", BaseURL: "https://one.example.com"},
+						},
+						EmbeddedServer: config.MCPEmbeddedServerConfig{ID: model.NewId(), Enabled: true},
+					},
+				}, true)
+				report, err := s.MigrateABACIDs()
+				require.NoError(t, err)
+				require.True(t, report.Migrated)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.False(t, report.Migrated)
+				assert.Zero(t, report.ServicesRemapped)
+				assert.Zero(t, report.MCPServerIDsAssigned)
+				assert.Zero(t, report.EmbeddedPluginServerIDsAssigned)
+				assert.Equal(t, 2, configHistoryCount(t, s), "second run must not write another config row")
+			},
+		},
+		{
+			name: "partial markers: only the unfinished migration runs",
+			seed: func(t *testing.T, s *Store) {
+				// Service migration already done: its marker is set and the
+				// active config carries a migrated (modern) service ID, per
+				// the invariant the atomic migration commit guarantees.
+				require.NoError(t, s.SetSystemValue(serviceIDMigrationKey, "1"))
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: "migrated26charidmigrated26", Name: "A"},
+					},
+					MCP: config.MCPConfig{
+						Servers: []config.MCPServerConfig{
+							{Name: "srv", BaseURL: "https://one.example.com"},
+						},
+						EmbeddedServer: config.MCPEmbeddedServerConfig{ID: "embedded26charidembedded26", Enabled: true},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+				assert.Zero(t, report.ServicesRemapped, "service migration already marked done")
+				assert.Equal(t, 1, report.MCPServerIDsAssigned)
+				assert.Zero(t, report.EmbeddedPluginServerIDsAssigned, "embedded already had an ID")
+
+				cfg, err := s.GetConfig()
+				require.NoError(t, err)
+				assert.Equal(t, "migrated26charidmigrated26", cfg.Services[0].ID, "service IDs untouched when marker already set")
+				assert.True(t, model.IsValidId(cfg.MCP.Servers[0].ID))
+				assert.Equal(t, "embedded26charidembedded26", cfg.MCP.EmbeddedServer.ID)
+				requireMarker(t, s, mcpServerIDMigrationKey)
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "content-based no-op sets markers without config write",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: model.NewId(), Name: "modern"},
+					},
+					MCP: config.MCPConfig{
+						Servers: []config.MCPServerConfig{
+							{ID: model.NewId(), Name: "srv", BaseURL: "https://one.example.com"},
+						},
+						EmbeddedServer: config.MCPEmbeddedServerConfig{ID: model.NewId(), Enabled: true},
+						PluginServers: []config.PluginServerConfig{
+							{ID: model.NewId(), PluginID: "com.example.a", Name: "A", Path: "/mcp"},
+						},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.False(t, report.Migrated)
+				assert.Equal(t, 1, configHistoryCount(t, s))
+				requireMarker(t, s, serviceIDMigrationKey)
+				requireMarker(t, s, mcpServerIDMigrationKey)
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "no active config sets markers without error",
+			seed: func(t *testing.T, s *Store) {},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.False(t, report.Migrated)
+				assert.Zero(t, configHistoryCount(t, s))
+				requireMarker(t, s, serviceIDMigrationKey)
+				requireMarker(t, s, mcpServerIDMigrationKey)
+				requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+			},
+		},
+		{
+			name: "inactive history rows unchanged",
+			seed: func(t *testing.T, s *Store) {
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDB, Name: "old-snapshot"},
+					},
+				}, false)
+				seedConfigRow(t, s, config.Config{
+					Services: []llm.ServiceConfig{
+						{ID: testUUIDA, Name: "A"},
+					},
+				}, true)
+			},
+			validate: func(t *testing.T, s *Store, report ABACIDMigrationReport) {
+				assert.True(t, report.Migrated)
+
+				var inactiveConfigs []string
+				require.NoError(t, s.db.Select(&inactiveConfigs, "SELECT Config FROM Agents_ConfigHistory WHERE Active = false ORDER BY CreateAt"))
+				// The pre-seeded inactive row plus the row deactivated by the migration.
+				require.Len(t, inactiveConfigs, 2)
+				assert.Contains(t, inactiveConfigs[0], testUUIDB, "pre-existing inactive row must keep its UUIDs")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupTestStore(t)
+			require.NoError(t, s.RunMigrations())
+
+			tt.seed(t, s)
+
+			report, err := s.MigrateABACIDs()
+			require.NoError(t, err)
+
+			tt.validate(t, s, report)
+		})
+	}
+}
+
+func TestMigrateABACIDsAtomicRollback(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(t *testing.T, s *Store)
+	}{
+		{
+			name: "agent table missing rolls back config write and markers",
+			corrupt: func(t *testing.T, s *Store) {
+				_, err := s.db.Exec("DROP TABLE Agents_UserAgents")
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "corrupt active config JSON fails without writes",
+			corrupt: func(t *testing.T, s *Store) {
+				_, err := s.db.Exec("UPDATE Agents_ConfigHistory SET Config = 'not-json' WHERE Active = true")
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupTestStore(t)
+			require.NoError(t, s.RunMigrations())
+			seedConfigRow(t, s, config.Config{
+				Services: []llm.ServiceConfig{
+					{ID: testUUIDA, Name: "A"},
+				},
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{Name: "srv", BaseURL: "https://one.example.com"},
+					},
+				},
+			}, true)
+			seedAgentRow(t, s, "agent1", testUUIDA, 100, 0)
+
+			tt.corrupt(t, s)
+
+			_, err := s.MigrateABACIDs()
+			require.Error(t, err)
+
+			for _, key := range []string{serviceIDMigrationKey, mcpServerIDMigrationKey, embeddedPluginServerIDMigrationKey} {
+				marker, markerErr := s.GetSystemValue(key)
+				require.NoError(t, markerErr)
+				assert.Empty(t, marker, "marker %q must not be set on failure", key)
+			}
+
+			assert.Equal(t, 1, configHistoryCount(t, s), "no new config row on failure")
+
+			var activeConfig string
+			require.NoError(t, s.db.Get(&activeConfig, "SELECT Config FROM Agents_ConfigHistory WHERE Active = true"))
+			if activeConfig != "not-json" {
+				assert.Contains(t, activeConfig, testUUIDA, "active config must keep its UUIDs on rollback")
+			}
+		})
+	}
+}
+
+func TestMigrateABACIDsConcurrentIdempotent(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+	seedConfigRow(t, s, config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: testUUIDA, Name: "A"},
+			{ID: testUUIDB, Name: "B"},
+		},
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServerConfig{
+				{Name: "srv", BaseURL: "https://one.example.com"},
+			},
+		},
+	}, true)
+	seedAgentRow(t, s, "agent1", testUUIDA, 100, 0)
+
+	const goroutines = 8
+	reports := make([]ABACIDMigrationReport, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			reports[idx], errs[idx] = s.MigrateABACIDs()
+		}(i)
+	}
+	wg.Wait()
+
+	migratedCount := 0
+	for i := 0; i < goroutines; i++ {
+		require.NoError(t, errs[i])
+		if reports[i].Migrated {
+			migratedCount++
+		}
+	}
+	assert.Equal(t, 1, migratedCount, "exactly one goroutine must perform the migration")
+	assert.Equal(t, 2, configHistoryCount(t, s), "exactly one new config row")
+
+	requireMarker(t, s, serviceIDMigrationKey)
+	requireMarker(t, s, mcpServerIDMigrationKey)
+	requireMarker(t, s, embeddedPluginServerIDMigrationKey)
+}
+
+// TestUpdateConfigRejectsStaleLegacyServiceIDs is the interleaving regression
+// for the migration/stale-save race: once the service ID migration has run, a
+// save echoing pre-migration UUID service IDs (stale webapp bundle) must be
+// rejected, while a fresh payload goes through.
+func TestUpdateConfigRejectsStaleLegacyServiceIDs(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+
+	// Stale client loads the pre-migration config...
+	seedConfigRow(t, s, config.Config{
+		Services: []llm.ServiceConfig{
+			{ID: testUUIDA, Name: "A"},
+		},
+	}, true)
+	staleSnapshot, err := s.GetConfig()
+	require.NoError(t, err)
+
+	// ...then the migration runs.
+	report, err := s.MigrateABACIDs()
+	require.NoError(t, err)
+	require.True(t, report.Migrated)
+	migratedCfg, err := s.GetConfig()
+	require.NoError(t, err)
+	migratedID := migratedCfg.Services[0].ID
+	require.True(t, model.IsValidId(migratedID))
+
+	// Stale save replays the UUID payload: rejected, active config untouched.
+	rowsBefore := configHistoryCount(t, s)
+	_, err = s.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		return *staleSnapshot, nil
+	})
+	require.ErrorIs(t, err, ErrStaleLegacyServiceIDs)
+	assert.Equal(t, rowsBefore, configHistoryCount(t, s), "rejected save must not write a config row")
+	current, err := s.GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, migratedID, current.Services[0].ID, "migrated ID must survive the stale save")
+
+	// A fresh payload (post-migration IDs) is accepted.
+	fresh := *migratedCfg
+	fresh.Services[0].Name = "A-renamed"
+	saved, err := s.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		require.NotNil(t, prev)
+		assert.Equal(t, migratedID, prev.Services[0].ID, "transform must see the migrated config")
+		return fresh, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "A-renamed", saved.Services[0].Name)
+	current, err = s.GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "A-renamed", current.Services[0].Name)
+	assert.Equal(t, migratedID, current.Services[0].ID)
+}
+
+// Before the migration marker is set, UpdateConfig must accept UUID service
+// IDs: pre-migration saves are legitimate.
+func TestUpdateConfigAllowsUUIDsBeforeMigration(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+
+	saved, err := s.UpdateConfig(func(prev *config.Config) (config.Config, error) {
+		assert.Nil(t, prev, "no active config yet")
+		return config.Config{
+			Services: []llm.ServiceConfig{{ID: testUUIDA, Name: "A"}},
+		}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, testUUIDA, saved.Services[0].ID)
+
+	current, err := s.GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, testUUIDA, current.Services[0].ID)
+}

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -949,7 +949,7 @@ export async function getPluginConfig(): Promise<PluginConfig> {
     });
 }
 
-export async function savePluginConfig(config: PluginConfig): Promise<void> {
+export async function savePluginConfig(config: PluginConfig): Promise<PluginConfig> {
     const url = `${baseRoute()}/admin/config`;
     const response = await fetch(url, Client4.getOptions({
         method: 'PUT',
@@ -958,7 +958,7 @@ export async function savePluginConfig(config: PluginConfig): Promise<void> {
     }));
 
     if (response.ok) {
-        return;
+        return response.json();
     }
 
     throw new ClientError(Client4.url, {

--- a/webapp/src/components/system_console/config.test.tsx
+++ b/webapp/src/components/system_console/config.test.tsx
@@ -1,0 +1,169 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, render, screen} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import {getAIBots, getPluginConfig, savePluginConfig} from '@/client';
+
+import Config from './config';
+
+jest.mock('react-intl', () => {
+    const actual = jest.requireActual('react-intl');
+
+    // A stable intl instance: config.tsx keys effects on [intl], and a fresh
+    // object per render would re-run the config load effect forever.
+    const intl = {
+        formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+    return {
+        ...actual,
+        useIntl: () => intl,
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('@/client', () => ({
+    getPluginConfig: jest.fn(),
+    getAIBots: jest.fn(),
+    savePluginConfig: jest.fn(),
+}));
+
+// The heavy editors are not under test; expose the identity each entry is
+// rendered with so ID propagation from the save response is observable.
+jest.mock('./services', () => ({
+    __esModule: true,
+    default: ({services}: {services: Array<{id: string; name: string}>}) => (
+        <div>
+            {services.map((s, i) => (
+                <span key={i}>{`service:${s.name}:${s.id || 'unsaved'}`}</span>
+            ))}
+        </div>
+    ),
+    firstNewService: {id: '', name: 'OpenAI Service'},
+}));
+
+jest.mock('./mcp_servers', () => ({
+    __esModule: true,
+    default: ({mcpConfig}: {mcpConfig: {servers: Array<{id?: string; name: string}> | null}}) => (
+        <div>
+            {(mcpConfig.servers ?? []).map((s, i) => (
+                <span key={i}>{`mcp:${s.name}:${s.id || 'unsaved'}`}</span>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('./embedding_search/embedding_search_panel', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./web_search/web_search_panel', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./bots_moved_notice', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./no_services_page', () => ({
+    __esModule: true,
+    default: () => <div>{'no-services'}</div>,
+}));
+
+type SaveAction = () => Promise<{error?: {message?: string}}>;
+
+const loadedConfig = {
+    services: [{id: '', name: 'My Service', type: 'openai'}],
+    mcp: {
+        enabled: true,
+        enablePluginServer: false,
+        servers: [{name: 'Jira', enabled: true, baseURL: 'https://jira.example.com', headers: {}}],
+        embeddedServer: {enabled: true},
+    },
+};
+
+function renderConfig() {
+    const registerSaveAction = jest.fn();
+    const props = {
+        id: 'Config',
+        label: '',
+        helpText: null,
+        value: {} as never,
+        disabled: false,
+        config: {},
+        currentState: {},
+        license: {},
+        setByEnv: false,
+        onChange: jest.fn(),
+        setSaveNeeded: jest.fn(),
+        registerSaveAction,
+        unRegisterSaveAction: jest.fn(),
+    };
+    render(
+        <IntlProvider locale='en'>
+            <Config {...props}/>
+        </IntlProvider>,
+    );
+    return {registerSaveAction};
+}
+
+describe('Config save flow', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getPluginConfig as jest.Mock).mockResolvedValue(loadedConfig);
+        (getAIBots as jest.Mock).mockResolvedValue({bots: []});
+    });
+
+    it('adopts server-minted IDs from the save response so ID-gated UI appears without a reload', async () => {
+        const {registerSaveAction} = renderConfig();
+
+        // Loaded config renders without IDs.
+        await screen.findByText('service:My Service:unsaved');
+        expect(screen.getByText('mcp:Jira:unsaved')).toBeTruthy();
+
+        const savedConfig = {
+            ...loadedConfig,
+            services: [{id: 'serviceidaaaaaaaaaaaaaaaaa', name: 'My Service', type: 'openai'}],
+            mcp: {
+                ...loadedConfig.mcp,
+                servers: [{...loadedConfig.mcp.servers[0], id: 'mcpserveridbbbbbbbbbbbbbbb'}],
+            },
+        };
+        (savePluginConfig as jest.Mock).mockResolvedValue(savedConfig);
+
+        const save = registerSaveAction.mock.calls.at(-1)?.[0] as SaveAction;
+        let result: {error?: {message?: string}} = {};
+        await act(async () => {
+            result = await save();
+        });
+
+        expect(result).toEqual({});
+        expect(savePluginConfig).toHaveBeenCalledTimes(1);
+
+        // The normalized response replaces local state: minted IDs are live.
+        await screen.findByText('service:My Service:serviceidaaaaaaaaaaaaaaaaa');
+        expect(screen.getByText('mcp:Jira:mcpserveridbbbbbbbbbbbbbbb')).toBeTruthy();
+    });
+
+    it('reports a save error and keeps local state when the save is rejected', async () => {
+        const {registerSaveAction} = renderConfig();
+        await screen.findByText('service:My Service:unsaved');
+
+        (savePluginConfig as jest.Mock).mockRejectedValue(new Error('409'));
+
+        const save = registerSaveAction.mock.calls.at(-1)?.[0] as SaveAction;
+        let result: {error?: {message?: string}} = {};
+        await act(async () => {
+            result = await save();
+        });
+
+        expect(result.error?.message).toBe('Failed to save configuration.');
+        expect(screen.getByText('service:My Service:unsaved')).toBeTruthy();
+        expect(screen.getByText('mcp:Jira:unsaved')).toBeTruthy();
+    });
+});

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -230,7 +230,12 @@ const Config = (props: Props) => {
     useEffect(() => {
         const save = async () => {
             try {
-                await savePluginConfig(localConfig);
+                const saved = await savePluginConfig(localConfig);
+
+                // Adopt the normalized saved config so server-minted
+                // service/MCP IDs (and the UI gated on them) appear
+                // immediately instead of after a page reload.
+                setLocalConfig({...defaultConfig, ...saved});
                 return {};
             } catch (e: any) {
                 return {error: {message: intl.formatMessage({defaultMessage: 'Failed to save configuration.'})}};
@@ -247,13 +252,11 @@ const Config = (props: Props) => {
         props.setSaveNeeded();
     }, [props.setSaveNeeded]);
 
+    // No id is assigned client-side: the backend mints the stable service ID
+    // on save (normalizeAdminConfig).
     const addFirstService = () => {
-        const id = crypto.randomUUID();
         updateConfig({
-            services: [{
-                ...firstNewService,
-                id,
-            }],
+            services: [{...firstNewService}],
         });
     };
 

--- a/webapp/src/components/system_console/mcp_servers.test.tsx
+++ b/webapp/src/components/system_console/mcp_servers.test.tsx
@@ -8,13 +8,26 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 jest.mock('react-intl', () => {
     const React = require('react'); // eslint-disable-line @typescript-eslint/no-shadow, no-shadow, global-require
 
+    const formatMessage = (
+        {defaultMessage}: {defaultMessage?: string},
+        values?: Record<string, unknown>,
+    ) => {
+        let message = defaultMessage ?? '';
+        if (values) {
+            for (const [key, value] of Object.entries(values)) {
+                message = message.replace(new RegExp(`\\{${key}\\}`, 'g'), String(value));
+            }
+        }
+        return message;
+    };
+
     return {
         __esModule: true,
         IntlProvider: ({children}: {children: React.ReactNode}) => React.createElement(React.Fragment, null, children),
-        FormattedMessage: ({defaultMessage}: {defaultMessage?: string}) =>
-            React.createElement(React.Fragment, null, defaultMessage ?? ''),
+        FormattedMessage: ({defaultMessage, values}: {defaultMessage?: string; values?: Record<string, unknown>}) =>
+            React.createElement(React.Fragment, null, formatMessage({defaultMessage}, values)),
         useIntl: () => ({
-            formatMessage: ({defaultMessage}: {defaultMessage?: string}) => defaultMessage ?? '',
+            formatMessage,
         }),
     };
 });
@@ -27,6 +40,7 @@ jest.mock('react-bootstrap', () => ({
 
 // The component reads SiteURL via useSelector; null falls back to window.location.origin.
 jest.mock('react-redux', () => ({
+    __esModule: true,
     useSelector: jest.fn(() => null),
 }));
 
@@ -42,22 +56,37 @@ jest.mock('../../client', () => ({
     updatePluginServer: jest.fn().mockResolvedValue({}),
 }));
 
+jest.mock('./mcp_tools_viewer', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
 /* eslint-disable import/first, import/order */
 import {IntlProvider} from 'react-intl';
 
 import {useIsBasicsLicensed} from '@/license';
 
-import MCPServers, {MCPConfig, MCPServerConfig} from './mcp_servers';
+import {getMCPTools} from '../../client';
+
+import MCPServers from './mcp_servers';
+import {MCPConfig, MCPServerConfig, PluginServerConfig} from './mcp_types';
 /* eslint-enable import/first, import/order */
 
 const mockUseIsBasicsLicensed = useIsBasicsLicensed as jest.Mock;
+const mockGetMCPTools = getMCPTools as jest.Mock;
 
-function makeMCPConfig(servers: MCPServerConfig[] = []): MCPConfig {
+const STABLE_ID = 'abcdefghijklmnopqrstuvwxyz';
+
+function makeMCPConfig(servers: MCPServerConfig[] = [], embeddedId?: string): MCPConfig {
     return {
         enabled: true,
         enablePluginServer: false,
         servers,
-        embeddedServer: {enabled: true, tool_configs: []},
+        embeddedServer: {
+            ...(embeddedId ? {id: embeddedId} : {}),
+            enabled: true,
+            tool_configs: [],
+        },
     };
 }
 
@@ -86,48 +115,137 @@ function renderServers(mcpConfig: MCPConfig) {
     };
 }
 
+function lastChangedServers(onChange: jest.Mock): MCPServerConfig[] {
+    expect(onChange).toHaveBeenCalled();
+    const config: MCPConfig = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    return config.servers ?? [];
+}
+
+const existingServer: MCPServerConfig = {
+    id: STABLE_ID,
+    name: 'Jira',
+    enabled: true,
+    baseURL: 'https://jira.example.com',
+    headers: {},
+};
+
+describe('MCPServers stable ID handling', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // The remote-server UI these tests drive is behind the license gate.
+        mockUseIsBasicsLicensed.mockReturnValue(true);
+
+        // Never resolves: these assertions are synchronous, so a resolving
+        // prefetch would update state outside act().
+        mockGetMCPTools.mockReturnValue(new Promise(() => null));
+    });
+
+    it('preserves the server id through a name edit', () => {
+        const {onChange} = renderServers(makeMCPConfig([existingServer]));
+
+        fireEvent.click(screen.getByText('Jira'));
+        const nameInput = screen.getByPlaceholderText('Server name');
+        fireEvent.change(nameInput, {target: {value: 'Jira Cloud'}});
+        fireEvent.blur(nameInput);
+
+        const servers = lastChangedServers(onChange);
+        expect(servers[0].name).toBe('Jira Cloud');
+        expect(servers[0].id).toBe(STABLE_ID);
+    });
+
+    it('preserves the server id through a URL edit', () => {
+        const {onChange} = renderServers(makeMCPConfig([existingServer]));
+
+        const urlInput = screen.getByPlaceholderText('https://mcp.example.com');
+        fireEvent.change(urlInput, {target: {value: 'https://jira2.example.com'}});
+
+        const servers = lastChangedServers(onChange);
+        expect(servers[0].baseURL).toBe('https://jira2.example.com');
+        expect(servers[0].id).toBe(STABLE_ID);
+    });
+
+    it('adds a new server without an id so the backend mints the stable ID on save', () => {
+        const {onChange} = renderServers(makeMCPConfig([existingServer]));
+
+        fireEvent.click(screen.getByText('Add Remote MCP Server'));
+
+        const servers = lastChangedServers(onChange);
+        expect(servers).toHaveLength(2);
+        expect(servers[1].id).toBeUndefined();
+        expect(servers[0].id).toBe(STABLE_ID);
+    });
+});
+
 describe('MCPServers license gating', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockGetMCPTools.mockResolvedValue({servers: []});
     });
 
-    test('unlicensed: remote server UI is hidden and the enterprise chip is shown', async () => {
-        mockUseIsBasicsLicensed.mockReturnValue(false);
+    test('built-in section is read-only: no delete or URL inputs', async () => {
+        mockGetMCPTools.mockResolvedValue({
+            servers: [{
+                name: 'Demo Plugin',
+                url: 'plugin://com.mattermost.demo/mcp',
+                tools: [],
+                needsOAuth: false,
+                error: null,
+                serverType: 'plugin',
+                enabled: true,
+                id: 'abcdefghijklmnopqrstuvwxpl',
+            }],
+        });
 
+        // Unlicensed so remote editable cards are hidden.
+        mockUseIsBasicsLicensed.mockReturnValue(false);
         renderServers(makeMCPConfig());
 
-        expect(screen.queryByRole('button', {name: /Add Remote MCP Server/})).toBeNull();
-        expect(screen.queryByText(/No remote MCP servers configured/)).toBeNull();
-        expect(screen.queryByText('MCP OAuth Callback URL')).toBeNull();
         await waitFor(() => {
-            expect(screen.getByText('Use remote MCP servers on qualifying Mattermost plans')).not.toBeNull();
+            expect(screen.getByText('Demo Plugin')).not.toBeNull();
         });
+
+        const section = screen.getByTestId('built-in-plugin-servers-section');
+        expect(section.querySelector('input')).toBeNull();
+        expect(screen.queryByText('Delete Server')).toBeNull();
+        expect(screen.queryByPlaceholderText('https://mcp.example.com')).toBeNull();
     });
 
-    test('unlicensed with configured servers: server rows are hidden too', async () => {
-        mockUseIsBasicsLicensed.mockReturnValue(false);
+    test('preserves embeddedServer.id through enablePluginServer toggle', () => {
+        const {onChange} = renderServers(makeMCPConfig([], STABLE_ID));
 
-        renderServers(makeMCPConfig([makeRemoteServer()]));
+        // BooleanItem exposes true/false radios under the enablePluginServer row.
+        const trueRadios = screen.getAllByDisplayValue('true');
+        fireEvent.click(trueRadios[0]);
 
-        expect(screen.queryByText('Jira')).toBeNull();
-        expect(screen.queryByRole('button', {name: /Add Remote MCP Server/})).toBeNull();
-        await waitFor(() => {
-            expect(screen.getByText('Use remote MCP servers on qualifying Mattermost plans')).not.toBeNull();
-        });
+        expect(onChange).toHaveBeenCalled();
+        const config: MCPConfig = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+        expect(config.embeddedServer.id).toBe(STABLE_ID);
+        expect(config.embeddedServer.enabled).toBe(true);
     });
 
-    test('licensed: remote server UI is shown and no license UI appears', async () => {
-        mockUseIsBasicsLicensed.mockReturnValue(true);
-
-        renderServers(makeMCPConfig([makeRemoteServer()]));
-
-        const addButton = screen.getByRole('button', {name: /Add Remote MCP Server/});
-        expect((addButton as HTMLButtonElement).disabled).toBe(false);
-        expect(screen.getByText('Jira')).not.toBeNull();
-        expect(screen.getByText('MCP OAuth Callback URL')).not.toBeNull();
-        await waitFor(() => {
-            expect(screen.queryByText('Use remote MCP servers on qualifying Mattermost plans')).toBeNull();
+    test('preserves plugin_servers through enablePluginServer toggle', () => {
+        const pluginServers: PluginServerConfig[] = [{
+            id: 'pluginstableidabcdefghijklm',
+            plugin_id: 'com.example.demo',
+            name: 'Demo Plugin',
+            path: '/mcp',
+            enabled: true,
+            expose_external: false,
+            tool_configs: [{name: 'echo', policy: 'ask', enabled: true}],
+        }];
+        const {onChange} = renderServers({
+            ...makeMCPConfig([], STABLE_ID),
+            plugin_servers: pluginServers,
         });
+
+        const trueRadios = screen.getAllByDisplayValue('true');
+        fireEvent.click(trueRadios[0]);
+
+        expect(onChange).toHaveBeenCalled();
+        const config: MCPConfig = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+        expect(config.plugin_servers).toEqual(pluginServers);
+        expect(config.enablePluginServer).toBe(true);
     });
 });
 

--- a/webapp/src/components/system_console/mcp_servers.test.tsx
+++ b/webapp/src/components/system_console/mcp_servers.test.tsx
@@ -68,8 +68,8 @@ import {useIsBasicsLicensed} from '@/license';
 
 import {getMCPTools} from '../../client';
 
-import MCPServers from './mcp_servers';
-import {MCPConfig, MCPServerConfig, PluginServerConfig} from './mcp_types';
+import MCPServers, {type MCPConfig, type MCPServerConfig} from './mcp_servers';
+import type {PluginServerConfig} from './mcp_types';
 /* eslint-enable import/first, import/order */
 
 const mockUseIsBasicsLicensed = useIsBasicsLicensed as jest.Mock;
@@ -175,43 +175,8 @@ describe('MCPServers stable ID handling', () => {
         expect(servers[1].id).toBeUndefined();
         expect(servers[0].id).toBe(STABLE_ID);
     });
-});
 
-describe('MCPServers license gating', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        mockGetMCPTools.mockResolvedValue({servers: []});
-    });
-
-    test('built-in section is read-only: no delete or URL inputs', async () => {
-        mockGetMCPTools.mockResolvedValue({
-            servers: [{
-                name: 'Demo Plugin',
-                url: 'plugin://com.mattermost.demo/mcp',
-                tools: [],
-                needsOAuth: false,
-                error: null,
-                serverType: 'plugin',
-                enabled: true,
-                id: 'abcdefghijklmnopqrstuvwxpl',
-            }],
-        });
-
-        // Unlicensed so remote editable cards are hidden.
-        mockUseIsBasicsLicensed.mockReturnValue(false);
-        renderServers(makeMCPConfig());
-
-        await waitFor(() => {
-            expect(screen.getByText('Demo Plugin')).not.toBeNull();
-        });
-
-        const section = screen.getByTestId('built-in-plugin-servers-section');
-        expect(section.querySelector('input')).toBeNull();
-        expect(screen.queryByText('Delete Server')).toBeNull();
-        expect(screen.queryByPlaceholderText('https://mcp.example.com')).toBeNull();
-    });
-
-    test('preserves embeddedServer.id through enablePluginServer toggle', () => {
+    it('preserves embeddedServer.id through enablePluginServer toggle', () => {
         const {onChange} = renderServers(makeMCPConfig([], STABLE_ID));
 
         // BooleanItem exposes true/false radios under the enablePluginServer row.
@@ -224,7 +189,7 @@ describe('MCPServers license gating', () => {
         expect(config.embeddedServer.enabled).toBe(true);
     });
 
-    test('preserves plugin_servers through enablePluginServer toggle', () => {
+    it('preserves plugin_servers through enablePluginServer toggle', () => {
         const pluginServers: PluginServerConfig[] = [{
             id: 'pluginstableidabcdefghijklm',
             plugin_id: 'com.example.demo',
@@ -315,5 +280,51 @@ describe('MCPServers service account headers', () => {
         expect(screen.getByPlaceholderText('Header name (e.g. Authorization)')).not.toBeNull();
         expect(screen.getByPlaceholderText('Header value (e.g. Bearer token)')).not.toBeNull();
         expect(screen.getByText(/Do not repeat the header name in the value/)).not.toBeNull();
+    });
+});
+
+describe('MCPServers license gating', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetMCPTools.mockResolvedValue({servers: []});
+    });
+
+    test('unlicensed: remote server UI is hidden and the enterprise chip is shown', async () => {
+        mockUseIsBasicsLicensed.mockReturnValue(false);
+
+        renderServers(makeMCPConfig());
+
+        expect(screen.queryByRole('button', {name: /Add Remote MCP Server/})).toBeNull();
+        expect(screen.queryByText(/No remote MCP servers configured/)).toBeNull();
+        expect(screen.queryByText('MCP OAuth Callback URL')).toBeNull();
+        await waitFor(() => {
+            expect(screen.getByText('Use remote MCP servers on qualifying Mattermost plans')).not.toBeNull();
+        });
+    });
+
+    test('unlicensed with configured servers: server rows are hidden too', async () => {
+        mockUseIsBasicsLicensed.mockReturnValue(false);
+
+        renderServers(makeMCPConfig([makeRemoteServer()]));
+
+        expect(screen.queryByText('Jira')).toBeNull();
+        expect(screen.queryByRole('button', {name: /Add Remote MCP Server/})).toBeNull();
+        await waitFor(() => {
+            expect(screen.getByText('Use remote MCP servers on qualifying Mattermost plans')).not.toBeNull();
+        });
+    });
+
+    test('licensed: remote server UI is shown and no license UI appears', async () => {
+        mockUseIsBasicsLicensed.mockReturnValue(true);
+
+        renderServers(makeMCPConfig([makeRemoteServer()]));
+
+        const addButton = screen.getByRole('button', {name: /Add Remote MCP Server/});
+        expect((addButton as HTMLButtonElement).disabled).toBe(false);
+        expect(screen.getByText('Jira')).not.toBeNull();
+        expect(screen.getByText('MCP OAuth Callback URL')).not.toBeNull();
+        await waitFor(() => {
+            expect(screen.queryByText('Use remote MCP servers on qualifying Mattermost plans')).toBeNull();
+        });
     });
 });

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -16,43 +16,27 @@ import manifest from '@/manifest';
 import {useIsBasicsLicensed} from '@/license';
 
 import {CopyableTextItem} from './copyable_text_item';
-import MCPToolsViewer, {MCPToolsResponse} from './mcp_tools_viewer';
+import MCPToolsViewer from './mcp_tools_viewer';
+import type {
+    MCPConfig as BaseMCPConfig,
+    MCPServerConfig as BaseMCPServerConfig,
+    MCPToolConfig as BaseMCPToolConfig,
+    MCPToolsResponse,
+} from './mcp_types';
 
 import EnterpriseChip from './enterprise_chip';
 
 import {BooleanItem, ItemList, TextItem} from './item';
 
-export type MCPToolConfig = {
-    name: string;
-    policy: 'auto_run_in_dm' | 'auto_run_everywhere' | 'ask';
-    enabled: boolean;
-    retrieval_description_override?: string;
-};
+export type MCPToolConfig = BaseMCPToolConfig;
 
-export type MCPServerConfig = {
-    name: string;
-    enabled: boolean;
-    baseURL: string;
-    headers: {[key: string]: string};
-
+export type MCPServerConfig = BaseMCPServerConfig & {
     // Optional: the backend tag has omitempty, so pre-feature servers omit the key entirely.
     serviceAccountHeaders?: {[key: string]: string};
-    tool_configs?: MCPToolConfig[];
-    clientID?: string;
-    clientSecret?: string;
 };
 
-export type MCPEmbeddedServerConfig = {
-    enabled: boolean;
-    tool_configs?: MCPToolConfig[];
-};
-
-export type MCPConfig = {
-    enabled: boolean;
-    enablePluginServer: boolean;
-    servers: MCPServerConfig[] | null; // server sends nil Go slice as JSON null
-    embeddedServer: MCPEmbeddedServerConfig;
-    idleTimeoutMinutes?: number;
+export type MCPConfig = Omit<BaseMCPConfig, 'servers'> & {
+    servers: MCPServerConfig[] | null;
 };
 
 type Props = {
@@ -167,8 +151,11 @@ const MCPServer = ({
     const [serverName, setServerName] = useState(serverConfig.name);
     const [isOAuthExpanded, setIsOAuthExpanded] = useState(Boolean(serverConfig.clientID));
 
-    // Ensure server config has all required properties
+    // Ensure server config has all required properties.
+    // id must be carried through: dropping it here would rotate the server's
+    // stable ID on every edit (the server backstop mints a new one per save).
     const config = {
+        id: serverConfig.id,
         name: serverConfig.name || '',
         enabled: serverConfig.enabled ?? false,
         baseURL: serverConfig.baseURL || '',
@@ -449,7 +436,10 @@ const MCPServers = ({mcpConfig, onChange}: Props) => {
 
     // MCP client and embedded server are always enabled; users can still
     // disable individual tools but cannot turn off MCP entirely.
+    // Spread mcpConfig so fields like plugin_servers and embeddedServer.id
+    // survive rebuilds that only override a subset of keys.
     const config: MCPConfig = {
+        ...mcpConfig,
         enabled: true,
         enablePluginServer: mcpConfig?.enablePluginServer ?? false,
         servers: normalizedServers,
@@ -475,7 +465,9 @@ const MCPServers = ({mcpConfig, onChange}: Props) => {
         return `${prefix}${counter}`;
     };
 
-    // Add a new server
+    // Add a new server. No id is assigned client-side: the server treats
+    // ID-less entries with no identity match as new and mints the stable ID
+    // on save (client-invented IDs are rejected as fabricated).
     const addServer = () => {
         // Use the auto-generated name
         const serverName = generateServerName();

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -19,6 +19,7 @@ import {CopyableTextItem} from './copyable_text_item';
 import MCPToolsViewer from './mcp_tools_viewer';
 import type {
     MCPConfig as BaseMCPConfig,
+    MCPEmbeddedServerConfig as BaseMCPEmbeddedServerConfig,
     MCPServerConfig as BaseMCPServerConfig,
     MCPToolConfig as BaseMCPToolConfig,
     MCPToolsResponse,
@@ -29,6 +30,7 @@ import EnterpriseChip from './enterprise_chip';
 import {BooleanItem, ItemList, TextItem} from './item';
 
 export type MCPToolConfig = BaseMCPToolConfig;
+export type MCPEmbeddedServerConfig = BaseMCPEmbeddedServerConfig;
 
 export type MCPServerConfig = BaseMCPServerConfig & {
     // Optional: the backend tag has omitempty, so pre-feature servers omit the key entirely.

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -33,6 +33,7 @@ export type MCPToolConfig = BaseMCPToolConfig;
 export type MCPEmbeddedServerConfig = BaseMCPEmbeddedServerConfig;
 
 export type MCPServerConfig = BaseMCPServerConfig & {
+
     // Optional: the backend tag has omitempty, so pre-feature servers omit the key entirely.
     serviceAccountHeaders?: {[key: string]: string};
 };

--- a/webapp/src/components/system_console/mcp_types.ts
+++ b/webapp/src/components/system_console/mcp_types.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Types mirror config/mcp_config.go JSON tags.
+
+export type MCPToolConfig = {
+    name: string;
+    policy: 'auto_run_in_dm' | 'auto_run_everywhere' | 'ask';
+    enabled: boolean;
+    retrieval_description_override?: string;
+};
+
+export type MCPServerConfig = {
+    id?: string; // stable ABAC policy identity; may be absent until the server-side ID migration runs
+    name: string;
+    enabled: boolean;
+    baseURL: string;
+    headers: {[key: string]: string};
+    tool_configs?: MCPToolConfig[];
+    clientID?: string;
+    clientSecret?: string;
+};
+
+export type MCPEmbeddedServerConfig = {
+    id?: string; // stable ABAC policy identity; may be absent until the server-side ID migration runs
+    enabled: boolean;
+    tool_configs?: MCPToolConfig[];
+};
+
+// Mirrors config.PluginServerConfig (json:"plugin_servers").
+export type PluginServerConfig = {
+    id?: string;
+    plugin_id: string;
+    name: string;
+    path: string;
+    enabled: boolean;
+    expose_external: boolean;
+    tool_configs?: MCPToolConfig[];
+};
+
+export type MCPConfig = {
+    enabled: boolean;
+    enablePluginServer: boolean;
+    servers: MCPServerConfig[] | null; // server sends nil Go slice as JSON null
+    plugin_servers?: PluginServerConfig[] | null;
+    embeddedServer: MCPEmbeddedServerConfig;
+    idleTimeoutMinutes?: number;
+};
+
+export type MCPToolInfo = {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown> | null;
+};
+
+export type MCPServerInfo = {
+    name: string;
+    url: string;
+    tools: MCPToolInfo[];
+    needsOAuth: boolean;
+    oauthURL?: string;
+    error: string | null;
+
+    // Plugin-server fields; remote and embedded rows read state from mcpConfig.
+    serverType?: string;
+    enabled?: boolean;
+    toolConfigs?: MCPToolConfig[];
+
+    // Stable ABAC policy identity when present.
+    id?: string;
+};
+
+export type MCPToolsResponse = {
+    servers: MCPServerInfo[];
+};

--- a/webapp/src/components/system_console/plugin_config_types.tsx
+++ b/webapp/src/components/system_console/plugin_config_types.tsx
@@ -3,7 +3,7 @@
 
 import {LLMBotConfig} from './bot';
 import {EmbeddingSearchConfig} from './embedding_search/types';
-import {MCPConfig} from './mcp_servers';
+import {MCPConfig} from './mcp_types';
 import {LLMService} from './service';
 import {WebSearchConfig as WebSearchSettings} from './web_search/web_search_panel';
 

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -13,6 +13,7 @@ import {ButtonIcon} from '../assets/buttons';
 
 import {fetchModels} from '../../client';
 
+
 import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem, ComboboxItem} from './item';
 
 export type LLMService = {
@@ -426,7 +427,10 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
                     {intl.formatMessage({defaultMessage: 'No fallback'})}
                 </SelectionItemOption>
                 {(props.services ?? []).
-                    filter((s) => s.id !== props.service.id).
+
+                    // ID-less entries were added this session and aren't
+                    // addressable as fallbacks until the config is saved.
+                    filter((s) => s.id && s.id !== props.service.id).
                     map((s) => (
                         <SelectionItemOption
                             key={s.id}
@@ -488,6 +492,7 @@ const Service = (props: Props) => {
                             onChange={props.onChange}
                         />
                     </ItemList>
+                        entry is persisted and policy authoring is safe. */}
                 </ItemListContainer>
             )}
         </ServiceContainer>

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -13,7 +13,6 @@ import {ButtonIcon} from '../assets/buttons';
 
 import {fetchModels} from '../../client';
 
-
 import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem, ComboboxItem} from './item';
 
 export type LLMService = {
@@ -492,7 +491,6 @@ const Service = (props: Props) => {
                             onChange={props.onChange}
                         />
                     </ItemList>
-                        entry is persisted and policy authoring is safe. */}
                 </ItemListContainer>
             )}
         </ServiceContainer>

--- a/webapp/src/components/system_console/services.test.tsx
+++ b/webapp/src/components/system_console/services.test.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import Services from './services';
+import {type LLMService} from './service';
+import {LLMBotConfig} from './bot';
+
+jest.mock('react-intl', () => {
+    const actual = jest.requireActual('react-intl');
+    return {
+        ...actual,
+        useIntl: () => ({
+            formatMessage: ({defaultMessage}: {defaultMessage: string}, values?: Record<string, string | number>) => {
+                if (!values) {
+                    return defaultMessage;
+                }
+                return Object.entries(values).reduce(
+                    (message, [key, value]) => message.replace(`{${key}}`, String(value)),
+                    defaultMessage,
+                );
+            },
+        }),
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+// The heavy per-service editor is not under test; expose identity and the
+// delete hook so list-level behavior is observable.
+jest.mock('./service', () => ({
+    __esModule: true,
+    default: ({service, onDelete}: {service: {id: string; name: string}; onDelete: () => void}) => (
+        <div>
+            <span>{`service:${service.name}:${service.id || 'unsaved'}`}</span>
+            <button onClick={onDelete}>{`delete-${service.name}`}</button>
+        </div>
+    ),
+}));
+
+const persistedService: LLMService = {
+    id: 'serviceidaaaaaaaaaaaaaaaaa',
+    name: 'Persisted',
+    type: 'openai',
+    apiKey: '',
+    apiURL: '',
+    orgId: '',
+    defaultModel: '',
+    tokenLimit: 0,
+    streamingTimeoutSeconds: 0,
+    outputTokenLimit: 0,
+    useResponsesAPI: true,
+    region: '',
+    awsAccessKeyID: '',
+    awsSecretAccessKey: '',
+    vertexProjectID: '',
+    vertexProjectNumber: '',
+    vertexAuthCredentials: '',
+    fallbackServiceID: '',
+};
+
+function renderServices(services: LLMService[], bots: LLMBotConfig[] = []) {
+    const onChange = jest.fn();
+    render(
+        <IntlProvider locale='en'>
+            <Services
+                services={services}
+                bots={bots}
+                onChange={onChange}
+            />
+        </IntlProvider>,
+    );
+    return {onChange};
+}
+
+describe('Services', () => {
+    it('adds the first service without a client-side id', () => {
+        const {onChange} = renderServices([]);
+
+        fireEvent.click(screen.getByText('Add an AI Service'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const added = onChange.mock.calls[0][0] as LLMService[];
+        expect(added).toHaveLength(1);
+        expect(added[0].name).toBe('OpenAI Service');
+        expect(added[0].id).toBe('');
+    });
+
+    it('appends subsequent services without client-side ids', () => {
+        const {onChange} = renderServices([persistedService]);
+
+        fireEvent.click(screen.getByText('Add an AI Service'));
+
+        const next = onChange.mock.calls[0][0] as LLMService[];
+        expect(next).toHaveLength(2);
+        expect(next[0]).toBe(persistedService);
+        expect(next[1].id).toBe('');
+    });
+
+    it('deletes unsaved entries by position, not by (empty) id', () => {
+        const unsavedA = {...persistedService, id: '', name: 'Unsaved A'};
+        const unsavedB = {...persistedService, id: '', name: 'Unsaved B'};
+        const {onChange} = renderServices([unsavedA, unsavedB]);
+
+        fireEvent.click(screen.getByText('delete-Unsaved B'));
+
+        expect(onChange).toHaveBeenCalledWith([unsavedA]);
+    });
+
+    it('blocks deleting a persisted service that a bot uses', () => {
+        const bot = {id: 'bot1', name: 'bot', displayName: 'My Bot', serviceID: persistedService.id} as unknown as LLMBotConfig;
+        const {onChange} = renderServices([persistedService], [bot]);
+
+        fireEvent.click(screen.getByText('delete-Persisted'));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getByText('Cannot delete this service because it is being used by the following bot(s): My Bot')).toBeTruthy();
+    });
+
+    it('clears dangling fallback links when deleting a persisted service', () => {
+        const dependent = {...persistedService, id: 'serviceidbbbbbbbbbbbbbbbbb', name: 'Dependent', fallbackServiceID: persistedService.id};
+        const {onChange} = renderServices([persistedService, dependent]);
+
+        fireEvent.click(screen.getByText('delete-Persisted'));
+
+        expect(onChange).toHaveBeenCalledWith([{...dependent, fallbackServiceID: ''}]);
+    });
+});

--- a/webapp/src/components/system_console/services.tsx
+++ b/webapp/src/components/system_console/services.tsx
@@ -49,59 +49,60 @@ const Services = (props: Props) => {
     const [showErrorDialog, setShowErrorDialog] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
 
+    // No id is assigned client-side: the backend mints the stable ID on save
+    // (normalizeAdminConfig); policy authoring needs a persisted id.
     const addNewService = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
-        const id = crypto.randomUUID();
         if (props.services.length === 0) {
-            props.onChange([{
-                ...firstNewService,
-                id,
-            }]);
+            props.onChange([{...firstNewService}]);
         } else {
-            props.onChange([...props.services, {
-                ...defaultNewService,
-                id,
-            }]);
+            props.onChange([...props.services, {...defaultNewService}]);
         }
     };
 
-    const onChange = (newService: LLMService) => {
-        props.onChange(props.services.map((b) => (b.id === newService.id ? newService : b)));
+    // Entries added this session have no id yet, so services are addressed by
+    // index rather than by id.
+    const onChange = (index: number, newService: LLMService) => {
+        props.onChange(props.services.map((s, i) => (i === index ? newService : s)));
     };
 
-    const onDelete = (id: string) => {
-        // Check if any bot is using this service
-        const botsUsingService = props.bots.filter((bot) => bot.serviceID === id);
+    const onDelete = (index: number) => {
+        const id = props.services[index].id;
 
-        if (botsUsingService.length > 0) {
-            const botNames = botsUsingService.map((bot) => bot.displayName).join(', ');
-            const message = intl.formatMessage(
-                {defaultMessage: 'Cannot delete this service because it is being used by the following bot(s): {botNames}'},
-                {botNames},
-            );
-            setErrorMessage(message);
-            setShowErrorDialog(true);
-            return;
+        // Only persisted services can be referenced by bots or as fallbacks.
+        if (id) {
+            const botsUsingService = props.bots.filter((bot) => bot.serviceID === id);
+
+            if (botsUsingService.length > 0) {
+                const botNames = botsUsingService.map((bot) => bot.displayName).join(', ');
+                const message = intl.formatMessage(
+                    {defaultMessage: 'Cannot delete this service because it is being used by the following bot(s): {botNames}'},
+                    {botNames},
+                );
+                setErrorMessage(message);
+                setShowErrorDialog(true);
+                return;
+            }
         }
 
         // Drop the service and clear any remaining service's fallback link to it,
         // so deletion never leaves a dangling fallbackServiceID behind.
         const remaining = props.services.
-            filter((b) => b.id !== id).
-            map((b) => (b.fallbackServiceID === id ? {...b, fallbackServiceID: ''} : b));
+            filter((_, i) => i !== index).
+            map((s) => (id && s.fallbackServiceID === id ? {...s, fallbackServiceID: ''} : s));
         props.onChange(remaining);
     };
 
     return (
         <>
             <ServicesList>
-                {props.services.map((service) => (
+                {props.services.map((service, index) => (
                     <Service
-                        key={service.id}
+                        key={service.id || `unsaved-${index}`}
                         service={service}
                         services={props.services}
-                        onChange={onChange}
-                        onDelete={() => onDelete(service.id)}
+                        onChange={(updated) => onChange(index, updated)}
+                        onDelete={() => onDelete(index)}
                     />
                 ))}
             </ServicesList>


### PR DESCRIPTION
#### Summary
- Give LLM services and MCP servers stable Mattermost-style 26-character IDs so later ABAC policies can attach to a resource that survives rename, reorder, and System Console edits.
- Mint IDs on save, carry them through admin config updates (atomic `UpdateConfig`), and run a one-time store migration that rewrites legacy UUID service IDs and assigns IDs to MCP / embedded / plugin servers.
- Reject stale or conflicting identity payloads instead of silently minting a new ID (that would detach any future policy).

This is layer 1 of the ABAC stack and **can merge on its own** — it does not need the Mattermost 11.10 ABAC platform APIs.

- #970 — durable IDs (this PR)
- #971 — [PEP package and access-policy API](https://github.com/mattermost/mattermost-plugin-agents/pull/971)
- #972 — [shared access policy editor](https://github.com/mattermost/mattermost-plugin-agents/pull/972)
- #973 — [host UIs](https://github.com/mattermost/mattermost-plugin-agents/pull/973)

Reviewers: focus on ID reconciliation (`config.ReconcileServiceIDs` / MCP equivalents), the one-time `store.MigrateABACIDs` transaction, and that the webapp round-trips IDs on config save without minting extras.

#### Test Plan
- [ ] Save a new LLM service and a new remote MCP server in System Console; confirm each gets a 26-character ID in `GET /plugins/mattermost-ai/admin/config`.
- [ ] Edit name/URL of an existing service or MCP server without changing identity; confirm the ID is unchanged after save.
- [ ] Upgrade (or activate against) a config that still has UUID service IDs; confirm they are rewritten once and `fallbackServiceID` references are remapped. Automation that hard-coded the old UUIDs must re-read admin config.
- [ ] Submit a stale/corrupt payload that tries to swap an existing service's ID; confirm the save is rejected.
- [ ] `make check` (or at least `make test` for `./config ./store ./api ./mcp` plus webapp unit tests for services/MCP config).

#### Release Note
```release-note
Added durable Mattermost-style 26-character IDs for LLM services and MCP servers. Existing UUID service IDs are rewritten once on upgrade; automation that hard-coded those UUIDs must re-read GET /plugins/mattermost-ai/admin/config.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-channel agent auto-reply settings, with support for root posts and threads.
  - Added administrator controls to rebuild the vector index and configure HNSW search options.
  - Added stable identifiers for services and MCP servers, preserved across edits and re-registration.
  - Added per-user MCP access controls for servers and tools.

- **Bug Fixes**
  - Prevented conflicting or outdated identifiers from overwriting saved configuration.
  - Improved plugin registration, persistence, and orphan handling.

- **Documentation**
  - Documented vector search tuning, auto-reply requirements, and service ID migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->