### PR TITLE
fix: stop flaking avatar placeholder tests on Jest asset mapper

### DIFF
--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {IntlProvider} from 'react-intl';
 
+import placeholderIcon from 'src/../../assets/bot_icon.png';
+
 import AvatarItem from './avatar';
 
 jest.mock('react-intl', () => {
@@ -21,8 +23,6 @@ jest.mock('react-intl', () => {
 jest.mock('@/client', () => ({
     getBotProfilePictureUrl: jest.fn(),
 }));
-
-jest.mock('src/../../assets/bot_icon.png', () => 'placeholder-icon.png', {virtual: true});
 
 const {getBotProfilePictureUrl} = jest.requireMock('@/client') as {
     getBotProfilePictureUrl: jest.Mock<Promise<string>, [string]>;
@@ -102,9 +102,8 @@ describe('AvatarItem', () => {
 
         await waitFor(() => {
             expect(getBotProfilePictureUrl).toHaveBeenCalledWith('newbot');
+            expect(screen.getByRole('img').getAttribute('src')).toBe(placeholderIcon);
         });
-
-        expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
     });
 
     it('keeps the placeholder when the avatar fetch rejects (no unhandled rejection)', async () => {
@@ -122,7 +121,7 @@ describe('AvatarItem', () => {
 
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
+            expect(screen.getByRole('img').getAttribute('src')).toBe(placeholderIcon);
             expect(unhandled).not.toHaveBeenCalled();
         } finally {
             process.off('unhandledRejection', unhandled);

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -5,7 +5,6 @@ import React, {ChangeEvent, useEffect, useRef, useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 
-//@ts-ignore it exists
 import aiIcon from 'src/../../assets/bot_icon.png';
 
 import {getBotProfilePictureUrl} from '@/client';

--- a/webapp/src/types/assets.d.ts
+++ b/webapp/src/types/assets.d.ts
@@ -5,3 +5,8 @@ declare module '*.svg' {
     const content: string;
     export default content;
 }
+
+declare module '*.png' {
+    const content: string;
+    export default content;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
`AvatarItem` placeholder tests failed whenever they ran in the full webapp Jest suite, while passing in isolation.

The tests used a virtual mock of `src/../../assets/bot_icon.png` that exported `placeholder-icon.png`. Jest's `moduleNameMapper` also maps every `png`/`svg` import to `tests/svg_mock.js` (`svg-file-stub`). When other suites had already loaded that mapped module in the same worker, the virtual mock lost and the assertions compared `placeholder-icon.png` against `svg-file-stub`.

The tests now import the same placeholder specifier the component uses and assert against that resolved value, so they follow whichever stub Jest actually applied.

#### Ticket Link
N/A

#### Screenshots
N/A — test-only change.

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9f67d04-6108-4600-a58f-6c8b39d24707?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9f67d04-6108-4600-a58f-6c8b39d24707&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the bot avatar fallback image.
  * Resolved image asset typing issues to support reliable avatar rendering.
* **Tests**
  * Updated avatar tests to validate fallback images against the bundled asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->