### PR TITLE
Cherry-pick #931 and #936 to release-2.4

### DIFF
--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -10,6 +10,8 @@ import manifest from './manifest';
 
 import {
     doLoopInAgent,
+    getConversation,
+    getConversationContext,
     normalizeConversationResponse,
     searchAllChannels,
     setSiteURL,
@@ -71,7 +73,7 @@ function okResponse(): Response {
 // Mattermost IDs are 26 characters of lowercase letters and digits.
 const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
-// The post id reaches doLoopInAgent straight off a post prop, so a caller can hand it anything.
+// These ids reach the client straight off free-form post props, so a caller can hand them anything.
 const NOT_WELL_FORMED_IDS: Array<{name: string; id: string}> = [
     {name: 'empty', id: ''},
     {name: 'relative path segments', id: '../../some/other/route'},
@@ -221,6 +223,40 @@ describe('doLoopInAgent', () => {
 
     test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the post id is not well-formed: $name', async ({id}) => {
         await expect(doLoopInAgent(id, 'matty')).rejects.toThrow();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});
+
+describe('getConversation', () => {
+    test('requests the conversation route for a well-formed id', async () => {
+        await expect(getConversation(WELL_FORMED_ID)).resolves.toEqual({turns: []});
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/conversations/${WELL_FORMED_ID}`);
+        expect(options).toEqual(expect.objectContaining({method: 'GET'}));
+    });
+
+    test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the conversation id is not well-formed: $name', async ({id}) => {
+        await expect(getConversation(id)).rejects.toThrow();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});
+
+describe('getConversationContext', () => {
+    test('requests the conversation context route for a well-formed id', async () => {
+        await expect(getConversationContext(WELL_FORMED_ID)).resolves.toEqual({});
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/conversations/${WELL_FORMED_ID}/context`);
+        expect(options).toEqual(expect.objectContaining({method: 'GET'}));
+    });
+
+    test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the conversation id is not well-formed: $name', async ({id}) => {
+        await expect(getConversationContext(id)).rejects.toThrow();
 
         expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -6,7 +6,15 @@ import type {OptsSignalExt} from '@mattermost/types/client4';
 
 import type {ConversationResponse, Turn} from '@/types/conversation';
 
-import {normalizeConversationResponse, searchAllChannels, updateRead} from './client';
+import manifest from './manifest';
+
+import {
+    doLoopInAgent,
+    normalizeConversationResponse,
+    searchAllChannels,
+    setSiteURL,
+    updateRead,
+} from './client';
 
 type SearchAllChannelsOpts = Omit<ChannelSearchOpts, 'page' | 'per_page'> & OptsSignalExt;
 
@@ -21,8 +29,17 @@ jest.mock('@mattermost/client', () => {
 
         // client.tsx constructs `new Client4()`; the mocked class exposes instance methods.
         Client4: class Client4 {
+            url = '';
             searchAllChannels = mockSearchAllChannels;
             updateThreadReadForUser = mockUpdateThreadReadForUser;
+
+            setUrl(url: string) {
+                this.url = url;
+            }
+
+            getOptions(options: Record<string, unknown>) {
+                return {...options, headers: {'X-Requested-With': 'XMLHttpRequest'}};
+            }
         },
         ClientError: class extends Error {},
         mockSearchAllChannels,
@@ -41,6 +58,26 @@ const {mockUpdateThreadReadForUser} = jest.requireMock('@mattermost/client') as 
         (userId: string, teamId: string, postId: string, timestamp: number) => Promise<void>
     >;
 };
+
+const mockFetch = jest.fn<Promise<Response>, [string, RequestInit]>();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const siteURL = 'http://localhost:8065';
+
+function okResponse(): Response {
+    return {ok: true, status: 200, json: () => Promise.resolve({})} as unknown as Response;
+}
+
+// Mattermost IDs are 26 characters of lowercase letters and digits.
+const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
+
+// The post id reaches doLoopInAgent straight off a post prop, so a caller can hand it anything.
+const NOT_WELL_FORMED_IDS: Array<{name: string; id: string}> = [
+    {name: 'empty', id: ''},
+    {name: 'relative path segments', id: '../../some/other/route'},
+    {name: 'right length but contains a separator', id: 'abcdefghijklmnopqrstuvwxy/'},
+    {name: 'well-formed id with leading whitespace', id: ` ${WELL_FORMED_ID}`},
+];
 
 function makeTurn(overrides: Partial<Turn> = {}): Turn {
     return {
@@ -68,6 +105,15 @@ function makeConv(overrides: Partial<ConversationResponse> = {}): ConversationRe
         ...overrides,
     };
 }
+
+beforeAll(() => {
+    setSiteURL(siteURL);
+});
+
+beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+});
 
 describe('normalizeConversationResponse', () => {
     beforeEach(() => {
@@ -153,5 +199,29 @@ describe('updateRead', () => {
         mockUpdateThreadReadForUser.mockRejectedValue(error);
 
         await expect(updateRead('user-id', 'team-id', 'post-id', 123)).rejects.toBe(error);
+    });
+});
+
+describe('doLoopInAgent', () => {
+    test('posts to the loop-in route for a well-formed post id', async () => {
+        await expect(doLoopInAgent(WELL_FORMED_ID, 'matty')).resolves.toBeUndefined();
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/post/${WELL_FORMED_ID}/loop_in_agent?botUsername=matty`);
+        expect(options).toEqual(expect.objectContaining({method: 'POST'}));
+    });
+
+    test('percent-encodes the bot username in the query string', async () => {
+        await doLoopInAgent(WELL_FORMED_ID, 'agent bot&x=1');
+
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/post/${WELL_FORMED_ID}/loop_in_agent?botUsername=agent%20bot%26x%3D1`);
+    });
+
+    test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the post id is not well-formed: $name', async ({id}) => {
+        await expect(doLoopInAgent(id, 'matty')).rejects.toThrow();
+
+        expect(mockFetch).not.toHaveBeenCalled();
     });
 });

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -36,17 +36,21 @@ function baseRoute(): string {
     return `${Client4.url}/plugins/${manifest.id}`;
 }
 
-// Encoded so the id can only ever occupy one path segment.
+// Interpolated ids are encoded so each one can only ever occupy one path segment.
 function postRoute(postid: string): string {
     return `${baseRoute()}/post/${encodeURIComponent(postid)}`;
 }
 
 function channelRoute(channelid: string): string {
-    return `${baseRoute()}/channel/${channelid}`;
+    return `${baseRoute()}/channel/${encodeURIComponent(channelid)}`;
 }
 
 function agentRoute(agentId: string): string {
-    return `${baseRoute()}/agents/${agentId}`;
+    return `${baseRoute()}/agents/${encodeURIComponent(agentId)}`;
+}
+
+function conversationRoute(conversationId: string): string {
+    return `${baseRoute()}/conversations/${encodeURIComponent(conversationId)}`;
 }
 
 // readAgentErrorMessage extracts the server-provided error message from an
@@ -327,7 +331,17 @@ export function normalizeConversationResponse(raw: ConversationResponse): Conver
 }
 
 export async function getConversation(conversationId: string): Promise<ConversationResponse> {
-    const url = `${baseRoute()}/conversations/${conversationId}`;
+    // The id can arrive straight off a free-form post prop; refuse to build a
+    // request from a value that is not a well-formed id.
+    if (!isValidId(conversationId)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid conversation id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
+    const url = conversationRoute(conversationId);
     const response = await fetch(url, Client4.getOptions({
         method: 'GET',
     }));
@@ -345,7 +359,16 @@ export async function getConversation(conversationId: string): Promise<Conversat
 }
 
 export async function getConversationContext(conversationId: string): Promise<Composition> {
-    const url = `${baseRoute()}/conversations/${conversationId}/context`;
+    // Same as getConversation: never build a request from a malformed id.
+    if (!isValidId(conversationId)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid conversation id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
+    const url = `${conversationRoute(conversationId)}/context`;
     const response = await fetch(url, Client4.getOptions({
         method: 'GET',
     }));

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -9,6 +9,7 @@ import {NotPagedTeamSearchOpts, Team} from '@mattermost/types/teams';
 import {PluginConfig} from '@/components/system_console/plugin_config_types';
 import type {Composition, ConversationResponse} from '@/types/conversation';
 import {UserAgent, CreateAgentRequest, UpdateAgentRequest, ServiceInfo} from '@/types/agents';
+import {isValidId} from '@/utils/ids';
 
 import manifest from './manifest';
 
@@ -35,8 +36,9 @@ function baseRoute(): string {
     return `${Client4.url}/plugins/${manifest.id}`;
 }
 
+// Encoded so the id can only ever occupy one path segment.
 function postRoute(postid: string): string {
-    return `${baseRoute()}/post/${postid}`;
+    return `${baseRoute()}/post/${encodeURIComponent(postid)}`;
 }
 
 function channelRoute(channelid: string): string {
@@ -253,6 +255,14 @@ export async function doPostbackSummary(postid: string) {
 }
 
 export async function doLoopInAgent(postid: string, botUsername: string) {
+    if (!isValidId(postid)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid post id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
     const url = `${postRoute(postid)}/loop_in_agent?botUsername=${encodeURIComponent(botUsername)}`;
     const response = await fetch(url, Client4.getOptions({
         method: 'POST',

--- a/webapp/src/components/agent_mention_reminder_post.test.tsx
+++ b/webapp/src/components/agent_mention_reminder_post.test.tsx
@@ -54,13 +54,13 @@ describe('AgentMentionReminderPost', () => {
 
     test('falls back to the bot username when no display name is set', () => {
         renderPost({bot_username: 'matty'});
-        expect(screen.getByRole('link', {name: 'Click here to loop in @matty'})).not.toBeNull();
+        expect(screen.getByRole('link', {name: 'click here to loop in @matty'})).not.toBeNull();
     });
 
     test('clicking the link loops in the agent and shows a confirmation', async () => {
         renderPost({bot_username: 'matty', bot_display_name: 'Matty', target_post_id: TARGET_POST_ID});
 
-        fireEvent.click(screen.getByRole('link', {name: 'Click here to loop in @Matty'}));
+        fireEvent.click(screen.getByRole('link', {name: 'click here to loop in @Matty'}));
 
         expect(mockedDoLoopInAgent).toHaveBeenCalledWith(TARGET_POST_ID, 'matty');
         expect(await screen.findByText('Looped in @Matty.')).not.toBeNull();
@@ -69,7 +69,7 @@ describe('AgentMentionReminderPost', () => {
     test('falls back to the post id when no target post id is set', async () => {
         renderPost({bot_username: 'matty', bot_display_name: 'Matty'});
 
-        fireEvent.click(screen.getByRole('link', {name: 'Click here to loop in @Matty'}));
+        fireEvent.click(screen.getByRole('link', {name: 'click here to loop in @Matty'}));
 
         expect(mockedDoLoopInAgent).toHaveBeenCalledWith(POST_ID, 'matty');
         expect(await screen.findByText('Looped in @Matty.')).not.toBeNull();
@@ -90,7 +90,7 @@ describe('AgentMentionReminderPost', () => {
     test.each(notWellFormedTargetPostIds)('renders a plain hint when target_post_id is not well-formed: $name', ({targetPostId}) => {
         renderPost({bot_username: 'matty', bot_display_name: 'Matty', target_post_id: targetPostId});
 
-        expect(screen.queryByRole('link', {name: /Click here to loop in/})).toBeNull();
+        expect(screen.queryByRole('link', {name: /click here to loop in/})).toBeNull();
         expect(mockedDoLoopInAgent).not.toHaveBeenCalled();
         expect(screen.getByText(POST_MESSAGE)).not.toBeNull();
     });
@@ -126,7 +126,7 @@ describe('AgentMentionReminderPost', () => {
             {type},
         );
 
-        expect(screen.queryByRole('link', {name: /Click here to loop in/})).toBeNull();
+        expect(screen.queryByRole('link', {name: /click here to loop in/})).toBeNull();
         expect(mockedDoLoopInAgent).not.toHaveBeenCalled();
         expect(screen.getByText(POST_MESSAGE)).not.toBeNull();
     });

--- a/webapp/src/components/agent_mention_reminder_post.test.tsx
+++ b/webapp/src/components/agent_mention_reminder_post.test.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import {doLoopInAgent} from '@/client';
+
+import {AgentMentionReminderPost} from './agent_mention_reminder_post';
+
+jest.mock('@/client', () => ({
+    doLoopInAgent: jest.fn(),
+}));
+
+const mockedDoLoopInAgent = doLoopInAgent as jest.MockedFunction<typeof doLoopInAgent>;
+
+// Mattermost IDs are 26 characters of lowercase letters and digits.
+const POST_ID = 'ehz9k3wqr7t1a5m2xd8pnb4jsc';
+const TARGET_POST_ID = 'kq3n7vd1x9r4bz2m8sw6t5jhpc';
+const POST_MESSAGE = 'To respond to an agent you must @mention them.';
+
+// Only the server stamps this type onto a post.
+const EPHEMERAL_POST_TYPE = 'system_ephemeral';
+
+type PostProps = {
+    bot_username?: unknown;
+    bot_display_name?: unknown;
+    target_post_id?: unknown;
+};
+
+type PostOverrides = {id?: string; type?: string; message?: string};
+
+function renderPost(props?: PostProps, overrides?: PostOverrides) {
+    return render(
+        <IntlProvider locale='en'>
+            <AgentMentionReminderPost
+                post={{
+                    id: overrides?.id ?? POST_ID,
+                    type: overrides?.type ?? EPHEMERAL_POST_TYPE,
+                    message: overrides?.message ?? POST_MESSAGE,
+                    props,
+                }}
+            />
+        </IntlProvider>,
+    );
+}
+
+describe('AgentMentionReminderPost', () => {
+    beforeEach(() => {
+        mockedDoLoopInAgent.mockReset();
+        mockedDoLoopInAgent.mockImplementation(() => Promise.resolve());
+    });
+
+    test('falls back to the bot username when no display name is set', () => {
+        renderPost({bot_username: 'matty'});
+        expect(screen.getByRole('link', {name: 'Click here to loop in @matty'})).not.toBeNull();
+    });
+
+    test('clicking the link loops in the agent and shows a confirmation', async () => {
+        renderPost({bot_username: 'matty', bot_display_name: 'Matty', target_post_id: TARGET_POST_ID});
+
+        fireEvent.click(screen.getByRole('link', {name: 'Click here to loop in @Matty'}));
+
+        expect(mockedDoLoopInAgent).toHaveBeenCalledWith(TARGET_POST_ID, 'matty');
+        expect(await screen.findByText('Looped in @Matty.')).not.toBeNull();
+    });
+
+    test('falls back to the post id when no target post id is set', async () => {
+        renderPost({bot_username: 'matty', bot_display_name: 'Matty'});
+
+        fireEvent.click(screen.getByRole('link', {name: 'Click here to loop in @Matty'}));
+
+        expect(mockedDoLoopInAgent).toHaveBeenCalledWith(POST_ID, 'matty');
+        expect(await screen.findByText('Looped in @Matty.')).not.toBeNull();
+    });
+
+    test('renders the plain fallback message when no bot username is present', () => {
+        renderPost({}, {message: POST_MESSAGE});
+        expect(screen.getByText(POST_MESSAGE)).not.toBeNull();
+        expect(screen.queryByRole('link')).toBeNull();
+    });
+
+    const notWellFormedTargetPostIds: Array<{name: string; targetPostId: string}> = [
+        {name: 'relative path segments', targetPostId: '../../some/other/route'},
+        {name: 'right length but contains a separator', targetPostId: 'abcdefghijklmnopqrstuvwxy/'},
+        {name: 'well-formed id with leading whitespace', targetPostId: ` ${TARGET_POST_ID}`},
+    ];
+
+    test.each(notWellFormedTargetPostIds)('renders a plain hint when target_post_id is not well-formed: $name', ({targetPostId}) => {
+        renderPost({bot_username: 'matty', bot_display_name: 'Matty', target_post_id: targetPostId});
+
+        expect(screen.queryByRole('link', {name: /Click here to loop in/})).toBeNull();
+        expect(mockedDoLoopInAgent).not.toHaveBeenCalled();
+        expect(screen.getByText(POST_MESSAGE)).not.toBeNull();
+    });
+
+    const notStrings: Array<{name: string; value: unknown}> = [
+        {name: 'a number', value: 42},
+        {name: 'a boolean', value: true},
+        {name: 'an object', value: {}},
+        {name: 'an array', value: ['matty']},
+    ];
+
+    const notStringProps = (['bot_username', 'bot_display_name', 'target_post_id'] as Array<keyof PostProps>).
+        flatMap((prop) => notStrings.map(({name, value}) => ({prop, name, value})));
+
+    test.each(notStringProps)('renders when $prop is $name', ({prop, value}) => {
+        const props: PostProps = {
+            bot_username: 'matty',
+            bot_display_name: 'Matty',
+            target_post_id: TARGET_POST_ID,
+        };
+        props[prop] = value;
+
+        expect(() => renderPost(props)).not.toThrow();
+    });
+
+    test.each([
+        {name: 'an empty type', type: ''},
+        {name: 'the custom post type from the props', type: 'custom_agent_mention_reminder'},
+        {name: 'an unrelated custom type', type: 'custom_llmbot'},
+    ])('offers no action on a post that is not ephemeral: $name', ({type}) => {
+        renderPost(
+            {bot_username: 'matty', bot_display_name: 'Matty', target_post_id: TARGET_POST_ID},
+            {type},
+        );
+
+        expect(screen.queryByRole('link', {name: /Click here to loop in/})).toBeNull();
+        expect(mockedDoLoopInAgent).not.toHaveBeenCalled();
+        expect(screen.getByText(POST_MESSAGE)).not.toBeNull();
+    });
+});

--- a/webapp/src/components/agent_mention_reminder_post.tsx
+++ b/webapp/src/components/agent_mention_reminder_post.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 
 import {doLoopInAgent} from '@/client';
+import {isValidId} from '@/utils/ids';
 
 const Hint = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.64);
@@ -30,14 +31,22 @@ const LoopInLink = styled.a<{$pending: boolean}>`
     }
 `;
 
+// Only the server sets this type.
+const EphemeralPostType = 'system_ephemeral';
+
+function stringProp(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
 interface Props {
     post: {
         id: string;
+        type?: string;
         message: string;
         props?: {
-            bot_username?: string;
-            bot_display_name?: string;
-            target_post_id?: string;
+            bot_username?: unknown;
+            bot_display_name?: unknown;
+            target_post_id?: unknown;
         };
     };
 }
@@ -45,21 +54,23 @@ interface Props {
 type LoopInStatus = 'idle' | 'pending' | 'done' | 'error';
 
 export const AgentMentionReminderPost = ({post}: Props) => {
-    const botUsername = post.props?.bot_username ?? '';
-    const botDisplayName = post.props?.bot_display_name?.trim() || botUsername;
+    const botUsername = stringProp(post.props?.bot_username);
+    const botDisplayName = stringProp(post.props?.bot_display_name).trim() || botUsername;
     const targetPostId = post.props?.target_post_id ?? post.id;
+    const loopInPostId = isValidId(targetPostId) ? targetPostId : '';
+    const canLoopIn = post.type === EphemeralPostType && botUsername !== '' && loopInPostId !== '';
 
     const [status, setStatus] = useState<LoopInStatus>('idle');
     const pending = status === 'pending';
 
     const onClick = async (event: React.MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
-        if (pending || status === 'done' || !botUsername || !targetPostId) {
+        if (pending || status === 'done' || !canLoopIn) {
             return;
         }
         setStatus('pending');
         try {
-            await doLoopInAgent(targetPostId, botUsername);
+            await doLoopInAgent(loopInPostId, botUsername);
             setStatus('done');
         } catch (err) {
             console.error('Failed to loop in agent:', err); // eslint-disable-line no-console
@@ -67,7 +78,7 @@ export const AgentMentionReminderPost = ({post}: Props) => {
         }
     };
 
-    if (!botUsername) {
+    if (!canLoopIn) {
         return (
             <Hint>{post.message}</Hint>
         );

--- a/webapp/src/components/llmbot_post/llmbot_post.test.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.test.tsx
@@ -2,17 +2,15 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {IntlProvider} from 'react-intl';
 import {useSelector} from 'react-redux';
-
-import {WebSocketMessage} from '@mattermost/client';
 
 import {useConversation} from '@/hooks/use_conversation';
 
 import {MAX_SEARCH_SOURCES} from '../search_sources';
 
-import {LLMBotPost, PostUpdateWebsocketMessage} from './llmbot_post';
+import {LLMBotPost} from './llmbot_post';
 
 jest.mock('react-redux', () => ({
     useSelector: jest.fn(),
@@ -69,8 +67,6 @@ jest.mock('../post_preview', () => ({
 const mockUseSelector = useSelector as unknown as jest.Mock;
 const mockUseConversation = useConversation as jest.Mock;
 
-type PostUpdateHandler = (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void;
-
 // Mattermost IDs are 26 characters of lowercase letters and digits.
 const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
@@ -98,23 +94,15 @@ function makeSource(i: number) {
     };
 }
 
-function renderPost(
-    post = makePost(),
-    websocketRegister?: (postID: string, listenerID: string, handler: PostUpdateHandler) => void,
-) {
+function renderPost(post = makePost()) {
     return render(
         <IntlProvider locale='en'>
             <LLMBotPost
                 post={post}
-                websocketRegister={websocketRegister}
                 websocketUnregister={jest.fn()}
             />
         </IntlProvider>,
     );
-}
-
-function postUpdateMessage(data: PostUpdateWebsocketMessage): WebSocketMessage<PostUpdateWebsocketMessage> {
-    return {data} as WebSocketMessage<PostUpdateWebsocketMessage>;
 }
 
 beforeEach(() => {
@@ -138,56 +126,6 @@ beforeEach(() => {
         conversation: null,
         loading: false,
         error: null,
-    });
-});
-
-describe('LLMBotPost streaming fallback rendering', () => {
-    test('keeps streamed error text visible after stream end while refetch is pending', async () => {
-        const errorText = 'Sorry! An error occurred while accessing the LLM.';
-        let listener: PostUpdateHandler | undefined;
-        const websocketRegister = jest.fn((postID, listenerID, handler) => {
-            listener = handler;
-        });
-
-        renderPost(makePost(), websocketRegister);
-
-        expect(screen.getByText('Starting...')).toBeTruthy();
-        expect(listener).toBeDefined();
-
-        act(() => {
-            listener?.(postUpdateMessage({post_id: 'post_1', control: 'start'}));
-            listener?.(postUpdateMessage({post_id: 'post_1', next: errorText}));
-        });
-
-        await expect(screen.findByText(errorText)).resolves.toBeTruthy();
-
-        act(() => {
-            listener?.(postUpdateMessage({post_id: 'post_1', control: 'end'}));
-        });
-
-        expect(screen.getByText(errorText)).toBeTruthy();
-        expect(screen.queryByText('Starting...')).toBeNull();
-    });
-
-    test('renders updated post message when the streaming text websocket was missed', async () => {
-        const errorText = 'Sorry! An error occurred while accessing the LLM.';
-        const {rerender} = renderPost(makePost());
-
-        expect(screen.getByText('Starting...')).toBeTruthy();
-
-        rerender(
-            <IntlProvider locale='en'>
-                <LLMBotPost
-                    post={makePost(errorText)}
-                    websocketUnregister={jest.fn()}
-                />
-            </IntlProvider>,
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText(errorText)).toBeTruthy();
-        });
-        expect(screen.queryByText('Starting...')).toBeNull();
     });
 });
 

--- a/webapp/src/components/llmbot_post/llmbot_post.test.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.test.tsx
@@ -1,0 +1,253 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+import {useSelector} from 'react-redux';
+
+import {WebSocketMessage} from '@mattermost/client';
+
+import {useConversation} from '@/hooks/use_conversation';
+
+import {MAX_SEARCH_SOURCES} from '../search_sources';
+
+import {LLMBotPost, PostUpdateWebsocketMessage} from './llmbot_post';
+
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn(),
+}));
+
+jest.mock('react-intl', () => {
+    const ReactLocal = jest.requireActual('react') as typeof React;
+
+    return {
+        IntlProvider: ({children}: {children: React.ReactNode}) => ReactLocal.createElement(ReactLocal.Fragment, null, children),
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => ReactLocal.createElement(ReactLocal.Fragment, null, defaultMessage),
+    };
+});
+
+jest.mock('@/client', () => ({
+    doPostbackSummary: jest.fn(),
+    doRegenerate: jest.fn(),
+    doStopGenerating: jest.fn(),
+}));
+
+jest.mock('@/hooks', () => ({
+    useSelectNotAIPost: () => jest.fn(),
+}));
+
+jest.mock('@/hooks/use_conversation', () => ({
+    invalidateConversation: jest.fn(),
+    useConversation: jest.fn(),
+}));
+
+jest.mock('@/mm_webapp', () => ({
+    PostMessagePreview: null,
+}));
+
+jest.mock('../post_text', () => {
+    const ReactLocal = jest.requireActual('react') as typeof React;
+
+    return {
+        __esModule: true,
+        default: ({message}: {message: string}) => ReactLocal.createElement('div', null, message),
+    };
+});
+
+jest.mock('../tool_approval_set', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+// The preview fetches the source post and profile on mount; stub it out so the
+// source list can render without a client.
+jest.mock('../post_preview', () => ({
+    PostPreview: () => null,
+}));
+
+const mockUseSelector = useSelector as unknown as jest.Mock;
+const mockUseConversation = useConversation as jest.Mock;
+
+type PostUpdateHandler = (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void;
+
+// Mattermost IDs are 26 characters of lowercase letters and digits.
+const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
+
+function makePost(message = '', props: Record<string, unknown> = {}) {
+    return {
+        id: 'post_1',
+        channel_id: 'channel_1',
+        root_id: 'root_1',
+        message,
+        props: {
+            conversation_id: WELL_FORMED_ID,
+            ...props,
+        },
+    };
+}
+
+// Builds a search source entry with a unique well-formed post id.
+function makeSource(i: number) {
+    return {
+        postId: String(i).padStart(26, '0'),
+        channelId: WELL_FORMED_ID,
+        userId: WELL_FORMED_ID,
+        content: `source message ${i}`,
+        score: 0.5,
+    };
+}
+
+function renderPost(
+    post = makePost(),
+    websocketRegister?: (postID: string, listenerID: string, handler: PostUpdateHandler) => void,
+) {
+    return render(
+        <IntlProvider locale='en'>
+            <LLMBotPost
+                post={post}
+                websocketRegister={websocketRegister}
+                websocketUnregister={jest.fn()}
+            />
+        </IntlProvider>,
+    );
+}
+
+function postUpdateMessage(data: PostUpdateWebsocketMessage): WebSocketMessage<PostUpdateWebsocketMessage> {
+    return {data} as WebSocketMessage<PostUpdateWebsocketMessage>;
+}
+
+beforeEach(() => {
+    mockUseSelector.mockImplementation((selector) => selector({
+        entities: {
+            channels: {
+                channels: {
+                    channel_1: {type: 'D'},
+                },
+            },
+            posts: {
+                posts: {},
+            },
+            users: {
+                currentUserId: 'user_1',
+            },
+        },
+    }));
+
+    mockUseConversation.mockReturnValue({
+        conversation: null,
+        loading: false,
+        error: null,
+    });
+});
+
+describe('LLMBotPost streaming fallback rendering', () => {
+    test('keeps streamed error text visible after stream end while refetch is pending', async () => {
+        const errorText = 'Sorry! An error occurred while accessing the LLM.';
+        let listener: PostUpdateHandler | undefined;
+        const websocketRegister = jest.fn((postID, listenerID, handler) => {
+            listener = handler;
+        });
+
+        renderPost(makePost(), websocketRegister);
+
+        expect(screen.getByText('Starting...')).toBeTruthy();
+        expect(listener).toBeDefined();
+
+        act(() => {
+            listener?.(postUpdateMessage({post_id: 'post_1', control: 'start'}));
+            listener?.(postUpdateMessage({post_id: 'post_1', next: errorText}));
+        });
+
+        await expect(screen.findByText(errorText)).resolves.toBeTruthy();
+
+        act(() => {
+            listener?.(postUpdateMessage({post_id: 'post_1', control: 'end'}));
+        });
+
+        expect(screen.getByText(errorText)).toBeTruthy();
+        expect(screen.queryByText('Starting...')).toBeNull();
+    });
+
+    test('renders updated post message when the streaming text websocket was missed', async () => {
+        const errorText = 'Sorry! An error occurred while accessing the LLM.';
+        const {rerender} = renderPost(makePost());
+
+        expect(screen.getByText('Starting...')).toBeTruthy();
+
+        rerender(
+            <IntlProvider locale='en'>
+                <LLMBotPost
+                    post={makePost(errorText)}
+                    websocketUnregister={jest.fn()}
+                />
+            </IntlProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(errorText)).toBeTruthy();
+        });
+        expect(screen.queryByText('Starting...')).toBeNull();
+    });
+});
+
+describe('LLMBotPost conversation_id prop handling', () => {
+    // Keep call assertions scoped to each test; the file-level beforeEach only
+    // re-stubs the return value.
+    beforeEach(() => {
+        mockUseConversation.mockClear();
+    });
+
+    test('passes a well-formed conversation_id to useConversation', () => {
+        renderPost();
+
+        expect(mockUseConversation).toHaveBeenCalledWith(WELL_FORMED_ID);
+    });
+
+    // Post props are free-form JSON, so the prop can hold anything; a value
+    // that is not a well-formed id must be treated as absent.
+    test.each([
+        {name: 'relative path segments', value: '../../some/other/route'},
+        {name: 'too short', value: 'abc'},
+        {name: 'right length but contains a separator', value: 'abcdefghijklmnopqrstuvwxy/'},
+        {name: 'not a string', value: 42},
+        {name: 'null', value: null},
+    ])('ignores a conversation_id that is not well-formed: $name', ({value}) => {
+        expect(() => renderPost(makePost('', {conversation_id: value}))).not.toThrow();
+
+        expect(mockUseConversation).toHaveBeenCalledWith(void 0); // eslint-disable-line no-void
+    });
+});
+
+describe('LLMBotPost search_results prop handling', () => {
+    test('renders the source list for a well-formed search_results prop', () => {
+        const sources = [makeSource(1), makeSource(2)];
+        renderPost(makePost('hello', {search_results: JSON.stringify(sources)}));
+
+        expect(screen.getByText('Sources')).toBeTruthy();
+        expect(screen.getByText('2')).toBeTruthy();
+    });
+
+    test('bounds the rendered source list to the server maximum result count', () => {
+        const sources = Array.from({length: MAX_SEARCH_SOURCES + 50}, (_, i) => makeSource(i));
+        renderPost(makePost('hello', {search_results: JSON.stringify(sources)}));
+
+        expect(screen.getByText(String(MAX_SEARCH_SOURCES))).toBeTruthy();
+    });
+
+    // Post props are free-form JSON; none of these values may throw during
+    // render, and none should produce a source list.
+    test.each([
+        {name: 'not a string', value: 42},
+        {name: 'an object instead of a JSON string', value: {postId: WELL_FORMED_ID}},
+        {name: 'not valid JSON', value: '{not json'},
+        {name: 'a JSON object instead of an array', value: '{"postId":"x"}'},
+        {name: 'a JSON string instead of an array', value: '"just a string"'},
+        {name: 'entries that are not objects', value: '[null, "x", 7]'},
+        {name: 'entries without well-formed ids', value: JSON.stringify([{postId: 'short', channelId: 'short', userId: 'short', content: 'hi', score: 1}])},
+    ])('renders no source list when search_results is malformed: $name', ({value}) => {
+        expect(() => renderPost(makePost('hello', {search_results: value}))).not.toThrow();
+
+        expect(screen.queryByText('Sources')).toBeNull();
+    });
+});

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -14,8 +14,10 @@ import {useSelectNotAIPost} from '@/hooks';
 import {useConversation, invalidateConversation} from '@/hooks/use_conversation';
 import {PostMessagePreview} from '@/mm_webapp';
 
+import {isValidId} from '@/utils/ids';
+
 import PostText from '../post_text';
-import {SearchSources} from '../search_sources';
+import {SearchSources, parseSearchSources} from '../search_sources';
 import ToolApprovalSet from '../tool_approval_set';
 import {ToolApprovalStage, ToolCall, ToolCallStatus} from '../tool_types';
 import {Annotation} from '../citations/types';
@@ -66,7 +68,11 @@ function isResolvedToolCallEvent(toolCalls: ToolCall[]): boolean {
 export const LLMBotPost = (props: LLMBotPostProps) => {
     const selectPost = useSelectNotAIPost();
 
-    const conversationId: string | undefined = props.post.props?.conversation_id;
+    // Post props are free-form JSON; a conversation_id that is not a
+    // well-formed id is treated as absent so no request is built from it and
+    // the component falls back to its no-conversation rendering path.
+    const rawConversationId: unknown = props.post.props?.conversation_id;
+    const conversationId: string | undefined = isValidId(rawConversationId) ? rawConversationId : undefined; // eslint-disable-line no-undefined
     const {conversation, loading: conversationLoading, error: conversationError} = useConversation(conversationId);
 
     // Meeting summarization posts have no conversation entity yet; fall back to
@@ -391,6 +397,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         return 'done';
     };
 
+    // Parsed defensively: search_results is a free-form post prop, so a
+    // malformed value yields an empty list instead of throwing during render.
+    const searchSources = useMemo(
+        () => parseSearchSources(props.post.props?.[SearchResultsPropKey]),
+        [props.post.props],
+    );
+
     const isReasoningCollapsed = (roundId: string): boolean => !expandedReasoning[roundId];
     const toggleReasoning = (roundId: string, collapsed: boolean) => {
         setExpandedReasoning((prev) => ({...prev, [roundId]: !collapsed}));
@@ -440,9 +453,9 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                     />
                 );
             })}
-            {props.post.props?.[SearchResultsPropKey] && (
+            {searchSources.length > 0 && (
                 <SearchSources
-                    sources={JSON.parse(props.post.props[SearchResultsPropKey])}
+                    sources={searchSources}
                 />
             )}
             { showPostbackButton &&

--- a/webapp/src/components/search_sources.tsx
+++ b/webapp/src/components/search_sources.tsx
@@ -5,7 +5,13 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 
+import {isValidId} from '@/utils/ids';
+
 import {PostPreview} from './post_preview';
+
+// Mirrors maxMaxResults in api/api_search.go: the server never returns more
+// than this many search results, so anything beyond it is dropped.
+export const MAX_SEARCH_SOURCES = 100;
 
 // Utility for formatting relevance scores
 const formatScore = (score: number): string => {
@@ -46,16 +52,17 @@ const SourceCount = styled.span`
 	line-height: 16px;
 `;
 
-const CollapseIcon = styled.i<{isOpen: boolean}>`
+// Transient ($-prefixed) props so styled-components doesn't forward them to the DOM.
+const CollapseIcon = styled.i<{$isOpen: boolean}>`
     font-size: 18px;
     color: rgba(var(--center-channel-color-rgb), 0.56);
     margin-left: auto;
-    transform: ${(props) => (props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+    transform: ${(props) => (props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
     transition: transform 0.15s ease-in-out;
 `;
 
-const SourcesList = styled.div<{isOpen: boolean}>`
-    display: ${(props) => (props.isOpen ? 'flex' : 'none')};
+const SourcesList = styled.div<{$isOpen: boolean}>`
+    display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
     flex-direction: column;
     margin-top: 8px;
 `;
@@ -96,12 +103,64 @@ const SourceItem = styled.div`
     }
 `;
 
-interface Source {
+export interface Source {
     postId: string;
     channelId: string;
     userId: string;
     content: string;
     score: number;
+}
+
+// toSource accepts an entry only when it is an object referencing well-formed
+// ids; the remaining display fields are coerced to safe defaults.
+function toSource(entry: unknown): Source | null {
+    if (typeof entry !== 'object' || entry === null) {
+        return null;
+    }
+    const {postId, channelId, userId, content, score} = entry as Record<string, unknown>;
+    if (!isValidId(postId) || !isValidId(channelId) || !isValidId(userId)) {
+        return null;
+    }
+    return {
+        postId,
+        channelId,
+        userId,
+        content: typeof content === 'string' ? content : '',
+        score: typeof score === 'number' && Number.isFinite(score) ? score : 0,
+    };
+}
+
+// parseSearchSources decodes the search_results post prop. Post props are
+// free-form JSON, so the value may be missing, not a string, not valid JSON,
+// not an array, or hold entries without well-formed ids. Anything unusable is
+// dropped rather than thrown so a bad prop can never break the post render,
+// and the result is bounded to the server's maximum result count.
+export function parseSearchSources(raw: unknown): Source[] {
+    if (typeof raw !== 'string' || raw === '') {
+        return [];
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+
+    const sources: Source[] = [];
+    for (const entry of parsed) {
+        if (sources.length >= MAX_SEARCH_SOURCES) {
+            break;
+        }
+        const source = toSource(entry);
+        if (source) {
+            sources.push(source);
+        }
+    }
+    return sources;
 }
 
 interface SourceItemProps {
@@ -148,10 +207,10 @@ export const SearchSources = ({sources}: Props) => {
                 </SourcesTitle>
                 <CollapseIcon
                     className='icon-chevron-down'
-                    isOpen={isOpen}
+                    $isOpen={isOpen}
                 />
             </SourcesHeader>
-            <SourcesList isOpen={isOpen}>
+            <SourcesList $isOpen={isOpen}>
                 {sources.map((source, index) => (
                     <SearchSource
                         key={source.postId}

--- a/webapp/src/hooks/use_conversation_id_for_thread.ts
+++ b/webapp/src/hooks/use_conversation_id_for_thread.ts
@@ -5,10 +5,13 @@ import {useSelector} from 'react-redux';
 
 import {GlobalState} from '@mattermost/types/store';
 
+import {isValidId} from '@/utils/ids';
+
 /**
  * useConversationIdForThread resolves the plugin's conversation_id from a
  * Mattermost root post id by scanning posts in the thread for the
- * conversation_id prop the plugin writes onto every bot post.
+ * conversation_id prop the plugin writes onto every bot post. Post props are
+ * free-form JSON, so a prop that is not a well-formed id is skipped.
  *
  * Returns an empty string ('') when no bot post is in Redux yet (e.g. a fresh
  * thread the user hasn't opened, or one where the assistant has not replied).
@@ -21,8 +24,8 @@ export function useConversationIdForThread(rootPostId: string | null | undefined
         const posts = state.entities.posts.posts;
 
         const root = posts[rootPostId];
-        const rootConvId = root?.props?.conversation_id;
-        if (typeof rootConvId === 'string' && rootConvId) {
+        const rootConvId: unknown = root?.props?.conversation_id;
+        if (isValidId(rootConvId)) {
             return rootConvId;
         }
 
@@ -31,8 +34,8 @@ export function useConversationIdForThread(rootPostId: string | null | undefined
             return '';
         }
         for (const id of replyIds) {
-            const convId = posts[id]?.props?.conversation_id;
-            if (typeof convId === 'string' && convId) {
+            const convId: unknown = posts[id]?.props?.conversation_id;
+            if (isValidId(convId)) {
                 return convId;
             }
         }

--- a/webapp/src/utils/ids.test.ts
+++ b/webapp/src/utils/ids.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {isValidId} from './ids';
+
+// Mattermost IDs are 26 characters of lowercase letters and digits.
+const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
+
+describe('isValidId', () => {
+    test.each([
+        {name: 'lowercase letters and digits', id: WELL_FORMED_ID},
+        {name: 'all digits', id: '01234567890123456789012345'},
+        {name: 'all letters', id: 'abcdefghijklmnopqrstuvwxyz'},
+    ])('accepts a well-formed id: $name', ({id}) => {
+        expect(isValidId(id)).toBe(true);
+    });
+
+    test.each([
+        {name: 'empty', id: ''},
+        {name: 'too short', id: 'abc'},
+        {name: 'too long', id: 'abcdefghijklmnopqrstuvwxyz7'},
+        {name: 'uppercase', id: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'},
+        {name: 'non-ascii', id: 'abcdefghijklmnopqrstuvwxy\u00e9'},
+        {name: 'contains a separator', id: 'abcdefghijklmnopqrstuvwxy/'},
+        {name: 'relative path segments', id: '../../some/other/route'},
+        {name: 'leading whitespace', id: ` ${WELL_FORMED_ID}`},
+        {name: 'trailing newline', id: `${WELL_FORMED_ID}\n`},
+    ])('rejects a malformed id: $name', ({id}) => {
+        expect(isValidId(id)).toBe(false);
+    });
+
+    // Post props are decoded from JSON off the websocket, so callers can hand
+    // this helper any JSON value regardless of what the TypeScript type says.
+    // Anything that is not a string is not an id.
+    test.each([
+        {name: 'a number', value: 1234567890},
+        {name: 'a boolean', value: true},
+        {name: 'null', value: null},
+        {name: 'a missing value', value: void 0}, // eslint-disable-line no-void
+        {name: 'an object', value: {}},
+        {name: 'an empty array', value: []},
+        {name: 'an array wrapping a well-formed id', value: [WELL_FORMED_ID]},
+    ])('rejects a value that is not a string: $name', ({value}) => {
+        expect(isValidId(value)).toBe(false);
+    });
+});

--- a/webapp/src/utils/ids.ts
+++ b/webapp/src/utils/ids.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Stricter than model.IsValidId (any 26 unicode letters or digits); accepts everything model.NewId emits.
+const ID_PATTERN = /^[a-z0-9]{26}$/;
+
+/** Takes unknown: decoded JSON (post props, API payloads) can put any value in a string-typed field. */
+export function isValidId(id: unknown): id is string {
+    return typeof id === 'string' && ID_PATTERN.test(id);
+}


### PR DESCRIPTION
#### Summary

Cherry pick of https://github.com/mattermost/mattermost-plugin-agents/pull/931 and https://github.com/mattermost/mattermost-plugin-agents/pull/936 onto `release-2.4`.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-69973

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and URL encoding for conversation, post, channel, and agent identifiers.
  - Prevented malformed conversation IDs and search data from causing errors or unexpected requests.
  - Limited agent loop-in actions to eligible ephemeral posts and valid targets.
  - Safely handled invalid or incomplete post properties.

- **Improvements**
  - Search results are capped at 100 items and rendered only when valid results are available.
  - Invalid conversation identifiers are ignored when determining thread context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->