### PR TITLE
Fix MCP cold-start latency from standalone SSE

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -481,8 +481,9 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 	// protocol version (2026-07-28 down to 2025-03-26) via a server/discover request,
 	// falling back to a legacy initialize request when the server does not support it.
 	streamableTransport := &mcp.StreamableClientTransport{
-		Endpoint:   serverConfig.BaseURL,
-		HTTPClient: httpClient,
+		Endpoint:             serverConfig.BaseURL,
+		HTTPClient:           httpClient,
+		DisableStandaloneSSE: true,
 	}
 	if oauthHandler != nil {
 		streamableTransport.OAuthHandler = oauthHandler

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -494,6 +494,32 @@ func TestNewClientDiscoversPaginatedRemoteTools(t *testing.T) {
 	}
 }
 
+func TestNewClientDoesNotOpenStandaloneSSE(t *testing.T) {
+	var getCalls atomic.Int32
+	server := newTestMCPServer(0, "tool_1")
+	streamableHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getCalls.Add(1)
+		}
+		streamableHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := NewClient(context.Background(), "user-id", ServerConfig{
+		Name:    "remote",
+		BaseURL: httpServer.URL,
+		Enabled: true,
+	}, newTestLogService(), newTestOAuthManager(), httpServer.Client(), newTestToolsCache(), false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Contains(t, client.Tools(), "tool_1")
+	require.Zero(t, getCalls.Load())
+}
+
 func TestRemoteReconnectRefreshesToolCatalog(t *testing.T) {
 	server := newTestMCPServer(0, "tool_1")
 	httpServer := startStreamableMCPServer(t, server)


### PR DESCRIPTION
#### Summary

Disables the optional standalone SSE listener for remote Streamable HTTP MCP connections. The Agents plugin does not register server-initiated notification handlers and refreshes tool catalogs explicitly, so the listener provided no functionality while allowing servers such as Atlassian to hold the initialization GET and delay agent responses.

Adds regression coverage using a real Streamable HTTP handler to verify remote tool discovery succeeds without opening a standalone GET.

QA:
- Confirmed authenticated Atlassian MCP requests no longer emit the blocking GET and Matty responds promptly.
- `go test ./mcp -count=1`
- `make check`

#### Release Note
```release-note
Fixed slow agent responses when connecting to some authenticated MCP servers.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote client connections by preventing unnecessary standalone SSE requests when using streamable HTTP.
  * Tool discovery now proceeds through the streamable HTTP endpoint as expected, while legacy HTTP/SSE fallback remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->