### PR TITLE
Cherry pick #994 to release-2.5

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -470,8 +470,9 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 	// Try new Streamable HTTP transport first (2025-03-26 spec).
 	// This will POST InitializeRequest and detect if the server supports the new transport.
 	session, errStreamable := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint:   serverConfig.BaseURL,
-		HTTPClient: httpClient,
+		Endpoint:             serverConfig.BaseURL,
+		HTTPClient:           httpClient,
+		DisableStandaloneSSE: true,
 	}, nil)
 	if errStreamable == nil {
 		// Successfully connected using Streamable HTTP transport

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -371,6 +371,32 @@ func TestNewClientDiscoversPaginatedRemoteTools(t *testing.T) {
 	}
 }
 
+func TestNewClientDoesNotOpenStandaloneSSE(t *testing.T) {
+	var getCalls atomic.Int32
+	server := newTestMCPServer(0, "tool_1")
+	streamableHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getCalls.Add(1)
+		}
+		streamableHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := NewClient(context.Background(), "user-id", ServerConfig{
+		Name:    "remote",
+		BaseURL: httpServer.URL,
+		Enabled: true,
+	}, newTestLogService(), newTestOAuthManager(), httpServer.Client(), newTestToolsCache(), false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Contains(t, client.Tools(), "tool_1")
+	require.Zero(t, getCalls.Load())
+}
+
 func TestRemoteReconnectRefreshesToolCatalog(t *testing.T) {
 	server := newTestMCPServer(0, "tool_1")
 	httpServer := startStreamableMCPServer(t, server)


### PR DESCRIPTION
See: https://github.com/mattermost/mattermost-plugin-agents/pull/994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote connection handling by preventing unnecessary standalone SSE requests when using streamable HTTP transport.
  - Tool discovery now proceeds through the configured streamable HTTP endpoint without opening an additional SSE connection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->