### PR TITLE
webapp: fix avatar placeholder tests against the Jest asset stub

### DIFF
--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -5,6 +5,10 @@ import React from 'react';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {IntlProvider} from 'react-intl';
 
+// Suite-wide mapper stubs pngs; import the same module id avatar.tsx uses.
+//@ts-ignore it exists
+import aiIcon from 'src/../../assets/bot_icon.png';
+
 import AvatarItem from './avatar';
 
 jest.mock('react-intl', () => {
@@ -21,8 +25,6 @@ jest.mock('react-intl', () => {
 jest.mock('@/client', () => ({
     getBotProfilePictureUrl: jest.fn(),
 }));
-
-jest.mock('src/../../assets/bot_icon.png', () => 'placeholder-icon.png', {virtual: true});
 
 const {getBotProfilePictureUrl} = jest.requireMock('@/client') as {
     getBotProfilePictureUrl: jest.Mock<Promise<string>, [string]>;
@@ -104,7 +106,7 @@ describe('AvatarItem', () => {
             expect(getBotProfilePictureUrl).toHaveBeenCalledWith('newbot');
         });
 
-        expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
+        expect(screen.getByRole('img').getAttribute('src')).toBe(aiIcon);
     });
 
     it('keeps the placeholder when the avatar fetch rejects (no unhandled rejection)', async () => {
@@ -122,7 +124,7 @@ describe('AvatarItem', () => {
 
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
+            expect(screen.getByRole('img').getAttribute('src')).toBe(aiIcon);
             expect(unhandled).not.toHaveBeenCalled();
         } finally {
             process.off('unhandledRejection', unhandled);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
`plugin-tests` has been failing on master and on open PRs because two `AvatarItem` cases still expect a virtual `placeholder-icon.png` mock.

Jest's `moduleNameMapper` now stubs `png` (and other image) imports via `tests/svg_mock.js` and takes precedence over that mock, so the img `src` is `svg-file-stub`. The tests now import the same `bot_icon.png` module id as `avatar.tsx` and assert against that stub.

This is a test-only change. No product behavior is affected.

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03e59-abb8-7361-a4ab-6a5e7da4900c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03e59-abb8-7361-a4ab-6a5e7da4900c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated avatar tests to use the shared bot icon asset.
  * Improved validation for unresolved avatars and rejected avatar requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->