### PR TITLE
Block DM and group message access for bot sessions

### DIFF
--- a/api/api_search.go
+++ b/api/api_search.go
@@ -121,11 +121,12 @@ func (a *API) handleSearchQuery(c *gin.Context) {
 
 // RawSearchRequest represents the request body for the raw semantic search endpoint
 type RawSearchRequest struct {
-	Query     string `json:"query"`
-	TeamID    string `json:"team_id,omitempty"`
-	ChannelID string `json:"channel_id,omitempty"`
-	Limit     int    `json:"limit,omitempty"`
-	Offset    int    `json:"offset,omitempty"`
+	Query                 string `json:"query"`
+	TeamID                string `json:"team_id,omitempty"`
+	ChannelID             string `json:"channel_id,omitempty"`
+	Limit                 int    `json:"limit,omitempty"`
+	Offset                int    `json:"offset,omitempty"`
+	ExcludeDirectAndGroup bool   `json:"exclude_direct_and_group,omitempty"`
 }
 
 // RawSearchResult represents a single raw semantic search result
@@ -192,11 +193,12 @@ func (a *API) handleRawSearch(c *gin.Context) {
 	}
 
 	results, err := a.searchService.Search(c.Request.Context(), req.Query, search.Options{
-		Limit:     limit,
-		Offset:    offset,
-		TeamID:    req.TeamID,
-		ChannelID: req.ChannelID,
-		UserID:    userID,
+		Limit:                 limit,
+		Offset:                offset,
+		TeamID:                req.TeamID,
+		ChannelID:             req.ChannelID,
+		UserID:                userID,
+		ExcludeDirectAndGroup: req.ExcludeDirectAndGroup,
 	})
 	if err != nil {
 		if errors.Is(err, search.ErrSearchUnavailable) {

--- a/api/api_search_test.go
+++ b/api/api_search_test.go
@@ -741,3 +741,44 @@ func TestHandleRunSearchMalformedJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleRawSearchExcludeDirectAndGroup(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	tests := []struct {
+		name    string
+		exclude bool
+	}{
+		{"true is forwarded to the search service", true},
+		{"false is forwarded to the search service", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			mockEmbedding := mocks.NewMockEmbeddingSearch(t)
+			mockEmbedding.On("Search", mock.Anything, "hello", mock.MatchedBy(func(opts embeddings.SearchOptions) bool {
+				return opts.ExcludeDirectAndGroup == tc.exclude && opts.UserID == "userid"
+			})).Return([]embeddings.SearchResult{}, nil)
+			e.api.searchService = search.New(func() embeddings.EmbeddingSearch { return mockEmbedding }, nil, nil, nil, nil, nil)
+			e.mockAPI.On("LogError", mock.Anything).Maybe()
+
+			body, err := json.Marshal(RawSearchRequest{
+				Query:                 "hello",
+				ExcludeDirectAndGroup: tc.exclude,
+			})
+			require.NoError(t, err)
+
+			request := httptest.NewRequest(http.MethodPost, "/search/raw", bytes.NewReader(body))
+			request.Header.Add("Mattermost-User-ID", "userid")
+			request.Header.Set("Content-Type", "application/json")
+
+			recorder := httptest.NewRecorder()
+			e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+			require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+		})
+	}
+}

--- a/embeddings/embeddings.go
+++ b/embeddings/embeddings.go
@@ -62,6 +62,9 @@ type SearchOptions struct {
 	UserID        string // User ID for permission checks
 	CreatedAfter  int64
 	CreatedBefore int64
+	// ExcludeDirectAndGroup omits DM and group-message channels. Used when the
+	// searching session is a bot that belongs to every user's DM with the agent.
+	ExcludeDirectAndGroup bool
 }
 
 // EmbeddingSearch defines the high-level interface for storing and searching using embeddings

--- a/mcpserver/auth/token_provider.go
+++ b/mcpserver/auth/token_provider.go
@@ -36,29 +36,37 @@ func NewTokenAuthenticationProvider(externalURL, internalURL, token string, logg
 
 // ValidateAuth validates authentication
 func (p *TokenAuthenticationProvider) ValidateAuth(ctx context.Context) error {
-	// Get authenticated client and validate token (single GetMe call)
 	_, err := p.GetAuthenticatedMattermostClient(ctx)
 	return err
 }
 
 // GetAuthenticatedMattermostClient returns an authenticated Mattermost client
 func (p *TokenAuthenticationProvider) GetAuthenticatedMattermostClient(ctx context.Context) (*model.Client4, error) {
+	client, _, err := p.authenticatedClientAndUser(ctx)
+	return client, err
+}
+
+// GetAuthenticatedUser returns the Mattermost user for the configured PAT.
+func (p *TokenAuthenticationProvider) GetAuthenticatedUser(ctx context.Context) (*model.User, error) {
+	_, user, err := p.authenticatedClientAndUser(ctx)
+	return user, err
+}
+
+func (p *TokenAuthenticationProvider) authenticatedClientAndUser(ctx context.Context) (*model.Client4, *model.User, error) {
 	if p.token == "" {
-		return nil, fmt.Errorf("no authentication token available")
+		return nil, nil, fmt.Errorf("no authentication token available")
 	}
 
-	// Create client with configured token
 	client := model.NewAPIv4Client(p.mmServerURL)
 	client.SetToken(p.token)
 
-	// Validate token by getting current user (single validation call)
 	user, _, err := client.GetMe(ctx, "")
 	if err != nil {
 		p.logger.Error("failed to validate token", "error", err)
-		return nil, fmt.Errorf("invalid authentication token: %w", err)
+		return nil, nil, fmt.Errorf("invalid authentication token: %w", err)
 	}
 
 	p.logger.Debug("validated token for user", "user_id", user.Id, "username", user.Username)
 
-	return client, nil
+	return client, user, nil
 }

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -602,7 +602,7 @@ func automationChannelIDs(a Automation) []string {
 }
 
 func (p *MattermostToolProvider) requireVisibleAutomation(ctx context.Context, mcpContext *MCPToolContext, id string) error {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return nil
 	}
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodGet, p.automationAPIURL("/automations/"+id), "")
@@ -622,7 +622,7 @@ func (p *MattermostToolProvider) requireVisibleAutomation(ctx context.Context, m
 }
 
 func automationVisibleToSession(mcpContext *MCPToolContext, a Automation) bool {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return true
 	}
 	r := mcpContext.channelResolver()

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -321,6 +321,19 @@ func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext,
 		return "No automations found matching the specified criteria.", nil
 	}
 
+	if mcpContext.IsBotSession {
+		visible := make([]Automation, 0, len(automations))
+		for _, a := range automations {
+			if automationVisibleToSession(mcpContext, a) {
+				visible = append(visible, a)
+			}
+		}
+		automations = visible
+		if len(automations) == 0 {
+			return "No automations found matching the specified criteria.", nil
+		}
+	}
+
 	return formatAutomationsJSON(automations)
 }
 
@@ -334,6 +347,10 @@ func (p *MattermostToolProvider) getAutomationByID(ctx context.Context, mcpConte
 	var automation Automation
 	if err := json.NewDecoder(resp.Body).Decode(&automation); err != nil {
 		return "", fmt.Errorf("failed to decode automation response: %w", err)
+	}
+
+	if !automationVisibleToSession(mcpContext, automation) {
+		return "", errDirectOrGroupInaccessible
 	}
 
 	return formatAutomationJSON(automation)
@@ -390,6 +407,9 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 	}
 
 	ctx := mcpContext.Ctx
+	if err := p.requireVisibleAutomation(ctx, mcpContext, args.AutomationID); err != nil {
+		return "", err
+	}
 
 	automation := Automation{
 		ID:      args.AutomationID,
@@ -436,6 +456,9 @@ func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext
 	}
 
 	ctx := mcpContext.Ctx
+	if err := p.requireVisibleAutomation(ctx, mcpContext, args.AutomationID); err != nil {
+		return "", err
+	}
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodDelete, p.automationAPIURL("/automations/"+args.AutomationID), "")
 	if err != nil {
@@ -550,4 +573,64 @@ func formatAutomationsJSON(automations []Automation) (string, error) {
 		result.WriteString(fmt.Sprintf("%d. %s (ID: %s)\n%s\n\n", i+1, a.Name, a.ID, jsonStr))
 	}
 	return result.String(), nil
+}
+
+func automationChannelIDs(a Automation) []string {
+	var ids []string
+	add := func(id string) {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	switch {
+	case a.Trigger.MessagePosted != nil:
+		add(a.Trigger.MessagePosted.ChannelID)
+	case a.Trigger.Schedule != nil:
+		add(a.Trigger.Schedule.ChannelID)
+	case a.Trigger.MembershipChanged != nil:
+		add(a.Trigger.MembershipChanged.ChannelID)
+	}
+	for _, action := range a.Actions {
+		if action.SendMessage != nil {
+			add(action.SendMessage.ChannelID)
+		}
+		if action.AIPrompt != nil && action.AIPrompt.Guardrails != nil {
+			ids = append(ids, action.AIPrompt.Guardrails.ChannelIDs...)
+		}
+	}
+	return ids
+}
+
+func (p *MattermostToolProvider) requireVisibleAutomation(ctx context.Context, mcpContext *MCPToolContext, id string) error {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return nil
+	}
+	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodGet, p.automationAPIURL("/automations/"+id), "")
+	if err != nil {
+		return handleAutomationHTTPError(resp, err, id)
+	}
+	defer resp.Body.Close()
+
+	var automation Automation
+	if err := json.NewDecoder(resp.Body).Decode(&automation); err != nil {
+		return fmt.Errorf("failed to decode automation response: %w", err)
+	}
+	if !automationVisibleToSession(mcpContext, automation) {
+		return errDirectOrGroupInaccessible
+	}
+	return nil
+}
+
+func automationVisibleToSession(mcpContext *MCPToolContext, a Automation) bool {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return true
+	}
+	r := mcpContext.channelResolver()
+	for _, id := range automationChannelIDs(a) {
+		ch, err := r.channel(id)
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
+			return false
+		}
+	}
+	return true
 }

--- a/mcpserver/tools/channel_members.go
+++ b/mcpserver/tools/channel_members.go
@@ -227,6 +227,10 @@ func (p *MattermostToolProvider) toolGetUserChannelMemberships(mcpContext *MCPTo
 	if len(members) == 0 {
 		return "no channel memberships found", nil
 	}
+	members = filterChannelMembers(mcpContext, members)
+	if len(members) == 0 {
+		return "no channel memberships found", nil
+	}
 
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("Channel memberships (%d):\n\n", len(members)))
@@ -307,12 +311,17 @@ func (p *MattermostToolProvider) toolListSidebarCategories(mcpContext *MCPToolCo
 		return "no sidebar categories found", nil
 	}
 
+	visible := filterSidebarCategories(mcpContext, categories.Categories)
+	if len(visible) == 0 {
+		return "no sidebar categories found", nil
+	}
+
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("Sidebar categories (%d):\n\n", len(categories.Categories)))
-	for i := range categories.Categories {
+	result.WriteString(fmt.Sprintf("Sidebar categories (%d):\n\n", len(visible)))
+	for i := range visible {
 		format.WriteSidebarCategory(&result, format.SidebarCategoryEntry{
 			HeaderLabel: fmt.Sprintf("Category %d", i+1),
-			Category:    categories.Categories[i],
+			Category:    visible[i],
 		})
 	}
 	return result.String(), nil

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -480,6 +480,13 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 		return "", fmt.Errorf("insufficient parameters for channel lookup")
 	}
 
+	if mcpContext.IsBotSession {
+		channels = withoutDirectAndGroup(channels)
+		if len(channels) == 0 {
+			return "No channels found matching the request.", nil
+		}
+	}
+
 	// If multiple channels found, return all with disambiguation guidance
 	if len(channels) > 1 {
 		return p.formatMultipleChannels(ctx, client, channels, mcpContext.UserID)
@@ -866,6 +873,10 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 		channels = allChannels
 	}
 
+	if mcpContext.IsBotSession {
+		channels = withoutDirectAndGroup(channels)
+	}
+
 	// Store total count before pagination
 	totalCount := len(channels)
 
@@ -1088,6 +1099,10 @@ func (p *MattermostToolProvider) toolSearchChannels(mcpContext *MCPToolContext, 
 		for _, ch := range found {
 			channels = append(channels, &ch.Channel)
 		}
+	}
+
+	if mcpContext.IsBotSession {
+		channels = withoutDirectAndGroup(channels)
 	}
 
 	return p.formatChannelList(ctx, client, channels, fmt.Sprintf("channels matching '%s'", args.Term)), nil

--- a/mcpserver/tools/dm_guard.go
+++ b/mcpserver/tools/dm_guard.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// errDirectOrGroupInaccessible is returned when a bot session names a DM or GM
+// channel (or a post/file in one). Tool errors here are not localized.
+var errDirectOrGroupInaccessible = fmt.Errorf("direct and group messages are not accessible to this agent")
+
+// errUnverifiedChannelReference is returned when a referenced ID cannot be
+// resolved to a channel. Rejecting keeps an unresolvable reference from
+// skipping the DM/GM check, and reports the real reason rather than implying
+// the target was a DM.
+var errUnverifiedChannelReference = fmt.Errorf("could not resolve the channel for a referenced ID; it may be invalid or inaccessible")
+
+type guardedArgKind int
+
+const (
+	guardedChannelID guardedArgKind = iota
+	guardedPostID
+	guardedFileID
+)
+
+// guardedArgKeys are argument names the ID guard resolves to a channel.
+// channel_ids / post_ids / file_ids share a kind with their singular forms.
+var guardedArgKeys = map[string]guardedArgKind{
+	"channel_id":       guardedChannelID,
+	"channel_ids":      guardedChannelID,
+	"post_id":          guardedPostID,
+	"post_ids":         guardedPostID,
+	"root_id":          guardedPostID,
+	"thread_id":        guardedPostID,
+	"reply_to_post_id": guardedPostID,
+	"file_id":          guardedFileID,
+	"file_ids":         guardedFileID,
+}
+
+// identifierArgsNotResolvedByGuard are schema property names that identify a
+// channel or post but are not Mattermost IDs. channel_name cannot look up a D/G
+// via GetChannelByName (those channels have no team); GetChannelsForTeamForUser
+// can still return DMs, so get_channel_info filters results instead.
+var identifierArgsNotResolvedByGuard = map[string]bool{
+	"channel_name": true,
+}
+
+func isDirectOrGroupChannel(ch *model.Channel) bool {
+	return ch != nil && ch.IsGroupOrDirect()
+}
+
+func withoutDirectAndGroup(channels []*model.Channel) []*model.Channel {
+	out := make([]*model.Channel, 0, len(channels))
+	for _, ch := range channels {
+		if isDirectOrGroupChannel(ch) {
+			continue
+		}
+		out = append(out, ch)
+	}
+	return out
+}
+
+// channelResolver maps IDs to channels, memoized for one tool call.
+type channelResolver struct {
+	mcpContext *MCPToolContext
+	byChannel  map[string]*model.Channel
+	byPost     map[string]*model.Channel
+	byFile     map[string]*model.Channel
+}
+
+func newChannelResolver(mcpContext *MCPToolContext) *channelResolver {
+	return &channelResolver{
+		mcpContext: mcpContext,
+		byChannel:  make(map[string]*model.Channel),
+		byPost:     make(map[string]*model.Channel),
+		byFile:     make(map[string]*model.Channel),
+	}
+}
+
+func (r *channelResolver) channel(id string) (*model.Channel, error) {
+	if ch, ok := r.byChannel[id]; ok {
+		return ch, nil
+	}
+	ch, _, err := r.mcpContext.Client.GetChannel(r.mcpContext.Ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	r.byChannel[id] = ch
+	return ch, nil
+}
+
+func (r *channelResolver) channelByPost(postID string) (*model.Channel, error) {
+	if ch, ok := r.byPost[postID]; ok {
+		return ch, nil
+	}
+	post, _, err := r.mcpContext.Client.GetPost(r.mcpContext.Ctx, postID, "")
+	if err != nil {
+		return nil, err
+	}
+	ch, err := r.channel(post.ChannelId)
+	if err != nil {
+		return nil, err
+	}
+	r.byPost[postID] = ch
+	return ch, nil
+}
+
+func (r *channelResolver) channelByFile(fileID string) (*model.Channel, error) {
+	if ch, ok := r.byFile[fileID]; ok {
+		return ch, nil
+	}
+	info, _, err := r.mcpContext.Client.GetFileInfo(r.mcpContext.Ctx, fileID)
+	if err != nil {
+		return nil, err
+	}
+	var ch *model.Channel
+	switch {
+	case info.ChannelId != "":
+		ch, err = r.channel(info.ChannelId)
+	case info.PostId != "":
+		ch, err = r.channelByPost(info.PostId)
+	default:
+		return nil, fmt.Errorf("file %s is not attached to a channel or post", fileID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	r.byFile[fileID] = ch
+	return ch, nil
+}
+
+// rejectDirectOrGroupArgs scans tool arguments for channel/post/file IDs and
+// rejects the call when any resolve to a DM or GM. No-op for human sessions.
+func rejectDirectOrGroupArgs(mcpContext *MCPToolContext, arguments any) error {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return nil
+	}
+	args := argumentsMap(arguments)
+	if len(args) == 0 {
+		return nil
+	}
+	return scanGuardedArgs(args, newChannelResolver(mcpContext))
+}
+
+func scanGuardedArgs(args map[string]any, r *channelResolver) error {
+	for key, val := range args {
+		if kind, ok := guardedArgKeys[key]; ok {
+			if err := rejectResolvedIDs(kind, val, r); err != nil {
+				return err
+			}
+		}
+		switch nested := val.(type) {
+		case map[string]any:
+			if err := scanGuardedArgs(nested, r); err != nil {
+				return err
+			}
+		case []any:
+			for _, item := range nested {
+				if m, ok := item.(map[string]any); ok {
+					if err := scanGuardedArgs(m, r); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func rejectResolvedIDs(kind guardedArgKind, val any, r *channelResolver) error {
+	for _, id := range stringIDs(val) {
+		ch, err := resolveGuardedID(kind, id, r)
+		if err != nil {
+			return errUnverifiedChannelReference
+		}
+		if isDirectOrGroupChannel(ch) {
+			return errDirectOrGroupInaccessible
+		}
+	}
+	return nil
+}
+
+func resolveGuardedID(kind guardedArgKind, id string, r *channelResolver) (*model.Channel, error) {
+	switch kind {
+	case guardedChannelID:
+		return r.channel(id)
+	case guardedPostID:
+		return r.channelByPost(id)
+	case guardedFileID:
+		return r.channelByFile(id)
+	default:
+		return nil, fmt.Errorf("unhandled guarded argument kind %d", kind)
+	}
+}
+
+func argumentsMap(arguments any) map[string]any {
+	switch v := arguments.(type) {
+	case map[string]any:
+		return v
+	case json.RawMessage:
+		var m map[string]any
+		if err := json.Unmarshal(v, &m); err != nil {
+			return nil
+		}
+		return m
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil
+		}
+		return m
+	}
+}
+
+func stringIDs(v any) []string {
+	switch x := v.(type) {
+	case string:
+		if x != "" {
+			return []string{x}
+		}
+	case []any:
+		ids := make([]string, 0, len(x))
+		for _, item := range x {
+			if s, ok := item.(string); ok && s != "" {
+				ids = append(ids, s)
+			}
+		}
+		return ids
+	}
+	return nil
+}
+
+func filterPostsFromDirectAndGroup(mcpContext *MCPToolContext, posts []*model.Post) []*model.Post {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return posts
+	}
+	r := newChannelResolver(mcpContext)
+	out := make([]*model.Post, 0, len(posts))
+	for _, post := range posts {
+		if post == nil {
+			continue
+		}
+		ch, err := r.channel(post.ChannelId)
+		if err != nil || isDirectOrGroupChannel(ch) {
+			continue
+		}
+		out = append(out, post)
+	}
+	return out
+}
+
+func looksLikeChannelOrPostIdentifier(name string) bool {
+	if name == "scheduled_post_id" {
+		return false
+	}
+	switch name {
+	case "channel_name", "root_id", "thread_id", "file_id", "file_ids":
+		return true
+	}
+	return strings.Contains(name, "channel_id") || strings.Contains(name, "post_id")
+}

--- a/mcpserver/tools/dm_guard.go
+++ b/mcpserver/tools/dm_guard.go
@@ -16,9 +16,8 @@ import (
 var errDirectOrGroupInaccessible = fmt.Errorf("direct and group messages are not accessible to this agent")
 
 // errUnverifiedChannelReference is returned when a referenced ID cannot be
-// resolved to a channel. Rejecting keeps an unresolvable reference from
-// skipping the DM/GM check, and reports the real reason rather than implying
-// the target was a DM.
+// resolved to an open or private channel. Rejecting keeps an unresolvable or
+// unexpected reference from skipping the DM/GM check.
 var errUnverifiedChannelReference = fmt.Errorf("could not resolve the channel for a referenced ID; it may be invalid or inaccessible")
 
 type guardedArgKind int
@@ -31,6 +30,7 @@ const (
 
 // guardedArgKeys are argument names the ID guard resolves to a channel.
 // channel_ids / post_ids / file_ids share a kind with their singular forms.
+// Matching is case-insensitive because encoding/json is.
 var guardedArgKeys = map[string]guardedArgKind{
 	"channel_id":       guardedChannelID,
 	"channel_ids":      guardedChannelID,
@@ -43,30 +43,37 @@ var guardedArgKeys = map[string]guardedArgKind{
 	"file_ids":         guardedFileID,
 }
 
-// identifierArgsNotResolvedByGuard are schema property names that identify a
-// channel or post but are not Mattermost IDs. channel_name cannot look up a D/G
-// via GetChannelByName (those channels have no team); GetChannelsForTeamForUser
-// can still return DMs, so get_channel_info filters results instead.
-var identifierArgsNotResolvedByGuard = map[string]bool{
-	"channel_name": true,
+// guardedIfIDKeys are argument names that are a Mattermost ID only when the
+// value itself looks like one (e.g. search_posts "in" may be a name or an ID).
+var guardedIfIDKeys = map[string]guardedArgKind{
+	"in": guardedChannelID,
 }
 
 func isDirectOrGroupChannel(ch *model.Channel) bool {
 	return ch != nil && ch.IsGroupOrDirect()
 }
 
+// isVerifiedOpenOrPrivate is the allow-list for bot sessions: only explicitly
+// open or private channels pass. nil, D, G, boards, and unknown types do not.
+func isVerifiedOpenOrPrivate(ch *model.Channel) bool {
+	return ch != nil && (ch.Type == model.ChannelTypeOpen || ch.Type == model.ChannelTypePrivate)
+}
+
+func includeDirectChannels(mcpContext *MCPToolContext) bool {
+	return mcpContext == nil || !mcpContext.IsBotSession
+}
+
 func withoutDirectAndGroup(channels []*model.Channel) []*model.Channel {
 	out := make([]*model.Channel, 0, len(channels))
 	for _, ch := range channels {
-		if isDirectOrGroupChannel(ch) {
-			continue
+		if isVerifiedOpenOrPrivate(ch) {
+			out = append(out, ch)
 		}
-		out = append(out, ch)
 	}
 	return out
 }
 
-// channelResolver maps IDs to channels, memoized for one tool call.
+// channelResolver maps IDs to channels, memoized for one MCP tool call.
 type channelResolver struct {
 	mcpContext *MCPToolContext
 	byChannel  map[string]*model.Channel
@@ -81,6 +88,13 @@ func newChannelResolver(mcpContext *MCPToolContext) *channelResolver {
 		byPost:     make(map[string]*model.Channel),
 		byFile:     make(map[string]*model.Channel),
 	}
+}
+
+func (mcpContext *MCPToolContext) channelResolver() *channelResolver {
+	if mcpContext.resolver == nil {
+		mcpContext.resolver = newChannelResolver(mcpContext)
+	}
+	return mcpContext.resolver
 }
 
 func (r *channelResolver) channel(id string) (*model.Channel, error) {
@@ -119,15 +133,7 @@ func (r *channelResolver) channelByFile(fileID string) (*model.Channel, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ch *model.Channel
-	switch {
-	case info.ChannelId != "":
-		ch, err = r.channel(info.ChannelId)
-	case info.PostId != "":
-		ch, err = r.channelByPost(info.PostId)
-	default:
-		return nil, fmt.Errorf("file %s is not attached to a channel or post", fileID)
-	}
+	ch, err := r.channelForFileInfo(info)
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +141,33 @@ func (r *channelResolver) channelByFile(fileID string) (*model.Channel, error) {
 	return ch, nil
 }
 
+func (r *channelResolver) channelForFileInfo(info *model.FileInfo) (*model.Channel, error) {
+	if info == nil {
+		return nil, fmt.Errorf("file info is missing")
+	}
+	switch {
+	case info.ChannelId != "":
+		return r.channel(info.ChannelId)
+	case info.PostId != "":
+		return r.channelByPost(info.PostId)
+	default:
+		return nil, fmt.Errorf("file %s is not attached to a channel or post", info.Id)
+	}
+}
+
+func rejectIfNotOpenOrPrivate(ch *model.Channel) error {
+	if isVerifiedOpenOrPrivate(ch) {
+		return nil
+	}
+	if isDirectOrGroupChannel(ch) {
+		return errDirectOrGroupInaccessible
+	}
+	return errUnverifiedChannelReference
+}
+
 // rejectDirectOrGroupArgs scans tool arguments for channel/post/file IDs and
-// rejects the call when any resolve to a DM or GM. No-op for human sessions.
+// rejects the call when any do not resolve to an open or private channel.
+// No-op for human sessions.
 func rejectDirectOrGroupArgs(mcpContext *MCPToolContext, arguments any) error {
 	if mcpContext == nil || !mcpContext.IsBotSession {
 		return nil
@@ -145,13 +176,18 @@ func rejectDirectOrGroupArgs(mcpContext *MCPToolContext, arguments any) error {
 	if len(args) == 0 {
 		return nil
 	}
-	return scanGuardedArgs(args, newChannelResolver(mcpContext))
+	return scanGuardedArgs(args, mcpContext.channelResolver())
 }
 
 func scanGuardedArgs(args map[string]any, r *channelResolver) error {
 	for key, val := range args {
-		if kind, ok := guardedArgKeys[key]; ok {
+		lower := strings.ToLower(key)
+		if kind, ok := guardedArgKeys[lower]; ok {
 			if err := rejectResolvedIDs(kind, val, r); err != nil {
+				return err
+			}
+		} else if kind, ok := guardedIfIDKeys[lower]; ok {
+			if err := rejectResolvedIDsIfID(kind, val, r); err != nil {
 				return err
 			}
 		}
@@ -179,8 +215,24 @@ func rejectResolvedIDs(kind guardedArgKind, val any, r *channelResolver) error {
 		if err != nil {
 			return errUnverifiedChannelReference
 		}
-		if isDirectOrGroupChannel(ch) {
-			return errDirectOrGroupInaccessible
+		if err := rejectIfNotOpenOrPrivate(ch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectResolvedIDsIfID(kind guardedArgKind, val any, r *channelResolver) error {
+	for _, id := range stringIDs(val) {
+		if !model.IsValidId(id) {
+			continue
+		}
+		ch, err := resolveGuardedID(kind, id, r)
+		if err != nil {
+			return errUnverifiedChannelReference
+		}
+		if err := rejectIfNotOpenOrPrivate(ch); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -244,14 +296,14 @@ func filterPostsFromDirectAndGroup(mcpContext *MCPToolContext, posts []*model.Po
 	if mcpContext == nil || !mcpContext.IsBotSession {
 		return posts
 	}
-	r := newChannelResolver(mcpContext)
+	r := mcpContext.channelResolver()
 	out := make([]*model.Post, 0, len(posts))
 	for _, post := range posts {
 		if post == nil {
 			continue
 		}
 		ch, err := r.channel(post.ChannelId)
-		if err != nil || isDirectOrGroupChannel(ch) {
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
 			continue
 		}
 		out = append(out, post)
@@ -259,13 +311,120 @@ func filterPostsFromDirectAndGroup(mcpContext *MCPToolContext, posts []*model.Po
 	return out
 }
 
-func looksLikeChannelOrPostIdentifier(name string) bool {
-	if name == "scheduled_post_id" {
-		return false
+// visiblePostList drops posts that are not in an open or private channel for
+// bot sessions. Human sessions get the list unchanged.
+func visiblePostList(mcpContext *MCPToolContext, postList *model.PostList) *model.PostList {
+	if postList == nil || mcpContext == nil || !mcpContext.IsBotSession {
+		return postList
 	}
-	switch name {
-	case "channel_name", "root_id", "thread_id", "file_id", "file_ids":
-		return true
+	posts := make([]*model.Post, 0, len(postList.Posts))
+	for _, post := range postList.Posts {
+		posts = append(posts, post)
 	}
-	return strings.Contains(name, "channel_id") || strings.Contains(name, "post_id")
+	filtered := filterPostsFromDirectAndGroup(mcpContext, posts)
+	if len(filtered) == len(postList.Posts) {
+		return postList
+	}
+	out := &model.PostList{Posts: make(map[string]*model.Post, len(filtered))}
+	for _, post := range filtered {
+		if post != nil {
+			out.Posts[post.Id] = post
+		}
+	}
+	return out
+}
+
+func filterScheduledPosts(mcpContext *MCPToolContext, posts []*model.ScheduledPost) []*model.ScheduledPost {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return posts
+	}
+	r := mcpContext.channelResolver()
+	out := make([]*model.ScheduledPost, 0, len(posts))
+	for _, sp := range posts {
+		if sp == nil {
+			continue
+		}
+		ch, err := r.channel(sp.ChannelId)
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
+			continue
+		}
+		out = append(out, sp)
+	}
+	return out
+}
+
+func filterThreads(mcpContext *MCPToolContext, threads []*model.ThreadResponse) []*model.ThreadResponse {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return threads
+	}
+	r := mcpContext.channelResolver()
+	out := make([]*model.ThreadResponse, 0, len(threads))
+	for _, tr := range threads {
+		if tr == nil || tr.Post == nil {
+			continue
+		}
+		ch, err := r.channel(tr.Post.ChannelId)
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
+			continue
+		}
+		out = append(out, tr)
+	}
+	return out
+}
+
+func filterFileInfos(mcpContext *MCPToolContext, infos []*model.FileInfo) []*model.FileInfo {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return infos
+	}
+	r := mcpContext.channelResolver()
+	out := make([]*model.FileInfo, 0, len(infos))
+	for _, info := range infos {
+		ch, err := r.channelForFileInfo(info)
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
+			continue
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+func filterChannelMembers(mcpContext *MCPToolContext, members model.ChannelMembers) model.ChannelMembers {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return members
+	}
+	r := mcpContext.channelResolver()
+	out := make(model.ChannelMembers, 0, len(members))
+	for i := range members {
+		ch, err := r.channel(members[i].ChannelId)
+		if err != nil || !isVerifiedOpenOrPrivate(ch) {
+			continue
+		}
+		out = append(out, members[i])
+	}
+	return out
+}
+
+func filterSidebarCategories(mcpContext *MCPToolContext, categories []*model.SidebarCategoryWithChannels) []*model.SidebarCategoryWithChannels {
+	if mcpContext == nil || !mcpContext.IsBotSession {
+		return categories
+	}
+	r := mcpContext.channelResolver()
+	out := make([]*model.SidebarCategoryWithChannels, 0, len(categories))
+	for _, cat := range categories {
+		if cat == nil || cat.Type == model.SidebarCategoryDirectMessages {
+			continue
+		}
+		copied := *cat
+		visible := make([]string, 0, len(cat.Channels))
+		for _, id := range cat.Channels {
+			ch, err := r.channel(id)
+			if err != nil || !isVerifiedOpenOrPrivate(ch) {
+				continue
+			}
+			visible = append(visible, id)
+		}
+		copied.Channels = visible
+		out = append(out, &copied)
+	}
+	return out
 }

--- a/mcpserver/tools/dm_guard.go
+++ b/mcpserver/tools/dm_guard.go
@@ -46,21 +46,15 @@ var guardedArgKeys = map[string]guardedArgKind{
 // guardedIfIDKeys are argument names that are a Mattermost ID only when the
 // value itself looks like one (e.g. search_posts "in" may be a name or an ID).
 var guardedIfIDKeys = map[string]guardedArgKind{
-	"in": guardedChannelID,
-}
-
-func isDirectOrGroupChannel(ch *model.Channel) bool {
-	return ch != nil && ch.IsGroupOrDirect()
+	"in":     guardedChannelID,
+	"before": guardedPostID,
+	"after":  guardedPostID,
 }
 
 // isVerifiedOpenOrPrivate is the allow-list for bot sessions: only explicitly
 // open or private channels pass. nil, D, G, boards, and unknown types do not.
 func isVerifiedOpenOrPrivate(ch *model.Channel) bool {
 	return ch != nil && (ch.Type == model.ChannelTypeOpen || ch.Type == model.ChannelTypePrivate)
-}
-
-func includeDirectChannels(mcpContext *MCPToolContext) bool {
-	return mcpContext == nil || !mcpContext.IsBotSession
 }
 
 func withoutDirectAndGroup(channels []*model.Channel) []*model.Channel {
@@ -159,7 +153,7 @@ func rejectIfNotOpenOrPrivate(ch *model.Channel) error {
 	if isVerifiedOpenOrPrivate(ch) {
 		return nil
 	}
-	if isDirectOrGroupChannel(ch) {
+	if ch != nil && ch.IsGroupOrDirect() {
 		return errDirectOrGroupInaccessible
 	}
 	return errUnverifiedChannelReference
@@ -169,7 +163,7 @@ func rejectIfNotOpenOrPrivate(ch *model.Channel) error {
 // rejects the call when any do not resolve to an open or private channel.
 // No-op for human sessions.
 func rejectDirectOrGroupArgs(mcpContext *MCPToolContext, arguments any) error {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return nil
 	}
 	args := argumentsMap(arguments)
@@ -292,13 +286,15 @@ func stringIDs(v any) []string {
 	return nil
 }
 
-func filterPostsFromDirectAndGroup(mcpContext *MCPToolContext, posts []*model.Post) []*model.Post {
-	if mcpContext == nil || !mcpContext.IsBotSession {
-		return posts
+// visiblePostList drops posts that are not in an open or private channel for
+// bot sessions. Human sessions get the list unchanged.
+func visiblePostList(mcpContext *MCPToolContext, postList *model.PostList) *model.PostList {
+	if postList == nil || !mcpContext.IsBotSession {
+		return postList
 	}
 	r := mcpContext.channelResolver()
-	out := make([]*model.Post, 0, len(posts))
-	for _, post := range posts {
+	out := &model.PostList{Posts: make(map[string]*model.Post, len(postList.Posts))}
+	for id, post := range postList.Posts {
 		if post == nil {
 			continue
 		}
@@ -306,36 +302,17 @@ func filterPostsFromDirectAndGroup(mcpContext *MCPToolContext, posts []*model.Po
 		if err != nil || !isVerifiedOpenOrPrivate(ch) {
 			continue
 		}
-		out = append(out, post)
+		out.Posts[id] = post
+	}
+	if len(out.Posts) == len(postList.Posts) {
+		return postList
 	}
 	return out
 }
 
-// visiblePostList drops posts that are not in an open or private channel for
-// bot sessions. Human sessions get the list unchanged.
-func visiblePostList(mcpContext *MCPToolContext, postList *model.PostList) *model.PostList {
-	if postList == nil || mcpContext == nil || !mcpContext.IsBotSession {
-		return postList
-	}
-	posts := make([]*model.Post, 0, len(postList.Posts))
-	for _, post := range postList.Posts {
-		posts = append(posts, post)
-	}
-	filtered := filterPostsFromDirectAndGroup(mcpContext, posts)
-	if len(filtered) == len(postList.Posts) {
-		return postList
-	}
-	out := &model.PostList{Posts: make(map[string]*model.Post, len(filtered))}
-	for _, post := range filtered {
-		if post != nil {
-			out.Posts[post.Id] = post
-		}
-	}
-	return out
-}
-
+// Verifies results locally; a remote includeDirectChannels flag is not trusted.
 func filterScheduledPosts(mcpContext *MCPToolContext, posts []*model.ScheduledPost) []*model.ScheduledPost {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return posts
 	}
 	r := mcpContext.channelResolver()
@@ -353,8 +330,9 @@ func filterScheduledPosts(mcpContext *MCPToolContext, posts []*model.ScheduledPo
 	return out
 }
 
+// Verifies results locally; a remote ExcludeDirect flag is not trusted.
 func filterThreads(mcpContext *MCPToolContext, threads []*model.ThreadResponse) []*model.ThreadResponse {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return threads
 	}
 	r := mcpContext.channelResolver()
@@ -373,7 +351,7 @@ func filterThreads(mcpContext *MCPToolContext, threads []*model.ThreadResponse) 
 }
 
 func filterFileInfos(mcpContext *MCPToolContext, infos []*model.FileInfo) []*model.FileInfo {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return infos
 	}
 	r := mcpContext.channelResolver()
@@ -389,7 +367,7 @@ func filterFileInfos(mcpContext *MCPToolContext, infos []*model.FileInfo) []*mod
 }
 
 func filterChannelMembers(mcpContext *MCPToolContext, members model.ChannelMembers) model.ChannelMembers {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return members
 	}
 	r := mcpContext.channelResolver()
@@ -405,7 +383,7 @@ func filterChannelMembers(mcpContext *MCPToolContext, members model.ChannelMembe
 }
 
 func filterSidebarCategories(mcpContext *MCPToolContext, categories []*model.SidebarCategoryWithChannels) []*model.SidebarCategoryWithChannels {
-	if mcpContext == nil || !mcpContext.IsBotSession {
+	if !mcpContext.IsBotSession {
 		return categories
 	}
 	r := mcpContext.channelResolver()

--- a/mcpserver/tools/dm_guard_test.go
+++ b/mcpserver/tools/dm_guard_test.go
@@ -42,25 +42,6 @@ func TestIsVerifiedOpenOrPrivate(t *testing.T) {
 	}
 }
 
-func TestIsDirectOrGroupChannel(t *testing.T) {
-	tests := []struct {
-		name string
-		ch   *model.Channel
-		want bool
-	}{
-		{"nil", nil, false},
-		{"open", &model.Channel{Type: model.ChannelTypeOpen}, false},
-		{"private", &model.Channel{Type: model.ChannelTypePrivate}, false},
-		{"direct", &model.Channel{Type: model.ChannelTypeDirect}, true},
-		{"group", &model.Channel{Type: model.ChannelTypeGroup}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isDirectOrGroupChannel(tt.ch))
-		})
-	}
-}
-
 func TestWithoutDirectAndGroup(t *testing.T) {
 	open := &model.Channel{Id: "o", Type: model.ChannelTypeOpen, DisplayName: "Town Square"}
 	dm := &model.Channel{Id: "d", Type: model.ChannelTypeDirect}
@@ -130,9 +111,14 @@ func TestRejectDirectOrGroupArgs(t *testing.T) {
 		{"bot session with nested uppercase CHANNEL_ID is rejected", botCtx, map[string]any{"trigger": map[string]any{"CHANNEL_ID": dmID}}, errDirectOrGroupInaccessible},
 		{"bot session with in: DM channel ID is rejected", botCtx, map[string]any{"in": dmID}, errDirectOrGroupInaccessible},
 		{"bot session with in: channel name is not resolved as an ID", botCtx, map[string]any{"in": "town-square"}, nil},
+		{"bot session with before: DM post ID is rejected", botCtx, map[string]any{"before": dmPostID}, errDirectOrGroupInaccessible},
+		{"bot session with after: DM post ID is rejected", botCtx, map[string]any{"after": dmPostID}, errDirectOrGroupInaccessible},
+		{"bot session with before: open post ID is allowed", botCtx, map[string]any{"before": openPostID}, nil},
+		{"bot session with after: open post ID is allowed", botCtx, map[string]any{"after": openPostID}, nil},
+		{"bot session with before: date is not resolved as an ID", botCtx, map[string]any{"before": "2024-01-01"}, nil},
+		{"bot session with after: date is not resolved as an ID", botCtx, map[string]any{"after": "2024-01-31"}, nil},
 		{"bot session dm tool args (username) are not guarded", botCtx, map[string]any{"username": "alice", "message": "hi"}, nil},
 		{"bot session group_message args (usernames) are not guarded", botCtx, map[string]any{"usernames": []any{"alice", "bob"}, "message": "hi"}, nil},
-		{"nil context is a no-op", nil, map[string]any{"channel_id": dmID}, nil},
 		{"empty args are a no-op", botCtx, map[string]any{}, nil},
 	}
 
@@ -171,23 +157,41 @@ func TestCreateMCPToolContextIsBotSession(t *testing.T) {
 	human := &model.User{Id: model.NewId(), IsBot: false}
 	bot := &model.User{Id: model.NewId(), IsBot: true}
 
+	patAuth := func(t *testing.T, user *model.User) auth.AuthenticationProvider {
+		t.Helper()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v4/users/me" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(user)
+		}))
+		t.Cleanup(ts.Close)
+		return auth.NewTokenAuthenticationProvider(ts.URL, "", "pat-token", &testLogger{t: t})
+	}
+
 	tests := []struct {
 		name       string
-		auth       auth.AuthenticationProvider
+		auth       func(t *testing.T) auth.AuthenticationProvider
 		wantBot    bool
 		wantUserID string
 	}{
-		{"human user", identityAuthProvider{user: human}, false, human.Id},
-		{"bot user", identityAuthProvider{user: bot}, true, bot.Id},
-		{"lookup error fails closed", identityAuthProvider{err: fmt.Errorf("unavailable")}, true, ""},
-		{"nil user fails closed", identityAuthProvider{}, true, ""},
-		{"no identity provider fails closed", fakeToolAuthProvider{}, true, ""},
+		{"human user", func(*testing.T) auth.AuthenticationProvider { return identityAuthProvider{user: human} }, false, human.Id},
+		{"bot user", func(*testing.T) auth.AuthenticationProvider { return identityAuthProvider{user: bot} }, true, bot.Id},
+		{"lookup error fails closed", func(*testing.T) auth.AuthenticationProvider {
+			return identityAuthProvider{err: fmt.Errorf("unavailable")}
+		}, true, ""},
+		{"nil user fails closed", func(*testing.T) auth.AuthenticationProvider { return identityAuthProvider{} }, true, ""},
+		{"no identity provider fails closed", func(*testing.T) auth.AuthenticationProvider { return fakeToolAuthProvider{} }, true, ""},
+		{"human PAT session is not a bot session", func(t *testing.T) auth.AuthenticationProvider { return patAuth(t, human) }, false, human.Id},
+		{"bot PAT session is a bot session", func(t *testing.T) auth.AuthenticationProvider { return patAuth(t, bot) }, true, bot.Id},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &MattermostToolProvider{
-				authProvider: tt.auth,
+				authProvider: tt.auth(t),
 				logger:       &testLogger{t: t},
 				mmServerURL:  "https://mm.example.com",
 				accessMode:   AccessModeRemote,
@@ -198,81 +202,6 @@ func TestCreateMCPToolContextIsBotSession(t *testing.T) {
 			assert.Equal(t, tt.wantUserID, mcpCtx.UserID)
 		})
 	}
-}
-
-func TestExecuteSemanticSearchSetsExcludeDirectAndGroup(t *testing.T) {
-	tests := []struct {
-		name    string
-		exclude bool
-	}{
-		{"bot session", true},
-		{"human session", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			capturing := &capturingSearchService{}
-			provider := &MattermostToolProvider{
-				logger:        &testLogger{t: t},
-				searchService: capturing,
-			}
-			_, err := provider.executeSemanticSearch(t.Context(), newTestClient("https://mm.example.com"), CombinedSearchArgs{
-				Query:         "hello",
-				SemanticLimit: 10,
-			}, "user1", tt.exclude)
-			require.NoError(t, err)
-			assert.Equal(t, tt.exclude, capturing.lastOpts.ExcludeDirectAndGroup)
-		})
-	}
-}
-
-func TestExecuteKeywordSearchFiltersDirectAndGroup(t *testing.T) {
-	openID := model.NewId()
-	dmID := model.NewId()
-	openPost := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: model.NewId(), Message: "public", CreateAt: 2}
-	dmPost := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: model.NewId(), Message: "secret", CreateAt: 1}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v4/posts/search", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(&model.PostList{
-			Order: []string{openPost.Id, dmPost.Id},
-			Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost},
-		})
-	})
-	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(&model.Channel{Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"})
-	})
-	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect})
-	})
-	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", openPost.UserId), func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(&model.User{Id: openPost.UserId, Username: "alice"})
-	})
-	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", dmPost.UserId), func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(&model.User{Id: dmPost.UserId, Username: "bob"})
-	})
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-
-	provider := newTestProvider(t, ts.URL)
-	client := newTestClient(ts.URL)
-	args := CombinedSearchArgs{Query: "hello", KeywordLimit: 10}
-
-	t.Run("human session keeps DM posts", func(t *testing.T) {
-		got, err := provider.executeKeywordSearch(t.Context(), client, args, false)
-		require.NoError(t, err)
-		require.Len(t, got, 2)
-	})
-	t.Run("bot session drops DM posts", func(t *testing.T) {
-		got, err := provider.executeKeywordSearch(t.Context(), client, args, true)
-		require.NoError(t, err)
-		require.Len(t, got, 1)
-		assert.Equal(t, openPost.Id, got[0].Post.Id)
-	})
 }
 
 func TestToolGetUserChannelsFiltersDirectAndGroupForBot(t *testing.T) {
@@ -447,7 +376,7 @@ func TestEveryToolDeclaresDMandGMEnforcement(t *testing.T) {
 	for _, tool := range provider.mcpTools() {
 		registered[tool.Name] = true
 		if _, ok := classified[tool.Name]; !ok {
-			t.Errorf("tool %q is registered but missing from botSessionDMGMEnforcement; classify it as argument-guard, output-filter, argument-guard+output-filter, cannot-reach-dm-gm, or write-by-username", tool.Name)
+			t.Errorf("tool %q is registered but missing from botSessionDMGMEnforcement; classify it with a dmGMEnforcement constant (dmGMArgumentGuard, dmGMOutputFilter, dmGMArgumentGuardAndOutputFilter, dmGMCannotReach, or dmGMWriteByUsername)", tool.Name)
 		}
 	}
 	for name := range classified {
@@ -457,155 +386,167 @@ func TestEveryToolDeclaresDMandGMEnforcement(t *testing.T) {
 	}
 }
 
+// dmGMEnforcement is how a registered MCP tool is kept from returning DM/GM
+// data to a bot session. Invalid values fail to compile.
+type dmGMEnforcement int
+
+const (
+	dmGMArgumentGuard dmGMEnforcement = iota
+	dmGMOutputFilter
+	dmGMArgumentGuardAndOutputFilter
+	dmGMCannotReach
+	dmGMWriteByUsername
+)
+
 // botSessionDMGMEnforcement is the load-bearing inventory of how every MCP tool
 // is kept from returning DM/GM data to a bot session. A newly registered tool
 // must be added here or TestEveryToolDeclaresDMandGMEnforcement fails.
-func botSessionDMGMEnforcement() map[string]string {
-	return map[string]string{
+func botSessionDMGMEnforcement() map[string]dmGMEnforcement {
+	return map[string]dmGMEnforcement{
 		// posts
-		"read_post":           "argument-guard",
-		"create_post":         "argument-guard",
-		"dm":                  "write-by-username",
-		"group_message":       "write-by-username",
-		"get_post_info":       "argument-guard",
-		"list_pinned_posts":   "argument-guard",
-		"list_saved_posts":    "argument-guard+output-filter",
-		"update_post":         "argument-guard",
-		"delete_post":         "argument-guard",
-		"pin_post":            "argument-guard",
-		"unpin_post":          "argument-guard",
-		"save_post":           "argument-guard",
-		"acknowledge_post":    "argument-guard",
-		"create_post_as_user": "argument-guard",
+		"read_post":           dmGMArgumentGuard,
+		"create_post":         dmGMArgumentGuard,
+		"dm":                  dmGMWriteByUsername,
+		"group_message":       dmGMWriteByUsername,
+		"get_post_info":       dmGMArgumentGuard,
+		"list_pinned_posts":   dmGMArgumentGuard,
+		"list_saved_posts":    dmGMArgumentGuardAndOutputFilter,
+		"update_post":         dmGMArgumentGuard,
+		"delete_post":         dmGMArgumentGuard,
+		"pin_post":            dmGMArgumentGuard,
+		"unpin_post":          dmGMArgumentGuard,
+		"save_post":           dmGMArgumentGuard,
+		"acknowledge_post":    dmGMArgumentGuard,
+		"create_post_as_user": dmGMArgumentGuard,
 		// scheduled posts
-		"list_scheduled_posts":  "output-filter",
-		"create_scheduled_post": "argument-guard",
-		"update_scheduled_post": "argument-guard+output-filter",
-		"delete_scheduled_post": "output-filter",
-		"set_post_reminder":     "argument-guard",
+		"list_scheduled_posts":  dmGMOutputFilter,
+		"create_scheduled_post": dmGMArgumentGuard,
+		"update_scheduled_post": dmGMArgumentGuardAndOutputFilter,
+		"delete_scheduled_post": dmGMOutputFilter,
+		"set_post_reminder":     dmGMArgumentGuard,
 		// reactions
-		"get_post_reactions":  "argument-guard",
-		"get_bulk_reactions":  "argument-guard",
-		"list_custom_emoji":   "cannot-reach-dm-gm",
-		"search_custom_emoji": "cannot-reach-dm-gm",
-		"add_reaction":        "argument-guard",
-		"remove_reaction":     "argument-guard",
+		"get_post_reactions":  dmGMArgumentGuard,
+		"get_bulk_reactions":  dmGMArgumentGuard,
+		"list_custom_emoji":   dmGMCannotReach,
+		"search_custom_emoji": dmGMCannotReach,
+		"add_reaction":        dmGMArgumentGuard,
+		"remove_reaction":     dmGMArgumentGuard,
 		// threads / unreads
-		"get_threads":             "output-filter",
-		"get_mentions":            "output-filter",
-		"get_unread_counts":       "cannot-reach-dm-gm",
-		"get_channel_unread":      "argument-guard",
-		"get_posts_around_unread": "argument-guard",
-		"mark_channel_read":       "argument-guard",
-		"mark_channels_viewed":    "argument-guard",
-		"mark_post_unread":        "argument-guard",
-		"set_thread_follow":       "argument-guard",
+		"get_threads":             dmGMOutputFilter,
+		"get_mentions":            dmGMOutputFilter,
+		"get_unread_counts":       dmGMCannotReach,
+		"get_channel_unread":      dmGMArgumentGuard,
+		"get_posts_around_unread": dmGMArgumentGuard,
+		"mark_channel_read":       dmGMArgumentGuard,
+		"mark_channels_viewed":    dmGMArgumentGuard,
+		"mark_post_unread":        dmGMArgumentGuard,
+		"set_thread_follow":       dmGMArgumentGuard,
 		// channels
-		"read_channel":              "argument-guard",
-		"create_channel":            "cannot-reach-dm-gm",
-		"get_channel_info":          "argument-guard+output-filter",
-		"get_channel_members":       "argument-guard",
-		"add_channel_member":        "argument-guard",
-		"get_user_channels":         "output-filter",
-		"get_channel_stats":         "argument-guard",
-		"get_channel_member_counts": "argument-guard",
-		"search_channels":           "output-filter",
-		"list_team_channels":        "cannot-reach-dm-gm",
-		"list_archived_channels":    "cannot-reach-dm-gm",
-		"update_channel":            "argument-guard",
-		"archive_channel":           "argument-guard",
-		"restore_channel":           "argument-guard",
-		"convert_channel_privacy":   "argument-guard",
+		"read_channel":              dmGMArgumentGuard,
+		"create_channel":            dmGMCannotReach,
+		"get_channel_info":          dmGMArgumentGuardAndOutputFilter,
+		"get_channel_members":       dmGMArgumentGuard,
+		"add_channel_member":        dmGMArgumentGuard,
+		"get_user_channels":         dmGMOutputFilter,
+		"get_channel_stats":         dmGMArgumentGuard,
+		"get_channel_member_counts": dmGMArgumentGuard,
+		"search_channels":           dmGMOutputFilter,
+		"list_team_channels":        dmGMCannotReach,
+		"list_archived_channels":    dmGMCannotReach,
+		"update_channel":            dmGMArgumentGuard,
+		"archive_channel":           dmGMArgumentGuard,
+		"restore_channel":           dmGMArgumentGuard,
+		"convert_channel_privacy":   dmGMArgumentGuard,
 		// channel members
-		"get_channel_member":            "argument-guard",
-		"get_channel_members_by_ids":    "argument-guard",
-		"get_channel_members_by_status": "argument-guard",
-		"get_user_channel_memberships":  "output-filter",
-		"get_users_not_in_channel":      "argument-guard",
-		"search_users_in_channel":       "argument-guard",
-		"list_sidebar_categories":       "output-filter",
-		"add_channel_members":           "argument-guard",
-		"remove_channel_member":         "argument-guard",
-		"set_channel_mute":              "argument-guard",
-		"set_channel_favorite":          "argument-guard",
-		"update_channel_notify_props":   "argument-guard",
+		"get_channel_member":            dmGMArgumentGuard,
+		"get_channel_members_by_ids":    dmGMArgumentGuard,
+		"get_channel_members_by_status": dmGMArgumentGuard,
+		"get_user_channel_memberships":  dmGMOutputFilter,
+		"get_users_not_in_channel":      dmGMArgumentGuard,
+		"search_users_in_channel":       dmGMArgumentGuard,
+		"list_sidebar_categories":       dmGMOutputFilter,
+		"add_channel_members":           dmGMArgumentGuard,
+		"remove_channel_member":         dmGMArgumentGuard,
+		"set_channel_mute":              dmGMArgumentGuard,
+		"set_channel_favorite":          dmGMArgumentGuard,
+		"update_channel_notify_props":   dmGMArgumentGuard,
 		// bookmarks
-		"list_channel_bookmarks":  "argument-guard",
-		"create_channel_bookmark": "argument-guard",
-		"update_channel_bookmark": "argument-guard",
-		"delete_channel_bookmark": "argument-guard",
+		"list_channel_bookmarks":  dmGMArgumentGuard,
+		"create_channel_bookmark": dmGMArgumentGuard,
+		"update_channel_bookmark": dmGMArgumentGuard,
+		"delete_channel_bookmark": dmGMArgumentGuard,
 		// users
-		"get_me":                 "cannot-reach-dm-gm",
-		"get_user":               "cannot-reach-dm-gm",
-		"get_user_by_username":   "cannot-reach-dm-gm",
-		"get_user_by_email":      "cannot-reach-dm-gm",
-		"get_users_by_ids":       "cannot-reach-dm-gm",
-		"get_users_by_usernames": "cannot-reach-dm-gm",
-		"get_user_stats":         "cannot-reach-dm-gm",
-		"get_user_cpa_values":    "cannot-reach-dm-gm",
-		"list_cpa_fields":        "cannot-reach-dm-gm",
-		"update_user":            "cannot-reach-dm-gm",
-		"create_user":            "cannot-reach-dm-gm",
+		"get_me":                 dmGMCannotReach,
+		"get_user":               dmGMCannotReach,
+		"get_user_by_username":   dmGMCannotReach,
+		"get_user_by_email":      dmGMCannotReach,
+		"get_users_by_ids":       dmGMCannotReach,
+		"get_users_by_usernames": dmGMCannotReach,
+		"get_user_stats":         dmGMCannotReach,
+		"get_user_cpa_values":    dmGMCannotReach,
+		"list_cpa_fields":        dmGMCannotReach,
+		"update_user":            dmGMCannotReach,
+		"create_user":            dmGMCannotReach,
 		// status
-		"get_user_status":        "cannot-reach-dm-gm",
-		"get_users_statuses":     "cannot-reach-dm-gm",
-		"get_user_custom_status": "cannot-reach-dm-gm",
-		"set_status":             "cannot-reach-dm-gm",
-		"set_dnd":                "cannot-reach-dm-gm",
+		"get_user_status":        dmGMCannotReach,
+		"get_users_statuses":     dmGMCannotReach,
+		"get_user_custom_status": dmGMCannotReach,
+		"set_status":             dmGMCannotReach,
+		"set_dnd":                dmGMCannotReach,
 		// teams
-		"get_team_info":                     "cannot-reach-dm-gm",
-		"get_team_members":                  "cannot-reach-dm-gm",
-		"add_team_member":                   "cannot-reach-dm-gm",
-		"get_team_member":                   "cannot-reach-dm-gm",
-		"get_team_stats":                    "cannot-reach-dm-gm",
-		"get_user_teams":                    "cannot-reach-dm-gm",
-		"get_users_in_team":                 "cannot-reach-dm-gm",
-		"get_users_not_in_team":             "cannot-reach-dm-gm",
-		"get_new_users_in_team":             "cannot-reach-dm-gm",
-		"get_dm_common_teams":               "cannot-reach-dm-gm",
-		"search_teams":                      "cannot-reach-dm-gm",
-		"search_users_in_team":              "cannot-reach-dm-gm",
-		"add_team_members":                  "cannot-reach-dm-gm",
-		"remove_team_member":                "cannot-reach-dm-gm",
-		"update_team":                       "cannot-reach-dm-gm",
-		"invite_users_to_team":              "cannot-reach-dm-gm",
-		"invite_users_to_team_and_channels": "argument-guard",
-		"create_team":                       "cannot-reach-dm-gm",
+		"get_team_info":                     dmGMCannotReach,
+		"get_team_members":                  dmGMCannotReach,
+		"add_team_member":                   dmGMCannotReach,
+		"get_team_member":                   dmGMCannotReach,
+		"get_team_stats":                    dmGMCannotReach,
+		"get_user_teams":                    dmGMCannotReach,
+		"get_users_in_team":                 dmGMCannotReach,
+		"get_users_not_in_team":             dmGMCannotReach,
+		"get_new_users_in_team":             dmGMCannotReach,
+		"get_dm_common_teams":               dmGMArgumentGuard,
+		"search_teams":                      dmGMCannotReach,
+		"search_users_in_team":              dmGMCannotReach,
+		"add_team_members":                  dmGMCannotReach,
+		"remove_team_member":                dmGMCannotReach,
+		"update_team":                       dmGMCannotReach,
+		"invite_users_to_team":              dmGMCannotReach,
+		"invite_users_to_team_and_channels": dmGMArgumentGuard,
+		"create_team":                       dmGMCannotReach,
 		// search
-		"search_posts": "argument-guard+output-filter",
-		"search_users": "cannot-reach-dm-gm",
+		"search_posts": dmGMArgumentGuardAndOutputFilter,
+		"search_users": dmGMCannotReach,
 		// files
-		"read_file":      "argument-guard",
-		"get_file_info":  "argument-guard",
-		"get_post_files": "argument-guard",
-		"get_file_link":  "argument-guard",
-		"search_files":   "output-filter",
-		"upload_file":    "argument-guard",
+		"read_file":      dmGMArgumentGuard,
+		"get_file_info":  dmGMArgumentGuard,
+		"get_post_files": dmGMArgumentGuard,
+		"get_file_link":  dmGMArgumentGuard,
+		"search_files":   dmGMOutputFilter,
+		"upload_file":    dmGMArgumentGuard,
 		// integrations
-		"get_bot":                "cannot-reach-dm-gm",
-		"list_bots":              "cannot-reach-dm-gm",
-		"list_incoming_webhooks": "cannot-reach-dm-gm",
-		"list_outgoing_webhooks": "argument-guard",
+		"get_bot":                dmGMCannotReach,
+		"list_bots":              dmGMCannotReach,
+		"list_incoming_webhooks": dmGMCannotReach,
+		"list_outgoing_webhooks": dmGMCannotReach,
 		// groups
-		"get_group_info":              "cannot-reach-dm-gm",
-		"list_groups":                 "cannot-reach-dm-gm",
-		"get_user_groups":             "cannot-reach-dm-gm",
-		"get_channel_groups":          "argument-guard",
-		"get_team_groups":             "cannot-reach-dm-gm",
-		"get_users_in_group_channels": "argument-guard",
+		"get_group_info":              dmGMCannotReach,
+		"list_groups":                 dmGMCannotReach,
+		"get_user_groups":             dmGMCannotReach,
+		"get_channel_groups":          dmGMArgumentGuard,
+		"get_team_groups":             dmGMCannotReach,
+		"get_users_in_group_channels": dmGMArgumentGuard,
 		// roles
-		"get_role":                    "cannot-reach-dm-gm",
-		"get_channel_moderations":     "argument-guard",
-		"update_channel_member_roles": "argument-guard",
-		"update_team_member_roles":    "cannot-reach-dm-gm",
+		"get_role":                    dmGMCannotReach,
+		"get_channel_moderations":     dmGMArgumentGuard,
+		"update_channel_member_roles": dmGMArgumentGuard,
+		"update_team_member_roles":    dmGMCannotReach,
 		// agents
-		"list_agents": "cannot-reach-dm-gm",
+		"list_agents": dmGMCannotReach,
 		// automations
-		"list_automations":            "argument-guard+output-filter",
-		"get_automation_instructions": "cannot-reach-dm-gm",
-		"create_automation":           "argument-guard",
-		"update_automation":           "argument-guard+output-filter",
-		"delete_automation":           "output-filter",
+		"list_automations":            dmGMArgumentGuardAndOutputFilter,
+		"get_automation_instructions": dmGMCannotReach,
+		"create_automation":           dmGMArgumentGuard,
+		"update_automation":           dmGMArgumentGuardAndOutputFilter,
+		"delete_automation":           dmGMOutputFilter,
 	}
 }
 
@@ -653,6 +594,7 @@ func TestExecuteSemanticSearchFiltersDirectAndGroup(t *testing.T) {
 		got, err := provider.executeSemanticSearch(t.Context(), client, args, "user1", false)
 		require.NoError(t, err)
 		require.Len(t, got, 3)
+		assert.False(t, svc.lastOpts.ExcludeDirectAndGroup)
 	})
 	t.Run("bot session drops DM and unverified hits", func(t *testing.T) {
 		got, err := provider.executeSemanticSearch(t.Context(), client, args, "user1", true)
@@ -925,6 +867,69 @@ func TestToolListSidebarCategoriesFiltersDirectAndGroupForBot(t *testing.T) {
 		assert.NotContains(t, out, dmID)
 		assert.NotContains(t, out, "Direct Messages")
 	})
+}
+
+func TestToolListSavedPostsRequiresScopeForBot(t *testing.T) {
+	userID := model.NewId()
+	teamID := model.NewId()
+	channelID := model.NewId()
+	openPost := &model.Post{Id: model.NewId(), ChannelId: channelID, UserId: userID, Message: "saved in town square", CreateAt: 1}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/posts/flagged", userID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.PostList{
+			Order: []string{openPost.Id},
+			Posts: map[string]*model.Post{openPost.Id: openPost},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", channelID), serveJSON(&model.Channel{Id: channelID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc("/api/v4/users/ids", serveJSON([]*model.User{{Id: userID, Username: "alice"}}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	tests := []struct {
+		name         string
+		ctx          *MCPToolContext
+		args         ListSavedPostsArgs
+		wantErr      string
+		wantContains string
+	}{
+		{
+			name:    "bot session without scope is rejected",
+			ctx:     &MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID, IsBotSession: true},
+			args:    ListSavedPostsArgs{},
+			wantErr: "team_id or channel_id is required",
+		},
+		{
+			name:         "bot session with team_id succeeds",
+			ctx:          &MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID, IsBotSession: true},
+			args:         ListSavedPostsArgs{TeamID: teamID},
+			wantContains: "saved in town square",
+		},
+		{
+			name:         "human session without scope succeeds",
+			ctx:          &MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID},
+			args:         ListSavedPostsArgs{},
+			wantContains: "saved in town square",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := provider.toolListSavedPosts(tt.ctx, tt.args)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, out, tt.wantContains)
+		})
+	}
 }
 
 func TestToolSearchFilesFiltersDirectAndGroupForBot(t *testing.T) {

--- a/mcpserver/tools/dm_guard_test.go
+++ b/mcpserver/tools/dm_guard_test.go
@@ -387,7 +387,8 @@ func TestEveryToolDeclaresDMandGMEnforcement(t *testing.T) {
 }
 
 // dmGMEnforcement is how a registered MCP tool is kept from returning DM/GM
-// data to a bot session. Invalid values fail to compile.
+// data to a bot session. A named constant is required, so an ad-hoc string
+// classification does not compile.
 type dmGMEnforcement int
 
 const (
@@ -398,9 +399,9 @@ const (
 	dmGMWriteByUsername
 )
 
-// botSessionDMGMEnforcement is the load-bearing inventory of how every MCP tool
-// is kept from returning DM/GM data to a bot session. A newly registered tool
-// must be added here or TestEveryToolDeclaresDMandGMEnforcement fails.
+// botSessionDMGMEnforcement inventories how every MCP tool is kept from
+// returning DM/GM data to a bot session. A newly registered tool must be added
+// here or TestEveryToolDeclaresDMandGMEnforcement fails.
 func botSessionDMGMEnforcement() map[string]dmGMEnforcement {
 	return map[string]dmGMEnforcement{
 		// posts

--- a/mcpserver/tools/dm_guard_test.go
+++ b/mcpserver/tools/dm_guard_test.go
@@ -16,9 +16,31 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcpserver/auth"
 	"github.com/mattermost/mattermost-plugin-agents/v2/search"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsVerifiedOpenOrPrivate(t *testing.T) {
+	tests := []struct {
+		name string
+		ch   *model.Channel
+		want bool
+	}{
+		{"nil", nil, false},
+		{"open", &model.Channel{Type: model.ChannelTypeOpen}, true},
+		{"private", &model.Channel{Type: model.ChannelTypePrivate}, true},
+		{"direct", &model.Channel{Type: model.ChannelTypeDirect}, false},
+		{"group", &model.Channel{Type: model.ChannelTypeGroup}, false},
+		{"empty type", &model.Channel{Type: ""}, false},
+		{"board", &model.Channel{Type: model.ChannelTypeOpenBoard}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isVerifiedOpenOrPrivate(tt.ch))
+		})
+	}
+}
 
 func TestIsDirectOrGroupChannel(t *testing.T) {
 	tests := []struct {
@@ -44,8 +66,9 @@ func TestWithoutDirectAndGroup(t *testing.T) {
 	dm := &model.Channel{Id: "d", Type: model.ChannelTypeDirect}
 	gm := &model.Channel{Id: "g", Type: model.ChannelTypeGroup}
 	priv := &model.Channel{Id: "p", Type: model.ChannelTypePrivate, DisplayName: "Secret"}
+	unknown := &model.Channel{Id: "x", Type: ""}
 
-	got := withoutDirectAndGroup([]*model.Channel{open, dm, gm, priv})
+	got := withoutDirectAndGroup([]*model.Channel{open, dm, gm, priv, unknown, nil})
 	require.Len(t, got, 2)
 	assert.Equal(t, "o", got[0].Id)
 	assert.Equal(t, "p", got[1].Id)
@@ -55,15 +78,17 @@ func TestRejectDirectOrGroupArgs(t *testing.T) {
 	openID := model.NewId()
 	dmID := model.NewId()
 	gmID := model.NewId()
+	unknownID := model.NewId()
 	openPostID := model.NewId()
 	dmPostID := model.NewId()
 	openFileID := model.NewId()
 	dmFileID := model.NewId()
 
 	channels := map[string]*model.Channel{
-		openID: {Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"},
-		dmID:   {Id: dmID, Type: model.ChannelTypeDirect},
-		gmID:   {Id: gmID, Type: model.ChannelTypeGroup},
+		openID:    {Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"},
+		dmID:      {Id: dmID, Type: model.ChannelTypeDirect},
+		gmID:      {Id: gmID, Type: model.ChannelTypeGroup},
+		unknownID: {Id: unknownID, Type: ""},
 	}
 	posts := map[string]*model.Post{
 		openPostID: {Id: openPostID, ChannelId: openID},
@@ -99,6 +124,12 @@ func TestRejectDirectOrGroupArgs(t *testing.T) {
 		{"bot session with open file_id is allowed", botCtx, map[string]any{"file_id": openFileID}, nil},
 		{"bot session with nested DM channel_id is rejected", botCtx, map[string]any{"trigger": map[string]any{"channel_id": dmID}}, errDirectOrGroupInaccessible},
 		{"bot session with unresolvable channel_id is rejected", botCtx, map[string]any{"channel_id": model.NewId()}, errUnverifiedChannelReference},
+		{"bot session with unknown channel type is rejected", botCtx, map[string]any{"channel_id": unknownID}, errUnverifiedChannelReference},
+		{"bot session with uppercase CHANNEL_ID DM is rejected", botCtx, map[string]any{"CHANNEL_ID": dmID}, errDirectOrGroupInaccessible},
+		{"bot session with mixed-case Channel_Id DM is rejected", botCtx, map[string]any{"Channel_Id": dmID}, errDirectOrGroupInaccessible},
+		{"bot session with nested uppercase CHANNEL_ID is rejected", botCtx, map[string]any{"trigger": map[string]any{"CHANNEL_ID": dmID}}, errDirectOrGroupInaccessible},
+		{"bot session with in: DM channel ID is rejected", botCtx, map[string]any{"in": dmID}, errDirectOrGroupInaccessible},
+		{"bot session with in: channel name is not resolved as an ID", botCtx, map[string]any{"in": "town-square"}, nil},
 		{"bot session dm tool args (username) are not guarded", botCtx, map[string]any{"username": "alice", "message": "hi"}, nil},
 		{"bot session group_message args (usernames) are not guarded", botCtx, map[string]any{"usernames": []any{"alice", "bob"}, "message": "hi"}, nil},
 		{"nil context is a no-op", nil, map[string]any{"channel_id": dmID}, nil},
@@ -312,12 +343,14 @@ func TestToolSearchChannelsFiltersDirectAndGroupForBot(t *testing.T) {
 	})
 }
 
-func TestFormatPostListChronoFiltersDirectAndGroupForBot(t *testing.T) {
+func TestVisiblePostListFiltersDirectAndGroupForBot(t *testing.T) {
 	openID := model.NewId()
 	dmID := model.NewId()
+	unknownID := model.NewId()
 	authorID := model.NewId()
 	openPost := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: authorID, Message: "public mention", CreateAt: 2}
 	dmPost := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: authorID, Message: "private mention", CreateAt: 1}
+	unknownPost := &model.Post{Id: model.NewId(), ChannelId: unknownID, UserId: authorID, Message: "unclassified", CreateAt: 3}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), func(w http.ResponseWriter, _ *http.Request) {
@@ -328,6 +361,10 @@ func TestFormatPostListChronoFiltersDirectAndGroupForBot(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect})
 	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", unknownID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: unknownID, Type: ""})
+	})
 	mux.HandleFunc("/api/v4/users/ids", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]*model.User{{Id: authorID, Username: "alice"}})
@@ -337,19 +374,26 @@ func TestFormatPostListChronoFiltersDirectAndGroupForBot(t *testing.T) {
 
 	provider := newTestProvider(t, ts.URL)
 	postList := &model.PostList{
-		Order: []string{openPost.Id, dmPost.Id},
-		Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost},
+		Order: []string{openPost.Id, dmPost.Id, unknownPost.Id},
+		Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost, unknownPost.Id: unknownPost},
 	}
 
 	t.Run("human session keeps DM posts", func(t *testing.T) {
-		out := provider.formatPostListChrono(&MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context()}, postList, "posts mentioning you")
+		mcpCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context()}
+		out := provider.formatPostListChrono(mcpCtx, visiblePostList(mcpCtx, postList), "posts mentioning you")
 		assert.Contains(t, out, "public mention")
 		assert.Contains(t, out, "private mention")
 	})
-	t.Run("bot session drops DM posts", func(t *testing.T) {
-		out := provider.formatPostListChrono(&MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}, postList, "posts mentioning you")
+	t.Run("bot session drops DM and unverified posts at the call site", func(t *testing.T) {
+		mcpCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}
+		out := provider.formatPostListChrono(mcpCtx, visiblePostList(mcpCtx, postList), "posts mentioning you")
 		assert.Contains(t, out, "public mention")
 		assert.NotContains(t, out, "private mention")
+		assert.NotContains(t, out, "unclassified")
+	})
+	t.Run("formatter itself does not drop DM posts", func(t *testing.T) {
+		out := provider.formatPostListChrono(&MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}, postList, "posts mentioning you")
+		assert.Contains(t, out, "private mention")
 	})
 }
 
@@ -391,36 +435,178 @@ func TestToolGetChannelInfoFiltersDirectAndGroupForBotByName(t *testing.T) {
 	assert.NotContains(t, out, dm.Id)
 }
 
-func TestToolSchemasGuardKnownIdentifiers(t *testing.T) {
+func TestEveryToolDeclaresDMandGMEnforcement(t *testing.T) {
 	provider := &MattermostToolProvider{
 		logger:     &testLogger{t: t},
 		accessMode: AccessModeRemote,
 		devMode:    true,
 	}
 
-	known := map[string]bool{}
-	for name := range guardedArgKeys {
-		known[name] = true
-	}
-	for name := range identifierArgsNotResolvedByGuard {
-		known[name] = true
-	}
-
+	classified := botSessionDMGMEnforcement()
+	registered := map[string]bool{}
 	for _, tool := range provider.mcpTools() {
-		for _, name := range schemaPropertyNames(tool.Schema) {
-			if !looksLikeChannelOrPostIdentifier(name) {
-				continue
-			}
-			if known[name] {
-				continue
-			}
-			t.Errorf("tool %q has property %q which looks like a channel or post identifier but is not handled by the DM/GM guard. Add it to guardedArgKeys in dm_guard.go (resolved via GetChannel, GetPost, or GetFileInfo), or to identifierArgsNotResolvedByGuard if it cannot reach a D/G channel — and document why.", tool.Name, name)
+		registered[tool.Name] = true
+		if _, ok := classified[tool.Name]; !ok {
+			t.Errorf("tool %q is registered but missing from botSessionDMGMEnforcement; classify it as argument-guard, output-filter, argument-guard+output-filter, cannot-reach-dm-gm, or write-by-username", tool.Name)
 		}
 	}
+	for name := range classified {
+		if !registered[name] {
+			t.Errorf("botSessionDMGMEnforcement has %q but that tool is not registered; remove the stale classification", name)
+		}
+	}
+}
 
-	assert.True(t, identifierArgsNotResolvedByGuard["channel_name"], "channel_name must stay in the known-identifier set")
-	_, guarded := guardedArgKeys["channel_name"]
-	assert.False(t, guarded, "channel_name is not an ID; get_channel_info filters D/G results instead of resolving the name")
+// botSessionDMGMEnforcement is the load-bearing inventory of how every MCP tool
+// is kept from returning DM/GM data to a bot session. A newly registered tool
+// must be added here or TestEveryToolDeclaresDMandGMEnforcement fails.
+func botSessionDMGMEnforcement() map[string]string {
+	return map[string]string{
+		// posts
+		"read_post":           "argument-guard",
+		"create_post":         "argument-guard",
+		"dm":                  "write-by-username",
+		"group_message":       "write-by-username",
+		"get_post_info":       "argument-guard",
+		"list_pinned_posts":   "argument-guard",
+		"list_saved_posts":    "argument-guard+output-filter",
+		"update_post":         "argument-guard",
+		"delete_post":         "argument-guard",
+		"pin_post":            "argument-guard",
+		"unpin_post":          "argument-guard",
+		"save_post":           "argument-guard",
+		"acknowledge_post":    "argument-guard",
+		"create_post_as_user": "argument-guard",
+		// scheduled posts
+		"list_scheduled_posts":  "output-filter",
+		"create_scheduled_post": "argument-guard",
+		"update_scheduled_post": "argument-guard+output-filter",
+		"delete_scheduled_post": "output-filter",
+		"set_post_reminder":     "argument-guard",
+		// reactions
+		"get_post_reactions":  "argument-guard",
+		"get_bulk_reactions":  "argument-guard",
+		"list_custom_emoji":   "cannot-reach-dm-gm",
+		"search_custom_emoji": "cannot-reach-dm-gm",
+		"add_reaction":        "argument-guard",
+		"remove_reaction":     "argument-guard",
+		// threads / unreads
+		"get_threads":             "output-filter",
+		"get_mentions":            "output-filter",
+		"get_unread_counts":       "cannot-reach-dm-gm",
+		"get_channel_unread":      "argument-guard",
+		"get_posts_around_unread": "argument-guard",
+		"mark_channel_read":       "argument-guard",
+		"mark_channels_viewed":    "argument-guard",
+		"mark_post_unread":        "argument-guard",
+		"set_thread_follow":       "argument-guard",
+		// channels
+		"read_channel":              "argument-guard",
+		"create_channel":            "cannot-reach-dm-gm",
+		"get_channel_info":          "argument-guard+output-filter",
+		"get_channel_members":       "argument-guard",
+		"add_channel_member":        "argument-guard",
+		"get_user_channels":         "output-filter",
+		"get_channel_stats":         "argument-guard",
+		"get_channel_member_counts": "argument-guard",
+		"search_channels":           "output-filter",
+		"list_team_channels":        "cannot-reach-dm-gm",
+		"list_archived_channels":    "cannot-reach-dm-gm",
+		"update_channel":            "argument-guard",
+		"archive_channel":           "argument-guard",
+		"restore_channel":           "argument-guard",
+		"convert_channel_privacy":   "argument-guard",
+		// channel members
+		"get_channel_member":            "argument-guard",
+		"get_channel_members_by_ids":    "argument-guard",
+		"get_channel_members_by_status": "argument-guard",
+		"get_user_channel_memberships":  "output-filter",
+		"get_users_not_in_channel":      "argument-guard",
+		"search_users_in_channel":       "argument-guard",
+		"list_sidebar_categories":       "output-filter",
+		"add_channel_members":           "argument-guard",
+		"remove_channel_member":         "argument-guard",
+		"set_channel_mute":              "argument-guard",
+		"set_channel_favorite":          "argument-guard",
+		"update_channel_notify_props":   "argument-guard",
+		// bookmarks
+		"list_channel_bookmarks":  "argument-guard",
+		"create_channel_bookmark": "argument-guard",
+		"update_channel_bookmark": "argument-guard",
+		"delete_channel_bookmark": "argument-guard",
+		// users
+		"get_me":                 "cannot-reach-dm-gm",
+		"get_user":               "cannot-reach-dm-gm",
+		"get_user_by_username":   "cannot-reach-dm-gm",
+		"get_user_by_email":      "cannot-reach-dm-gm",
+		"get_users_by_ids":       "cannot-reach-dm-gm",
+		"get_users_by_usernames": "cannot-reach-dm-gm",
+		"get_user_stats":         "cannot-reach-dm-gm",
+		"get_user_cpa_values":    "cannot-reach-dm-gm",
+		"list_cpa_fields":        "cannot-reach-dm-gm",
+		"update_user":            "cannot-reach-dm-gm",
+		"create_user":            "cannot-reach-dm-gm",
+		// status
+		"get_user_status":        "cannot-reach-dm-gm",
+		"get_users_statuses":     "cannot-reach-dm-gm",
+		"get_user_custom_status": "cannot-reach-dm-gm",
+		"set_status":             "cannot-reach-dm-gm",
+		"set_dnd":                "cannot-reach-dm-gm",
+		// teams
+		"get_team_info":                     "cannot-reach-dm-gm",
+		"get_team_members":                  "cannot-reach-dm-gm",
+		"add_team_member":                   "cannot-reach-dm-gm",
+		"get_team_member":                   "cannot-reach-dm-gm",
+		"get_team_stats":                    "cannot-reach-dm-gm",
+		"get_user_teams":                    "cannot-reach-dm-gm",
+		"get_users_in_team":                 "cannot-reach-dm-gm",
+		"get_users_not_in_team":             "cannot-reach-dm-gm",
+		"get_new_users_in_team":             "cannot-reach-dm-gm",
+		"get_dm_common_teams":               "cannot-reach-dm-gm",
+		"search_teams":                      "cannot-reach-dm-gm",
+		"search_users_in_team":              "cannot-reach-dm-gm",
+		"add_team_members":                  "cannot-reach-dm-gm",
+		"remove_team_member":                "cannot-reach-dm-gm",
+		"update_team":                       "cannot-reach-dm-gm",
+		"invite_users_to_team":              "cannot-reach-dm-gm",
+		"invite_users_to_team_and_channels": "argument-guard",
+		"create_team":                       "cannot-reach-dm-gm",
+		// search
+		"search_posts": "argument-guard+output-filter",
+		"search_users": "cannot-reach-dm-gm",
+		// files
+		"read_file":      "argument-guard",
+		"get_file_info":  "argument-guard",
+		"get_post_files": "argument-guard",
+		"get_file_link":  "argument-guard",
+		"search_files":   "output-filter",
+		"upload_file":    "argument-guard",
+		// integrations
+		"get_bot":                "cannot-reach-dm-gm",
+		"list_bots":              "cannot-reach-dm-gm",
+		"list_incoming_webhooks": "cannot-reach-dm-gm",
+		"list_outgoing_webhooks": "argument-guard",
+		// groups
+		"get_group_info":              "cannot-reach-dm-gm",
+		"list_groups":                 "cannot-reach-dm-gm",
+		"get_user_groups":             "cannot-reach-dm-gm",
+		"get_channel_groups":          "argument-guard",
+		"get_team_groups":             "cannot-reach-dm-gm",
+		"get_users_in_group_channels": "argument-guard",
+		// roles
+		"get_role":                    "cannot-reach-dm-gm",
+		"get_channel_moderations":     "argument-guard",
+		"update_channel_member_roles": "argument-guard",
+		"update_team_member_roles":    "cannot-reach-dm-gm",
+		// agents
+		"list_agents": "cannot-reach-dm-gm",
+		// automations
+		"list_automations":            "argument-guard+output-filter",
+		"get_automation_instructions": "cannot-reach-dm-gm",
+		"create_automation":           "argument-guard",
+		"update_automation":           "argument-guard+output-filter",
+		"delete_automation":           "output-filter",
+	}
 }
 
 func TestDMAndGroupMessageSchemasHaveNoGuardedKeys(t *testing.T) {
@@ -439,6 +625,345 @@ func TestDMAndGroupMessageSchemasHaveNoGuardedKeys(t *testing.T) {
 	}
 }
 
+func TestExecuteSemanticSearchFiltersDirectAndGroup(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+	unknownID := model.NewId()
+	openPost := model.NewId()
+	dmPost := model.NewId()
+	unknownPost := model.NewId()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", unknownID), serveJSON(&model.Channel{Id: unknownID, Type: ""}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	svc := &capturingSearchService{results: []search.RAGResult{
+		{PostID: openPost, ChannelID: openID, ChannelName: "Town Square", Content: "public", Score: 0.9},
+		{PostID: dmPost, ChannelID: dmID, ChannelName: "Direct Message", Content: "secret", Score: 0.8},
+		{PostID: unknownPost, ChannelID: unknownID, ChannelName: "??", Content: "unverified", Score: 0.7},
+	}}
+	provider := &MattermostToolProvider{logger: &testLogger{t: t}, searchService: svc}
+	client := newTestClient(ts.URL)
+	args := CombinedSearchArgs{Query: "hello", SemanticLimit: 10}
+
+	t.Run("human session keeps DM hits", func(t *testing.T) {
+		got, err := provider.executeSemanticSearch(t.Context(), client, args, "user1", false)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+	})
+	t.Run("bot session drops DM and unverified hits", func(t *testing.T) {
+		got, err := provider.executeSemanticSearch(t.Context(), client, args, "user1", true)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, openPost, got[0].Post.Id)
+		assert.True(t, svc.lastOpts.ExcludeDirectAndGroup)
+	})
+}
+
+func TestExecuteKeywordSearchPaginatesAfterFiltering(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+	openPost := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: model.NewId(), Message: "public", CreateAt: 1}
+	dmPost := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: model.NewId(), Message: "secret", CreateAt: 3}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/posts/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.PostList{
+			Order: []string{dmPost.Id, openPost.Id},
+			Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", openPost.UserId), serveJSON(&model.User{Id: openPost.UserId, Username: "alice"}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", dmPost.UserId), serveJSON(&model.User{Id: dmPost.UserId, Username: "bob"}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("bot session limit applies to visible posts", func(t *testing.T) {
+		got, err := provider.executeKeywordSearch(t.Context(), client, CombinedSearchArgs{Query: "hello", KeywordLimit: 1}, true)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, openPost.Id, got[0].Post.Id)
+	})
+	t.Run("human session limit can select a DM post", func(t *testing.T) {
+		got, err := provider.executeKeywordSearch(t.Context(), client, CombinedSearchArgs{Query: "hello", KeywordLimit: 1}, false)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, dmPost.Id, got[0].Post.Id)
+	})
+}
+
+func TestRegisterDynamicToolEnforcesBotDMGuard(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s/stats", openID), serveJSON(&model.ChannelStats{ChannelId: openID, MemberCount: 3}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s/stats", dmID), serveJSON(&model.ChannelStats{ChannelId: dmID, MemberCount: 2}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newTestClient(ts.URL)
+	human := &model.User{Id: model.NewId(), IsBot: false}
+	bot := &model.User{Id: model.NewId(), IsBot: true}
+
+	tests := []struct {
+		name      string
+		user      *model.User
+		args      map[string]any
+		wantError bool
+		wantText  string
+	}{
+		{"bot session with DM channel_id is rejected by the handler", bot, map[string]any{"channel_id": dmID}, true, errDirectOrGroupInaccessible.Error()},
+		{"bot session with uppercase CHANNEL_ID DM is rejected by the handler", bot, map[string]any{"CHANNEL_ID": dmID}, true, errDirectOrGroupInaccessible.Error()},
+		{"bot session with open channel_id reaches the resolver", bot, map[string]any{"channel_id": openID}, false, openID},
+		{"human session with DM channel_id reaches the resolver", human, map[string]any{"channel_id": dmID}, false, dmID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &MattermostToolProvider{
+				authProvider: sessionAuthProvider{client: client, user: tt.user},
+				logger:       &testLogger{t: t},
+				accessMode:   AccessModeRemote,
+			}
+			result, err := callRegisteredMCPTool(t, provider, "get_channel_stats", tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			text := mcpToolText(result)
+			if tt.wantError {
+				assert.True(t, result.IsError)
+				assert.Contains(t, text, tt.wantText)
+				return
+			}
+			assert.False(t, result.IsError)
+			assert.Contains(t, text, tt.wantText)
+		})
+	}
+}
+
+func TestToolGetThreadsFiltersDirectAndGroupForBot(t *testing.T) {
+	teamID := model.NewId()
+	userID := model.NewId()
+	openID := model.NewId()
+	dmID := model.NewId()
+	authorID := model.NewId()
+	openRoot := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: authorID, Message: "public thread"}
+	dmRoot := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: authorID, Message: "secret thread"}
+
+	var gotExcludeDirect string
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/teams/%s/threads", userID, teamID), func(w http.ResponseWriter, r *http.Request) {
+		gotExcludeDirect = r.URL.Query().Get("excludeDirect")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Threads{
+			Total:   2,
+			Threads: []*model.ThreadResponse{{PostId: openRoot.Id, Post: openRoot}, {PostId: dmRoot.Id, Post: dmRoot}},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", authorID), serveJSON(&model.User{Id: authorID, Username: "alice"}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DM threads", func(t *testing.T) {
+		gotExcludeDirect = ""
+		out, err := provider.toolGetThreads(&MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID}, GetThreadsArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public thread")
+		assert.Contains(t, out, "secret thread")
+		assert.NotEqual(t, "true", gotExcludeDirect)
+	})
+	t.Run("bot session omits DM threads", func(t *testing.T) {
+		gotExcludeDirect = ""
+		out, err := provider.toolGetThreads(&MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID, IsBotSession: true}, GetThreadsArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public thread")
+		assert.NotContains(t, out, "secret thread")
+		assert.Equal(t, "true", gotExcludeDirect)
+	})
+}
+
+func TestToolListScheduledPostsFiltersDirectAndGroupForBot(t *testing.T) {
+	teamID := model.NewId()
+	openID := model.NewId()
+	dmID := model.NewId()
+	openSP := &model.ScheduledPost{Draft: model.Draft{ChannelId: openID, Message: "public later"}}
+	openSP.Id = model.NewId()
+	dmSP := &model.ScheduledPost{Draft: model.Draft{ChannelId: dmID, Message: "secret later"}}
+	dmSP.Id = model.NewId()
+
+	var includeDirect string
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/posts/scheduled/team/%s", teamID), func(w http.ResponseWriter, r *http.Request) {
+		includeDirect = r.URL.Query().Get("includeDirectChannels")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string][]*model.ScheduledPost{openID: {openSP}, "directChannels": {dmSP}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DM scheduled posts", func(t *testing.T) {
+		includeDirect = ""
+		out, err := provider.toolListScheduledPosts(&MCPToolContext{Client: client, Ctx: t.Context()}, ListScheduledPostsArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public later")
+		assert.Contains(t, out, "secret later")
+		assert.Equal(t, "true", includeDirect)
+	})
+	t.Run("bot session omits DM scheduled posts", func(t *testing.T) {
+		includeDirect = ""
+		out, err := provider.toolListScheduledPosts(&MCPToolContext{Client: client, Ctx: t.Context(), IsBotSession: true}, ListScheduledPostsArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public later")
+		assert.NotContains(t, out, "secret later")
+		assert.Equal(t, "false", includeDirect)
+	})
+}
+
+func TestToolDeleteScheduledPostRejectsDMForBot(t *testing.T) {
+	userID := model.NewId()
+	teamID := model.NewId()
+	openID := model.NewId()
+	dmID := model.NewId()
+	openSPID := model.NewId()
+	dmSPID := model.NewId()
+	openSP := &model.ScheduledPost{Draft: model.Draft{ChannelId: openID, Message: "public later"}}
+	openSP.Id = openSPID
+	deleted := ""
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/teams", userID), serveJSON([]*model.Team{{Id: teamID}}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/posts/scheduled/team/%s", teamID), serveJSON(map[string][]*model.ScheduledPost{openID: {openSP}}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/posts/schedule/%s", openSPID), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.NotFound(w, r)
+			return
+		}
+		deleted = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.ScheduledPost{})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	botCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), UserID: userID, IsBotSession: true}
+
+	t.Run("bot cannot delete a DM scheduled post", func(t *testing.T) {
+		deleted = ""
+		_, err := provider.toolDeleteScheduledPost(botCtx, DeleteScheduledPostArgs{ScheduledPostID: dmSPID})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errDirectOrGroupInaccessible)
+		assert.Empty(t, deleted)
+	})
+	t.Run("bot can delete an open-channel scheduled post", func(t *testing.T) {
+		deleted = ""
+		out, err := provider.toolDeleteScheduledPost(botCtx, DeleteScheduledPostArgs{ScheduledPostID: openSPID})
+		require.NoError(t, err)
+		assert.Contains(t, out, openSPID)
+		assert.Contains(t, deleted, openSPID)
+	})
+}
+
+func TestToolListSidebarCategoriesFiltersDirectAndGroupForBot(t *testing.T) {
+	teamID := model.NewId()
+	userID := model.NewId()
+	openID := model.NewId()
+	dmID := model.NewId()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/teams/%s/channels/categories", userID, teamID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.OrderedSidebarCategories{
+			Categories: []*model.SidebarCategoryWithChannels{
+				{SidebarCategory: model.SidebarCategory{Id: "fav", DisplayName: "Favorites", Type: model.SidebarCategoryFavorites}, Channels: []string{openID, dmID}},
+				{SidebarCategory: model.SidebarCategory{Id: "dms", DisplayName: "Direct Messages", Type: model.SidebarCategoryDirectMessages}, Channels: []string{dmID}},
+			},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DM channel IDs", func(t *testing.T) {
+		out, err := provider.toolListSidebarCategories(&MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID}, ListSidebarCategoriesArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, openID)
+		assert.Contains(t, out, dmID)
+		assert.Contains(t, out, "Direct Messages")
+	})
+	t.Run("bot session omits DM channel IDs and the DM category", func(t *testing.T) {
+		out, err := provider.toolListSidebarCategories(&MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID, IsBotSession: true}, ListSidebarCategoriesArgs{TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, openID)
+		assert.NotContains(t, out, dmID)
+		assert.NotContains(t, out, "Direct Messages")
+	})
+}
+
+func TestToolSearchFilesFiltersDirectAndGroupForBot(t *testing.T) {
+	teamID := model.NewId()
+	openID := model.NewId()
+	dmID := model.NewId()
+	openFile := &model.FileInfo{Id: model.NewId(), Name: "public.pdf", Size: 10, ChannelId: openID}
+	dmFile := &model.FileInfo{Id: model.NewId(), Name: "secret.pdf", Size: 20, ChannelId: dmID}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/teams/%s/files/search", teamID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.FileInfoList{
+			Order:     []string{openFile.Id, dmFile.Id},
+			FileInfos: map[string]*model.FileInfo{openFile.Id: openFile, dmFile.Id: dmFile},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), serveJSON(&model.Channel{Id: openID, Type: model.ChannelTypeOpen}))
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), serveJSON(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DM files", func(t *testing.T) {
+		out, err := provider.toolSearchFiles(&MCPToolContext{Client: client, Ctx: t.Context()}, SearchFilesArgs{Terms: "pdf", TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public.pdf")
+		assert.Contains(t, out, "secret.pdf")
+	})
+	t.Run("bot session omits DM files", func(t *testing.T) {
+		out, err := provider.toolSearchFiles(&MCPToolContext{Client: client, Ctx: t.Context(), IsBotSession: true}, SearchFilesArgs{Terms: "pdf", TeamID: teamID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "public.pdf")
+		assert.NotContains(t, out, "secret.pdf")
+	})
+}
+
 type identityAuthProvider struct {
 	fakeToolAuthProvider
 	user *model.User
@@ -451,13 +976,70 @@ func (p identityAuthProvider) GetAuthenticatedUser(context.Context) (*model.User
 
 type capturingSearchService struct {
 	lastOpts search.Options
+	results  []search.RAGResult
 }
 
 func (c *capturingSearchService) Enabled() bool { return true }
 
 func (c *capturingSearchService) Search(_ context.Context, _ string, opts search.Options) ([]search.RAGResult, error) {
 	c.lastOpts = opts
-	return nil, nil
+	return c.results, nil
+}
+
+type sessionAuthProvider struct {
+	client *model.Client4
+	user   *model.User
+}
+
+func (p sessionAuthProvider) ValidateAuth(context.Context) error { return nil }
+
+func (p sessionAuthProvider) GetAuthenticatedMattermostClient(context.Context) (*model.Client4, error) {
+	return p.client, nil
+}
+
+func (p sessionAuthProvider) GetAuthenticatedUser(context.Context) (*model.User, error) {
+	return p.user, nil
+}
+
+func callRegisteredMCPTool(t *testing.T, provider *MattermostToolProvider, name string, args map[string]any) (*mcp.CallToolResult, error) {
+	t.Helper()
+	var tool MCPTool
+	for _, candidate := range provider.mcpTools() {
+		if candidate.Name == name {
+			tool = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, tool.Name, "tool %s is not registered", name)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	provider.registerDynamicTool(server, tool)
+
+	ctx := t.Context()
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+
+	return session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+}
+
+func mcpToolText(result *mcp.CallToolResult) string {
+	if result == nil {
+		return ""
+	}
+	var text string
+	for _, content := range result.Content {
+		if tc, ok := content.(*mcp.TextContent); ok {
+			text += tc.Text
+		}
+	}
+	return text
 }
 
 func newIDLookupServer(t *testing.T, channels map[string]*model.Channel, posts map[string]*model.Post, files map[string]*model.FileInfo) *httptest.Server {

--- a/mcpserver/tools/dm_guard_test.go
+++ b/mcpserver/tools/dm_guard_test.go
@@ -1,0 +1,515 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/mattermost/mattermost-plugin-agents/v2/mcpserver/auth"
+	"github.com/mattermost/mattermost-plugin-agents/v2/search"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDirectOrGroupChannel(t *testing.T) {
+	tests := []struct {
+		name string
+		ch   *model.Channel
+		want bool
+	}{
+		{"nil", nil, false},
+		{"open", &model.Channel{Type: model.ChannelTypeOpen}, false},
+		{"private", &model.Channel{Type: model.ChannelTypePrivate}, false},
+		{"direct", &model.Channel{Type: model.ChannelTypeDirect}, true},
+		{"group", &model.Channel{Type: model.ChannelTypeGroup}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDirectOrGroupChannel(tt.ch))
+		})
+	}
+}
+
+func TestWithoutDirectAndGroup(t *testing.T) {
+	open := &model.Channel{Id: "o", Type: model.ChannelTypeOpen, DisplayName: "Town Square"}
+	dm := &model.Channel{Id: "d", Type: model.ChannelTypeDirect}
+	gm := &model.Channel{Id: "g", Type: model.ChannelTypeGroup}
+	priv := &model.Channel{Id: "p", Type: model.ChannelTypePrivate, DisplayName: "Secret"}
+
+	got := withoutDirectAndGroup([]*model.Channel{open, dm, gm, priv})
+	require.Len(t, got, 2)
+	assert.Equal(t, "o", got[0].Id)
+	assert.Equal(t, "p", got[1].Id)
+}
+
+func TestRejectDirectOrGroupArgs(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+	gmID := model.NewId()
+	openPostID := model.NewId()
+	dmPostID := model.NewId()
+	openFileID := model.NewId()
+	dmFileID := model.NewId()
+
+	channels := map[string]*model.Channel{
+		openID: {Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"},
+		dmID:   {Id: dmID, Type: model.ChannelTypeDirect},
+		gmID:   {Id: gmID, Type: model.ChannelTypeGroup},
+	}
+	posts := map[string]*model.Post{
+		openPostID: {Id: openPostID, ChannelId: openID},
+		dmPostID:   {Id: dmPostID, ChannelId: dmID},
+	}
+	files := map[string]*model.FileInfo{
+		openFileID: {Id: openFileID, ChannelId: openID},
+		dmFileID:   {Id: dmFileID, ChannelId: dmID},
+	}
+
+	ts := newIDLookupServer(t, channels, posts, files)
+	defer ts.Close()
+
+	botCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}
+	humanCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: false}
+
+	tests := []struct {
+		name    string
+		ctx     *MCPToolContext
+		args    any
+		wantErr error
+	}{
+		{"human session with DM channel_id is allowed", humanCtx, map[string]any{"channel_id": dmID}, nil},
+		{"bot session with open channel_id is allowed", botCtx, map[string]any{"channel_id": openID}, nil},
+		{"bot session with DM channel_id is rejected", botCtx, map[string]any{"channel_id": dmID}, errDirectOrGroupInaccessible},
+		{"bot session with GM channel_id is rejected", botCtx, map[string]any{"channel_id": gmID}, errDirectOrGroupInaccessible},
+		{"bot session with mixed channel_ids is rejected", botCtx, map[string]any{"channel_ids": []any{openID, dmID}}, errDirectOrGroupInaccessible},
+		{"bot session with open post_id is allowed", botCtx, map[string]any{"post_id": openPostID}, nil},
+		{"bot session with DM post_id is rejected", botCtx, map[string]any{"post_id": dmPostID}, errDirectOrGroupInaccessible},
+		{"bot session with DM root_id is rejected", botCtx, map[string]any{"root_id": dmPostID}, errDirectOrGroupInaccessible},
+		{"bot session with DM thread_id is rejected", botCtx, map[string]any{"thread_id": dmPostID}, errDirectOrGroupInaccessible},
+		{"bot session with DM file_id is rejected", botCtx, map[string]any{"file_id": dmFileID}, errDirectOrGroupInaccessible},
+		{"bot session with open file_id is allowed", botCtx, map[string]any{"file_id": openFileID}, nil},
+		{"bot session with nested DM channel_id is rejected", botCtx, map[string]any{"trigger": map[string]any{"channel_id": dmID}}, errDirectOrGroupInaccessible},
+		{"bot session with unresolvable channel_id is rejected", botCtx, map[string]any{"channel_id": model.NewId()}, errUnverifiedChannelReference},
+		{"bot session dm tool args (username) are not guarded", botCtx, map[string]any{"username": "alice", "message": "hi"}, nil},
+		{"bot session group_message args (usernames) are not guarded", botCtx, map[string]any{"usernames": []any{"alice", "bob"}, "message": "hi"}, nil},
+		{"nil context is a no-op", nil, map[string]any{"channel_id": dmID}, nil},
+		{"empty args are a no-op", botCtx, map[string]any{}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectDirectOrGroupArgs(tt.ctx, tt.args)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRejectDirectOrGroupArgsMemoizesChannelLookups(t *testing.T) {
+	channelID := model.NewId()
+	var gets atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", channelID), func(w http.ResponseWriter, _ *http.Request) {
+		gets.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: channelID, Type: model.ChannelTypeOpen})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mcpCtx := &MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}
+	err := rejectDirectOrGroupArgs(mcpCtx, map[string]any{"channel_ids": []any{channelID, channelID}})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), gets.Load(), "repeated channel IDs in one call must share one lookup")
+}
+
+func TestCreateMCPToolContextIsBotSession(t *testing.T) {
+	human := &model.User{Id: model.NewId(), IsBot: false}
+	bot := &model.User{Id: model.NewId(), IsBot: true}
+
+	tests := []struct {
+		name       string
+		auth       auth.AuthenticationProvider
+		wantBot    bool
+		wantUserID string
+	}{
+		{"human user", identityAuthProvider{user: human}, false, human.Id},
+		{"bot user", identityAuthProvider{user: bot}, true, bot.Id},
+		{"lookup error fails closed", identityAuthProvider{err: fmt.Errorf("unavailable")}, true, ""},
+		{"nil user fails closed", identityAuthProvider{}, true, ""},
+		{"no identity provider fails closed", fakeToolAuthProvider{}, true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &MattermostToolProvider{
+				authProvider: tt.auth,
+				logger:       &testLogger{t: t},
+				mmServerURL:  "https://mm.example.com",
+				accessMode:   AccessModeRemote,
+			}
+			mcpCtx, err := provider.createMCPToolContext(t.Context(), nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBot, mcpCtx.IsBotSession)
+			assert.Equal(t, tt.wantUserID, mcpCtx.UserID)
+		})
+	}
+}
+
+func TestExecuteSemanticSearchSetsExcludeDirectAndGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		exclude bool
+	}{
+		{"bot session", true},
+		{"human session", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturing := &capturingSearchService{}
+			provider := &MattermostToolProvider{
+				logger:        &testLogger{t: t},
+				searchService: capturing,
+			}
+			_, err := provider.executeSemanticSearch(t.Context(), newTestClient("https://mm.example.com"), CombinedSearchArgs{
+				Query:         "hello",
+				SemanticLimit: 10,
+			}, "user1", tt.exclude)
+			require.NoError(t, err)
+			assert.Equal(t, tt.exclude, capturing.lastOpts.ExcludeDirectAndGroup)
+		})
+	}
+}
+
+func TestExecuteKeywordSearchFiltersDirectAndGroup(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+	openPost := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: model.NewId(), Message: "public", CreateAt: 2}
+	dmPost := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: model.NewId(), Message: "secret", CreateAt: 1}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/posts/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.PostList{
+			Order: []string{openPost.Id, dmPost.Id},
+			Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost},
+		})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: openID, Type: model.ChannelTypeOpen, DisplayName: "Town Square"})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", openPost.UserId), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.User{Id: openPost.UserId, Username: "alice"})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s", dmPost.UserId), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.User{Id: dmPost.UserId, Username: "bob"})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+	args := CombinedSearchArgs{Query: "hello", KeywordLimit: 10}
+
+	t.Run("human session keeps DM posts", func(t *testing.T) {
+		got, err := provider.executeKeywordSearch(t.Context(), client, args, false)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	})
+	t.Run("bot session drops DM posts", func(t *testing.T) {
+		got, err := provider.executeKeywordSearch(t.Context(), client, args, true)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, openPost.Id, got[0].Post.Id)
+	})
+}
+
+func TestToolGetUserChannelsFiltersDirectAndGroupForBot(t *testing.T) {
+	userID := model.NewId()
+	teamID := model.NewId()
+	open := &model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen, DisplayName: "Town Square", TeamId: teamID}
+	dm := &model.Channel{Id: model.NewId(), Type: model.ChannelTypeDirect}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/users/me", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.User{Id: userID, Username: "bot"})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/channels", userID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*model.Channel{open, dm})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/teams", userID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*model.Team{{Id: teamID, DisplayName: "Engineering"}})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DMs", func(t *testing.T) {
+		out, err := provider.toolGetUserChannels(&MCPToolContext{Client: client, Ctx: t.Context()}, GetUserChannelsArgs{})
+		require.NoError(t, err)
+		assert.Contains(t, out, open.Id)
+		assert.Contains(t, out, dm.Id)
+	})
+	t.Run("bot session omits DMs", func(t *testing.T) {
+		out, err := provider.toolGetUserChannels(&MCPToolContext{Client: client, Ctx: t.Context(), IsBotSession: true}, GetUserChannelsArgs{})
+		require.NoError(t, err)
+		assert.Contains(t, out, open.Id)
+		assert.NotContains(t, out, dm.Id)
+	})
+}
+
+func TestToolSearchChannelsFiltersDirectAndGroupForBot(t *testing.T) {
+	open := &model.ChannelWithTeamData{Channel: model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen, DisplayName: "Town Square"}}
+	dm := &model.ChannelWithTeamData{Channel: model.Channel{Id: model.NewId(), Type: model.ChannelTypeDirect, DisplayName: "Direct Message"}}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/channels/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*model.ChannelWithTeamData{open, dm})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	client := newTestClient(ts.URL)
+
+	t.Run("human session includes DMs", func(t *testing.T) {
+		out, err := provider.toolSearchChannels(&MCPToolContext{Client: client, Ctx: t.Context()}, SearchChannelsArgs{Term: "town"})
+		require.NoError(t, err)
+		assert.Contains(t, out, open.Id)
+		assert.Contains(t, out, dm.Id)
+	})
+	t.Run("bot session omits DMs", func(t *testing.T) {
+		out, err := provider.toolSearchChannels(&MCPToolContext{Client: client, Ctx: t.Context(), IsBotSession: true}, SearchChannelsArgs{Term: "town"})
+		require.NoError(t, err)
+		assert.Contains(t, out, open.Id)
+		assert.NotContains(t, out, dm.Id)
+	})
+}
+
+func TestFormatPostListChronoFiltersDirectAndGroupForBot(t *testing.T) {
+	openID := model.NewId()
+	dmID := model.NewId()
+	authorID := model.NewId()
+	openPost := &model.Post{Id: model.NewId(), ChannelId: openID, UserId: authorID, Message: "public mention", CreateAt: 2}
+	dmPost := &model.Post{Id: model.NewId(), ChannelId: dmID, UserId: authorID, Message: "private mention", CreateAt: 1}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", openID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: openID, Type: model.ChannelTypeOpen})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", dmID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: dmID, Type: model.ChannelTypeDirect})
+	})
+	mux.HandleFunc("/api/v4/users/ids", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*model.User{{Id: authorID, Username: "alice"}})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	postList := &model.PostList{
+		Order: []string{openPost.Id, dmPost.Id},
+		Posts: map[string]*model.Post{openPost.Id: openPost, dmPost.Id: dmPost},
+	}
+
+	t.Run("human session keeps DM posts", func(t *testing.T) {
+		out := provider.formatPostListChrono(&MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context()}, postList, "posts mentioning you")
+		assert.Contains(t, out, "public mention")
+		assert.Contains(t, out, "private mention")
+	})
+	t.Run("bot session drops DM posts", func(t *testing.T) {
+		out := provider.formatPostListChrono(&MCPToolContext{Client: newTestClient(ts.URL), Ctx: t.Context(), IsBotSession: true}, postList, "posts mentioning you")
+		assert.Contains(t, out, "public mention")
+		assert.NotContains(t, out, "private mention")
+	})
+}
+
+func TestToolGetChannelInfoFiltersDirectAndGroupForBotByName(t *testing.T) {
+	userID := model.NewId()
+	teamID := model.NewId()
+	open := &model.ChannelWithTeamData{Channel: model.Channel{Id: model.NewId(), Name: "town-square", DisplayName: "Town Square", Type: model.ChannelTypeOpen, TeamId: teamID}}
+	dm := &model.ChannelWithTeamData{Channel: model.Channel{Id: model.NewId(), Name: "alice__bot", DisplayName: "Town Square", Type: model.ChannelTypeDirect}}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/channels/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*model.ChannelWithTeamData{open, dm})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/teams/%s", teamID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Team{Id: teamID, DisplayName: "Engineering"})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s/stats", open.Id), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.ChannelStats{ChannelId: open.Id, MemberCount: 3})
+	})
+	mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s/members/%s", open.Id, userID), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.ChannelMember{ChannelId: open.Id, UserId: userID, SchemeUser: true})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := newTestProvider(t, ts.URL)
+	out, err := provider.toolGetChannelInfo(&MCPToolContext{
+		Client:       newTestClient(ts.URL),
+		Ctx:          t.Context(),
+		UserID:       userID,
+		IsBotSession: true,
+	}, GetChannelInfoArgs{ChannelName: "Town Square"})
+	require.NoError(t, err)
+	assert.Contains(t, out, open.Id)
+	assert.NotContains(t, out, dm.Id)
+}
+
+func TestToolSchemasGuardKnownIdentifiers(t *testing.T) {
+	provider := &MattermostToolProvider{
+		logger:     &testLogger{t: t},
+		accessMode: AccessModeRemote,
+		devMode:    true,
+	}
+
+	known := map[string]bool{}
+	for name := range guardedArgKeys {
+		known[name] = true
+	}
+	for name := range identifierArgsNotResolvedByGuard {
+		known[name] = true
+	}
+
+	for _, tool := range provider.mcpTools() {
+		for _, name := range schemaPropertyNames(tool.Schema) {
+			if !looksLikeChannelOrPostIdentifier(name) {
+				continue
+			}
+			if known[name] {
+				continue
+			}
+			t.Errorf("tool %q has property %q which looks like a channel or post identifier but is not handled by the DM/GM guard. Add it to guardedArgKeys in dm_guard.go (resolved via GetChannel, GetPost, or GetFileInfo), or to identifierArgsNotResolvedByGuard if it cannot reach a D/G channel — and document why.", tool.Name, name)
+		}
+	}
+
+	assert.True(t, identifierArgsNotResolvedByGuard["channel_name"], "channel_name must stay in the known-identifier set")
+	_, guarded := guardedArgKeys["channel_name"]
+	assert.False(t, guarded, "channel_name is not an ID; get_channel_info filters D/G results instead of resolving the name")
+}
+
+func TestDMAndGroupMessageSchemasHaveNoGuardedKeys(t *testing.T) {
+	provider := &MattermostToolProvider{
+		logger:     &testLogger{t: t},
+		accessMode: AccessModeRemote,
+	}
+	for _, tool := range provider.getPostTools() {
+		if tool.Name != "dm" && tool.Name != "group_message" {
+			continue
+		}
+		for _, name := range schemaPropertyNames(tool.Schema) {
+			_, guarded := guardedArgKeys[name]
+			assert.False(t, guarded, "%s schema must not take a guarded channel/post ID (%q); it addresses users by username so the bot can still send DMs/GMs", tool.Name, name)
+		}
+	}
+}
+
+type identityAuthProvider struct {
+	fakeToolAuthProvider
+	user *model.User
+	err  error
+}
+
+func (p identityAuthProvider) GetAuthenticatedUser(context.Context) (*model.User, error) {
+	return p.user, p.err
+}
+
+type capturingSearchService struct {
+	lastOpts search.Options
+}
+
+func (c *capturingSearchService) Enabled() bool { return true }
+
+func (c *capturingSearchService) Search(_ context.Context, _ string, opts search.Options) ([]search.RAGResult, error) {
+	c.lastOpts = opts
+	return nil, nil
+}
+
+func newIDLookupServer(t *testing.T, channels map[string]*model.Channel, posts map[string]*model.Post, files map[string]*model.FileInfo) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for id, ch := range channels {
+		mux.HandleFunc(fmt.Sprintf("/api/v4/channels/%s", id), serveJSON(ch))
+	}
+	for id, post := range posts {
+		mux.HandleFunc(fmt.Sprintf("/api/v4/posts/%s", id), serveJSON(post))
+	}
+	for id, info := range files {
+		mux.HandleFunc(fmt.Sprintf("/api/v4/files/%s/info", id), serveJSON(info))
+	}
+	return httptest.NewServer(mux)
+}
+
+func serveJSON(v any) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+}
+
+func schemaPropertyNames(schema *jsonschema.Schema) []string {
+	seen := map[*jsonschema.Schema]bool{}
+	names := map[string]struct{}{}
+	collectSchemaPropertyNames(schema, seen, names)
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	return out
+}
+
+func collectSchemaPropertyNames(schema *jsonschema.Schema, seen map[*jsonschema.Schema]bool, names map[string]struct{}) {
+	if schema == nil || seen[schema] {
+		return
+	}
+	seen[schema] = true
+	for name, prop := range schema.Properties {
+		names[name] = struct{}{}
+		collectSchemaPropertyNames(prop, seen, names)
+	}
+	for _, prop := range schema.Defs {
+		collectSchemaPropertyNames(prop, seen, names)
+	}
+	for _, prop := range schema.Definitions {
+		collectSchemaPropertyNames(prop, seen, names)
+	}
+	collectSchemaPropertyNames(schema.Items, seen, names)
+	for _, s := range schema.PrefixItems {
+		collectSchemaPropertyNames(s, seen, names)
+	}
+}

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/files"
 	"github.com/mattermost/mattermost-plugin-agents/v2/format"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // FileContentService reads the text contents of Mattermost file attachments on
@@ -219,13 +220,22 @@ func (p *MattermostToolProvider) toolSearchFiles(mcpContext *MCPToolContext, arg
 		return fmt.Sprintf("no files found for %q", args.Terms), nil
 	}
 
-	var result strings.Builder
-	result.WriteString(fmt.Sprintf("Found %d file(s) for %q:\n\n", len(results.Order), args.Terms))
-	for i, id := range results.Order {
+	infos := make([]*model.FileInfo, 0, len(results.Order))
+	for _, id := range results.Order {
 		info := results.FileInfos[id]
 		if info == nil {
 			continue
 		}
+		infos = append(infos, info)
+	}
+	infos = filterFileInfos(mcpContext, infos)
+	if len(infos) == 0 {
+		return fmt.Sprintf("no files found for %q", args.Terms), nil
+	}
+
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("Found %d file(s) for %q:\n\n", len(infos), args.Terms))
+	for i, info := range infos {
 		format.WriteFileDescriptor(&result, format.FileDescriptorEntry{Number: i + 1, FileInfo: info})
 	}
 	return result.String(), nil

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -813,6 +813,10 @@ func (p *MattermostToolProvider) formatPostListChrono(mcpContext *MCPToolContext
 	for _, post := range postList.Posts {
 		posts = append(posts, post)
 	}
+	posts = filterPostsFromDirectAndGroup(mcpContext, posts)
+	if len(posts) == 0 {
+		return fmt.Sprintf("no %s found", noun)
+	}
 	sort.Slice(posts, func(i, j int) bool {
 		return posts[i].CreateAt < posts[j].CreateAt
 	})

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -610,7 +610,7 @@ type AcknowledgePostArgs struct {
 const (
 	getPostInfoDescription     = "Get metadata and channel/team context for a single post (without the thread). Parameters: post_id (required). Use read_post to get the full thread content. Returns channel, team, type, and your membership."
 	listPinnedPostsDescription = "List the pinned posts in a channel. Parameters: channel_id (required). Returns each pinned post's author, content, and timestamp."
-	listSavedPostsDescription  = "List your saved (flagged) posts, optionally scoped to a channel or team. Parameters: channel_id (optional), team_id (optional), page, per_page. Returns matching saved posts."
+	listSavedPostsDescription  = "List your saved (flagged) posts, optionally scoped to a channel or team. Parameters: channel_id (optional), team_id (optional; agent sessions must provide one of these), page, per_page. Returns matching saved posts."
 	updatePostDescription      = "Edit the message text of an existing post. Parameters: post_id (required), message (required). Returns the updated post."
 	deletePostDescription      = "Delete (soft-remove) a post by ID. Parameters: post_id (required). This cannot be undone by the agent."
 	pinPostDescription         = "Pin a post to its channel. Parameters: post_id (required)."
@@ -646,7 +646,7 @@ func (p *MattermostToolProvider) toolListPinnedPosts(mcpContext *MCPToolContext,
 		return "", fmt.Errorf("error fetching pinned posts: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "pinned posts"), nil
+	return p.formatPostListChrono(mcpContext, postList, "pinned posts"), nil
 }
 
 // toolListSavedPosts implements the list_saved_posts tool.
@@ -665,6 +665,9 @@ func (p *MattermostToolProvider) toolListSavedPosts(mcpContext *MCPToolContext, 
 	}
 	if args.Page < 0 {
 		args.Page = 0
+	}
+	if mcpContext.IsBotSession && args.ChannelID == "" && args.TeamID == "" {
+		return "", fmt.Errorf("team_id or channel_id is required")
 	}
 
 	userID, err := p.resolveUserID(mcpContext)

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -646,7 +646,7 @@ func (p *MattermostToolProvider) toolListPinnedPosts(mcpContext *MCPToolContext,
 		return "", fmt.Errorf("error fetching pinned posts: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, postList, "pinned posts"), nil
+	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "pinned posts"), nil
 }
 
 // toolListSavedPosts implements the list_saved_posts tool.
@@ -688,7 +688,7 @@ func (p *MattermostToolProvider) toolListSavedPosts(mcpContext *MCPToolContext, 
 		return "", fmt.Errorf("error fetching saved posts: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, postList, "saved posts"), nil
+	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "saved posts"), nil
 }
 
 // toolUpdatePost implements the update_post tool.
@@ -813,7 +813,6 @@ func (p *MattermostToolProvider) formatPostListChrono(mcpContext *MCPToolContext
 	for _, post := range postList.Posts {
 		posts = append(posts, post)
 	}
-	posts = filterPostsFromDirectAndGroup(mcpContext, posts)
 	if len(posts) == 0 {
 		return fmt.Sprintf("no %s found", noun)
 	}

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -36,6 +36,10 @@ type MCPToolContext struct {
 	// Empty when the auth provider cannot resolve an authenticated user.
 	UserID string
 
+	// IsBotSession is true when the authenticated Mattermost user is a bot.
+	// True also when the user cannot be resolved, so the DM/GM guard fails closed.
+	IsBotSession bool
+
 	// MMServerURL is the Mattermost server base URL (same as API Client4 origin) for resolving hook keys and firing callbacks.
 	MMServerURL        string
 	BeforeHookResolver auth.BeforeHookResolver
@@ -262,6 +266,18 @@ func (p *MattermostToolProvider) registerDynamicTool(server *mcp.Server, mcpTool
 			}, nil
 		}
 
+		if mcpContext.IsBotSession {
+			if guardErr := rejectDirectOrGroupArgs(mcpContext, req.Params.Arguments); guardErr != nil {
+				p.logger.Debug("MCP tool rejected DM/GM access", "tool", mcpTool.Name, "error", guardErr.Error())
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{Text: "Error: " + guardErr.Error()},
+					},
+					IsError: true,
+				}, nil
+			}
+		}
+
 		// Create argument getter that extracts arguments from the MCP request
 		argsGetter := func(target interface{}) error {
 			// Convert MCP arguments to the target struct
@@ -328,21 +344,24 @@ func (p *MattermostToolProvider) createMCPToolContext(ctx context.Context, metad
 	}
 
 	var userID string
+	isBotSession := true
 	if identityProvider, ok := p.authProvider.(auth.UserIdentityProvider); ok {
 		if user, userErr := identityProvider.GetAuthenticatedUser(ctx); userErr == nil && user != nil {
 			userID = user.Id
+			isBotSession = user.IsBot
 		} else if userErr != nil {
 			p.logger.Debug("failed to resolve authenticated user for tool-call context", "error", userErr.Error())
 		}
 	}
 
 	mcpContext := &MCPToolContext{
-		Ctx:         ctx,
-		Client:      client,
-		AccessMode:  p.accessMode,
-		MMServerURL: p.mmServerURL,
-		ToolHooks:   decodeToolHooksFromMetadata(metadata),
-		UserID:      userID,
+		Ctx:          ctx,
+		Client:       client,
+		AccessMode:   p.accessMode,
+		MMServerURL:  p.mmServerURL,
+		ToolHooks:    decodeToolHooksFromMetadata(metadata),
+		UserID:       userID,
+		IsBotSession: isBotSession,
 	}
 
 	if resolver, ok := ctx.Value(auth.BeforeHookResolverContextKey).(auth.BeforeHookResolver); ok {

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -40,6 +40,10 @@ type MCPToolContext struct {
 	// True also when the user cannot be resolved, so the DM/GM guard fails closed.
 	IsBotSession bool
 
+	// resolver memoizes channel lookups for one tool call (argument guard and
+	// output filters share it).
+	resolver *channelResolver
+
 	// MMServerURL is the Mattermost server base URL (same as API Client4 origin) for resolving hook keys and firing callbacks.
 	MMServerURL        string
 	BeforeHookResolver auth.BeforeHookResolver

--- a/mcpserver/tools/scheduled_posts.go
+++ b/mcpserver/tools/scheduled_posts.go
@@ -96,7 +96,7 @@ func (p *MattermostToolProvider) toolListScheduledPosts(mcpContext *MCPToolConte
 		return "", err
 	}
 
-	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, args.TeamID, true)
+	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, args.TeamID, includeDirectChannels(mcpContext))
 	if err != nil {
 		return "", fmt.Errorf("error fetching scheduled posts: %w", err)
 	}
@@ -105,6 +105,7 @@ func (p *MattermostToolProvider) toolListScheduledPosts(mcpContext *MCPToolConte
 	for _, posts := range byChannel {
 		scheduled = append(scheduled, posts...)
 	}
+	scheduled = filterScheduledPosts(mcpContext, scheduled)
 	if len(scheduled) == 0 {
 		return "no scheduled posts found", nil
 	}
@@ -230,13 +231,22 @@ func (p *MattermostToolProvider) findScheduledPost(mcpContext *MCPToolContext, c
 		teamID = teams[0].Id
 	}
 
-	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, teamID, true)
+	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, teamID, includeDirectChannels(mcpContext))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching scheduled posts: %w", err)
 	}
 	for _, posts := range byChannel {
 		for _, sp := range posts {
 			if sp.Id == scheduledPostID {
+				if mcpContext.IsBotSession {
+					ch, chErr := mcpContext.channelResolver().channel(sp.ChannelId)
+					if chErr != nil {
+						return nil, errUnverifiedChannelReference
+					}
+					if err := rejectIfNotOpenOrPrivate(ch); err != nil {
+						return nil, err
+					}
+				}
 				return sp, nil
 			}
 		}
@@ -250,11 +260,53 @@ func (p *MattermostToolProvider) toolDeleteScheduledPost(mcpContext *MCPToolCont
 		return "", err
 	}
 
+	if mcpContext.IsBotSession {
+		if err := p.requireVisibleScheduledPost(mcpContext, args.ScheduledPostID); err != nil {
+			return "", err
+		}
+	}
+
 	if _, _, err := mcpContext.Client.DeleteScheduledPost(mcpContext.Ctx, args.ScheduledPostID); err != nil {
 		return "", fmt.Errorf("error deleting scheduled post: %w", err)
 	}
 
 	return fmt.Sprintf("Successfully canceled scheduled post %s", args.ScheduledPostID), nil
+}
+
+// requireVisibleScheduledPost fails closed for bot sessions if the scheduled
+// post cannot be found among non-direct posts or its channel is not open/private.
+func (p *MattermostToolProvider) requireVisibleScheduledPost(mcpContext *MCPToolContext, scheduledPostID string) error {
+	userID, err := p.resolveUserID(mcpContext)
+	if err != nil {
+		return errUnverifiedChannelReference
+	}
+	teams, _, err := mcpContext.Client.GetTeamsForUser(mcpContext.Ctx, userID, "")
+	if err != nil {
+		return errUnverifiedChannelReference
+	}
+	r := mcpContext.channelResolver()
+	for _, team := range teams {
+		if team == nil {
+			continue
+		}
+		byChannel, _, listErr := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, team.Id, false)
+		if listErr != nil {
+			return errUnverifiedChannelReference
+		}
+		for _, posts := range byChannel {
+			for _, sp := range posts {
+				if sp == nil || sp.Id != scheduledPostID {
+					continue
+				}
+				ch, chErr := r.channel(sp.ChannelId)
+				if chErr != nil {
+					return errUnverifiedChannelReference
+				}
+				return rejectIfNotOpenOrPrivate(ch)
+			}
+		}
+	}
+	return errDirectOrGroupInaccessible
 }
 
 // toolSetPostReminder implements the set_post_reminder tool.

--- a/mcpserver/tools/scheduled_posts.go
+++ b/mcpserver/tools/scheduled_posts.go
@@ -96,7 +96,7 @@ func (p *MattermostToolProvider) toolListScheduledPosts(mcpContext *MCPToolConte
 		return "", err
 	}
 
-	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, args.TeamID, includeDirectChannels(mcpContext))
+	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, args.TeamID, !mcpContext.IsBotSession)
 	if err != nil {
 		return "", fmt.Errorf("error fetching scheduled posts: %w", err)
 	}
@@ -231,7 +231,7 @@ func (p *MattermostToolProvider) findScheduledPost(mcpContext *MCPToolContext, c
 		teamID = teams[0].Id
 	}
 
-	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, teamID, includeDirectChannels(mcpContext))
+	byChannel, _, err := mcpContext.Client.GetUserScheduledPosts(mcpContext.Ctx, teamID, !mcpContext.IsBotSession)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching scheduled posts: %w", err)
 	}

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -220,14 +220,14 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			semanticResults, semanticErr = p.executeSemanticSearch(ctx, client, args, userID)
+			semanticResults, semanticErr = p.executeSemanticSearch(ctx, client, args, userID, mcpContext.IsBotSession)
 		}()
 	}
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		keywordResults, keywordErr = p.executeKeywordSearch(ctx, client, args)
+		keywordResults, keywordErr = p.executeKeywordSearch(ctx, client, args, mcpContext.IsBotSession)
 	}()
 
 	wg.Wait()
@@ -250,13 +250,14 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 }
 
 // executeSemanticSearch runs the semantic search and returns enriched results.
-func (p *MattermostToolProvider) executeSemanticSearch(ctx context.Context, client *model.Client4, args CombinedSearchArgs, userID string) ([]searchPostResult, error) {
+func (p *MattermostToolProvider) executeSemanticSearch(ctx context.Context, client *model.Client4, args CombinedSearchArgs, userID string, excludeDirectAndGroup bool) ([]searchPostResult, error) {
 	opts := search.Options{
-		Limit:     args.SemanticLimit,
-		Offset:    args.SemanticOffset,
-		TeamID:    args.TeamID,
-		ChannelID: args.ChannelID,
-		UserID:    userID,
+		Limit:                 args.SemanticLimit,
+		Offset:                args.SemanticOffset,
+		TeamID:                args.TeamID,
+		ChannelID:             args.ChannelID,
+		UserID:                userID,
+		ExcludeDirectAndGroup: excludeDirectAndGroup,
 	}
 
 	results, err := p.searchService.Search(ctx, args.Query, opts)
@@ -304,7 +305,7 @@ func (p *MattermostToolProvider) executeSemanticSearch(ctx context.Context, clie
 }
 
 // executeKeywordSearch runs the Mattermost keyword search and returns enriched results.
-func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, client *model.Client4, args CombinedSearchArgs) ([]searchPostResult, error) {
+func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, client *model.Client4, args CombinedSearchArgs, excludeDirectAndGroup bool) ([]searchPostResult, error) {
 	searchTerm := args.Query
 	teamID := args.TeamID
 
@@ -420,6 +421,13 @@ func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, clien
 
 		if user := userCache[post.UserId]; user != nil {
 			result.Username = user.Username
+		}
+
+		if excludeDirectAndGroup {
+			ch := channelCache[post.ChannelId]
+			if ch == nil || isDirectOrGroupChannel(ch) {
+				continue
+			}
 		}
 
 		postResults = append(postResults, result)

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -266,12 +266,18 @@ func (p *MattermostToolProvider) executeSemanticSearch(ctx context.Context, clie
 	}
 
 	channelTeamCache := make(map[string]string)
+	channelVisible := make(map[string]bool)
 	for _, r := range results {
 		if _, exists := channelTeamCache[r.ChannelID]; exists {
 			continue
 		}
 
 		channel, _, chErr := client.GetChannel(ctx, r.ChannelID)
+		if excludeDirectAndGroup {
+			channelVisible[r.ChannelID] = chErr == nil && isVerifiedOpenOrPrivate(channel)
+		} else {
+			channelVisible[r.ChannelID] = true
+		}
 		if chErr == nil && channel.TeamId != "" {
 			team, _, teamErr := client.GetTeam(ctx, channel.TeamId, "")
 			if teamErr == nil {
@@ -285,6 +291,9 @@ func (p *MattermostToolProvider) executeSemanticSearch(ctx context.Context, clie
 
 	postResults := make([]searchPostResult, 0, len(results))
 	for _, r := range results {
+		if !channelVisible[r.ChannelID] {
+			continue
+		}
 		postResults = append(postResults, searchPostResult{
 			Post: &model.Post{
 				Id:        r.PostID,
@@ -348,6 +357,31 @@ func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, clien
 		return nil, nil
 	}
 
+	for _, post := range posts {
+		if _, exists := channelCache[post.ChannelId]; exists {
+			continue
+		}
+		channel, _, chErr := client.GetChannel(ctx, post.ChannelId)
+		if chErr == nil {
+			channelCache[post.ChannelId] = channel
+		} else {
+			channelCache[post.ChannelId] = nil
+		}
+	}
+
+	if excludeDirectAndGroup {
+		visible := make([]*model.Post, 0, len(posts))
+		for _, post := range posts {
+			if isVerifiedOpenOrPrivate(channelCache[post.ChannelId]) {
+				visible = append(visible, post)
+			}
+		}
+		posts = visible
+		if len(posts) == 0 {
+			return nil, nil
+		}
+	}
+
 	sort.Slice(posts, func(i, j int) bool {
 		if posts[i].CreateAt != posts[j].CreateAt {
 			return posts[i].CreateAt > posts[j].CreateAt
@@ -366,15 +400,6 @@ func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, clien
 	}
 
 	for _, post := range posts {
-		if _, exists := channelCache[post.ChannelId]; !exists {
-			channel, _, chErr := client.GetChannel(ctx, post.ChannelId)
-			if chErr == nil {
-				channelCache[post.ChannelId] = channel
-			} else {
-				channelCache[post.ChannelId] = nil
-			}
-		}
-
 		if channel := channelCache[post.ChannelId]; channel != nil && channel.TeamId != "" {
 			if _, exists := teamCache[channel.TeamId]; !exists {
 				team, _, teamErr := client.GetTeam(ctx, channel.TeamId, "")
@@ -421,13 +446,6 @@ func (p *MattermostToolProvider) executeKeywordSearch(ctx context.Context, clien
 
 		if user := userCache[post.UserId]; user != nil {
 			result.Username = user.Username
-		}
-
-		if excludeDirectAndGroup {
-			ch := channelCache[post.ChannelId]
-			if ch == nil || isDirectOrGroupChannel(ch) {
-				continue
-			}
 		}
 
 		postResults = append(postResults, result)

--- a/mcpserver/tools/search_http.go
+++ b/mcpserver/tools/search_http.go
@@ -38,11 +38,12 @@ func (s *HTTPSemanticSearchService) Enabled() bool {
 
 // httpSearchRequest represents the request body sent to the plugin endpoint
 type httpSearchRequest struct {
-	Query     string `json:"query"`
-	TeamID    string `json:"team_id,omitempty"`
-	ChannelID string `json:"channel_id,omitempty"`
-	Limit     int    `json:"limit,omitempty"`
-	Offset    int    `json:"offset,omitempty"`
+	Query                 string `json:"query"`
+	TeamID                string `json:"team_id,omitempty"`
+	ChannelID             string `json:"channel_id,omitempty"`
+	Limit                 int    `json:"limit,omitempty"`
+	Offset                int    `json:"offset,omitempty"`
+	ExcludeDirectAndGroup bool   `json:"exclude_direct_and_group,omitempty"`
 }
 
 // httpSearchResult represents a single result from the plugin endpoint
@@ -67,11 +68,12 @@ type httpSearchResponse struct {
 func (s *HTTPSemanticSearchService) Search(ctx context.Context, query string, opts search.Options) ([]search.RAGResult, error) {
 	// Build request body
 	reqBody := httpSearchRequest{
-		Query:     query,
-		TeamID:    opts.TeamID,
-		ChannelID: opts.ChannelID,
-		Limit:     opts.Limit,
-		Offset:    opts.Offset,
+		Query:                 query,
+		TeamID:                opts.TeamID,
+		ChannelID:             opts.ChannelID,
+		Limit:                 opts.Limit,
+		Offset:                opts.Offset,
+		ExcludeDirectAndGroup: opts.ExcludeDirectAndGroup,
 	}
 
 	status, respBody, err := postPluginJSON(ctx, s.client, s.pluginURL+"/api/v1/search/raw", reqBody, "")

--- a/mcpserver/tools/search_http_test.go
+++ b/mcpserver/tools/search_http_test.go
@@ -123,16 +123,18 @@ func TestHTTPSemanticSearchService_Search(t *testing.T) {
 				assert.Equal(t, "chan1", req.ChannelID)
 				assert.Equal(t, 20, req.Limit)
 				assert.Equal(t, 5, req.Offset)
+				assert.True(t, req.ExcludeDirectAndGroup)
 
 				resp := httpSearchResponse{Results: []httpSearchResult{}}
 				_ = json.NewEncoder(w).Encode(resp)
 			},
 			query: "search query",
 			opts: search.Options{
-				TeamID:    "team1",
-				ChannelID: "chan1",
-				Limit:     20,
-				Offset:    5,
+				TeamID:                "team1",
+				ChannelID:             "chan1",
+				Limit:                 20,
+				Offset:                5,
+				ExcludeDirectAndGroup: true,
 			},
 			expectedCount: 0,
 		},

--- a/mcpserver/tools/threads.go
+++ b/mcpserver/tools/threads.go
@@ -106,12 +106,9 @@ func (p *MattermostToolProvider) toolGetThreads(mcpContext *MCPToolContext, args
 	}
 
 	opts := model.GetUserThreadsOpts{
-		PageSize: uint64(args.Limit),
-		Extended: true,
-		Unread:   args.UnreadOnly,
-		// TeamOnly is the documented exclude-DM option; this Client4
-		// serializes ExcludeDirect, not TeamOnly, so both are set.
-		TeamOnly:      mcpContext.IsBotSession,
+		PageSize:      uint64(args.Limit),
+		Extended:      true,
+		Unread:        args.UnreadOnly,
 		ExcludeDirect: mcpContext.IsBotSession,
 	}
 	threads, _, err := mcpContext.Client.GetUserThreads(mcpContext.Ctx, userID, args.TeamID, opts)
@@ -279,7 +276,7 @@ func (p *MattermostToolProvider) toolGetPostsAroundUnread(mcpContext *MCPToolCon
 		return "", fmt.Errorf("error fetching posts around unread: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "posts around your last-read line"), nil
+	return p.formatPostListChrono(mcpContext, postList, "posts around your last-read line"), nil
 }
 
 // toolMarkChannelRead implements the mark_channel_read tool.

--- a/mcpserver/tools/threads.go
+++ b/mcpserver/tools/threads.go
@@ -109,6 +109,10 @@ func (p *MattermostToolProvider) toolGetThreads(mcpContext *MCPToolContext, args
 		PageSize: uint64(args.Limit),
 		Extended: true,
 		Unread:   args.UnreadOnly,
+		// TeamOnly is the documented exclude-DM option; this Client4
+		// serializes ExcludeDirect, not TeamOnly, so both are set.
+		TeamOnly:      mcpContext.IsBotSession,
+		ExcludeDirect: mcpContext.IsBotSession,
 	}
 	threads, _, err := mcpContext.Client.GetUserThreads(mcpContext.Ctx, userID, args.TeamID, opts)
 	if err != nil {
@@ -119,10 +123,19 @@ func (p *MattermostToolProvider) toolGetThreads(mcpContext *MCPToolContext, args
 		return "no threads found", nil
 	}
 
+	visible := filterThreads(mcpContext, threads.Threads)
+	if len(visible) == 0 {
+		return "no threads found", nil
+	}
+
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("Threads inbox: %d total, %d unread threads, %d unread mentions\n\n",
-		threads.Total, threads.TotalUnreadThreads, threads.TotalUnreadMentions))
-	for i, tr := range threads.Threads {
+	if mcpContext.IsBotSession {
+		result.WriteString(fmt.Sprintf("Threads inbox: %d thread(s)\n\n", len(visible)))
+	} else {
+		result.WriteString(fmt.Sprintf("Threads inbox: %d total, %d unread threads, %d unread mentions\n\n",
+			threads.Total, threads.TotalUnreadThreads, threads.TotalUnreadMentions))
+	}
+	for i, tr := range visible {
 		username := ""
 		if tr.Post != nil {
 			username = p.usernameFor(mcpContext.Ctx, mcpContext.Client, tr.Post.UserId)
@@ -159,7 +172,7 @@ func (p *MattermostToolProvider) toolGetMentions(mcpContext *MCPToolContext, arg
 		return "", fmt.Errorf("error searching mentions: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, postList, "posts mentioning you"), nil
+	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "posts mentioning you"), nil
 }
 
 // mentionKeywords builds the set of terms that mention a user: their @username plus
@@ -266,7 +279,7 @@ func (p *MattermostToolProvider) toolGetPostsAroundUnread(mcpContext *MCPToolCon
 		return "", fmt.Errorf("error fetching posts around unread: %w", err)
 	}
 
-	return p.formatPostListChrono(mcpContext, postList, "posts around your last-read line"), nil
+	return p.formatPostListChrono(mcpContext, visiblePostList(mcpContext, postList), "posts around your last-read line"), nil
 }
 
 // toolMarkChannelRead implements the mark_channel_read tool.

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -386,7 +386,7 @@ func (pv *PGVector) Search(ctx context.Context, embedding []float32, opts embedd
 	}
 
 	if opts.ExcludeDirectAndGroup {
-		queryBuilder = queryBuilder.Where(sq.NotEq{"c.Type": []string{"D", "G"}})
+		queryBuilder = queryBuilder.Where(sq.Eq{"c.Type": []string{"O", "P"}})
 	}
 
 	if opts.CreatedAfter != 0 {

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -385,6 +385,10 @@ func (pv *PGVector) Search(ctx context.Context, embedding []float32, opts embedd
 		queryBuilder = queryBuilder.Where(sq.Eq{"e.channel_id": opts.ChannelID})
 	}
 
+	if opts.ExcludeDirectAndGroup {
+		queryBuilder = queryBuilder.Where(sq.NotEq{"c.Type": []string{"D", "G"}})
+	}
+
 	if opts.CreatedAfter != 0 {
 		queryBuilder = queryBuilder.Where(sq.Gt{"e.created_at": opts.CreatedAfter})
 	}

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -1622,6 +1622,7 @@ func TestSearchExcludeDirectAndGroup(t *testing.T) {
 		{id: "private-channel", channelType: "P", postID: "private-post"},
 		{id: "dm-channel", channelType: "D", postID: "dm-post"},
 		{id: "gm-channel", channelType: "G", postID: "gm-post"},
+		{id: "unknown-channel", channelType: "X", postID: "unknown-post"},
 	}
 
 	postIDs := make([]string, len(channels))
@@ -1667,15 +1668,15 @@ func TestSearchExcludeDirectAndGroup(t *testing.T) {
 		wantMissingPostIDs    []string
 	}{
 		{
-			name:                  "off includes D and G",
+			name:                  "off includes D, G, and unknown types",
 			excludeDirectAndGroup: false,
-			wantPostIDs:           []string{"open-post", "private-post", "dm-post", "gm-post"},
+			wantPostIDs:           []string{"open-post", "private-post", "dm-post", "gm-post", "unknown-post"},
 		},
 		{
-			name:                  "on excludes D and G",
+			name:                  "on allows only O and P",
 			excludeDirectAndGroup: true,
 			wantPostIDs:           []string{"open-post", "private-post"},
-			wantMissingPostIDs:    []string{"dm-post", "gm-post"},
+			wantMissingPostIDs:    []string{"dm-post", "gm-post", "unknown-post"},
 		},
 	}
 

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -1629,7 +1629,7 @@ func TestSearchExcludeDirectAndGroup(t *testing.T) {
 	docs := make([]embeddings.PostDocument, len(channels))
 	embedVectors := make([][]float32, len(channels))
 	for i, ch := range channels {
-		_, err := db.Exec(
+		_, execErr := db.Exec(
 			"INSERT INTO Channels (Id, Name, DisplayName, Type, DeleteAt) VALUES ($1, $2, $3, $4, $5)",
 			ch.id,
 			fmt.Sprintf("name-%s", ch.id),
@@ -1637,7 +1637,7 @@ func TestSearchExcludeDirectAndGroup(t *testing.T) {
 			ch.channelType,
 			int64(0),
 		)
-		require.NoError(t, err, "Failed to insert test channel %s", ch.id)
+		require.NoError(t, execErr, "Failed to insert test channel %s", ch.id)
 		addTestChannelMembers(t, db, ch.id, []string{userID})
 
 		postIDs[i] = ch.postID

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -1604,6 +1604,102 @@ func TestSearchExcludesDeletedPosts(t *testing.T) {
 	}
 }
 
+func TestSearchExcludeDirectAndGroup(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	userID := "user1"
+	channels := []struct {
+		id          string
+		channelType string
+		postID      string
+	}{
+		{id: "open-channel", channelType: "O", postID: "open-post"},
+		{id: "private-channel", channelType: "P", postID: "private-post"},
+		{id: "dm-channel", channelType: "D", postID: "dm-post"},
+		{id: "gm-channel", channelType: "G", postID: "gm-post"},
+	}
+
+	postIDs := make([]string, len(channels))
+	createAts := make([]int64, len(channels))
+	docs := make([]embeddings.PostDocument, len(channels))
+	embedVectors := make([][]float32, len(channels))
+	for i, ch := range channels {
+		_, err := db.Exec(
+			"INSERT INTO Channels (Id, Name, DisplayName, Type, DeleteAt) VALUES ($1, $2, $3, $4, $5)",
+			ch.id,
+			fmt.Sprintf("name-%s", ch.id),
+			fmt.Sprintf("display-%s", ch.id),
+			ch.channelType,
+			int64(0),
+		)
+		require.NoError(t, err, "Failed to insert test channel %s", ch.id)
+		addTestChannelMembers(t, db, ch.id, []string{userID})
+
+		postIDs[i] = ch.postID
+		createAts[i] = now
+		docs[i] = embeddings.PostDocument{
+			PostID:    ch.postID,
+			CreateAt:  now,
+			TeamID:    "team1",
+			ChannelID: ch.id,
+			UserID:    userID,
+			Content:   "shared content",
+		}
+		embedVectors[i] = []float32{0.5, 0.5, 0.5}
+	}
+	addTestPosts(t, db, postIDs, createAts)
+
+	ctx := context.Background()
+	err = pgVector.Store(ctx, docs, embedVectors)
+	require.NoError(t, err)
+
+	searchVector := []float32{0.5, 0.5, 0.5}
+
+	tests := []struct {
+		name                  string
+		excludeDirectAndGroup bool
+		wantPostIDs           []string
+		wantMissingPostIDs    []string
+	}{
+		{
+			name:                  "off includes D and G",
+			excludeDirectAndGroup: false,
+			wantPostIDs:           []string{"open-post", "private-post", "dm-post", "gm-post"},
+		},
+		{
+			name:                  "on excludes D and G",
+			excludeDirectAndGroup: true,
+			wantPostIDs:           []string{"open-post", "private-post"},
+			wantMissingPostIDs:    []string{"dm-post", "gm-post"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := pgVector.Search(ctx, searchVector, embeddings.SearchOptions{
+				UserID:                userID,
+				Limit:                 10,
+				ExcludeDirectAndGroup: tc.excludeDirectAndGroup,
+			})
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(results))
+			for _, result := range results {
+				got = append(got, result.Document.PostID)
+			}
+			assert.ElementsMatch(t, tc.wantPostIDs, got)
+			for _, postID := range tc.wantMissingPostIDs {
+				assert.NotContains(t, got, postID)
+			}
+		})
+	}
+}
+
 func TestNewPGVectorValidation(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/search/search.go
+++ b/search/search.go
@@ -62,6 +62,9 @@ type Options struct {
 	TeamID    string
 	ChannelID string
 	UserID    string
+	// ExcludeDirectAndGroup omits DM and group-message channels. Used when the
+	// searching session is a bot that belongs to every user's DM with the agent.
+	ExcludeDirectAndGroup bool
 }
 
 // SearchResultsProp is the post prop key used to attach search results JSON to the response post.
@@ -205,11 +208,12 @@ func (s *Search) executeSearch(ctx context.Context, query string, opts Options) 
 	}
 
 	searchOpts := embeddings.SearchOptions{
-		Limit:     limit,
-		Offset:    opts.Offset,
-		TeamID:    opts.TeamID,
-		ChannelID: opts.ChannelID,
-		UserID:    opts.UserID,
+		Limit:                 limit,
+		Offset:                opts.Offset,
+		TeamID:                opts.TeamID,
+		ChannelID:             opts.ChannelID,
+		UserID:                opts.UserID,
+		ExcludeDirectAndGroup: opts.ExcludeDirectAndGroup,
 	}
 
 	searchResults, err := search.Search(ctx, query, searchOpts)

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -402,6 +402,26 @@ func TestExecuteSearch(t *testing.T) {
 				require.Empty(t, results)
 			},
 		},
+		{
+			name:  "ExcludeDirectAndGroup is forwarded",
+			query: "test query",
+			opts: Options{
+				Limit:                 5,
+				UserID:                "user1",
+				ExcludeDirectAndGroup: true,
+			},
+			setupMocks: func(me *mocks.MockEmbeddingSearch, mc *mmapimocks.MockClient) {
+				me.On("Search", mock.Anything, "test query", embeddings.SearchOptions{
+					Limit:                 5,
+					UserID:                "user1",
+					ExcludeDirectAndGroup: true,
+				}).Return([]embeddings.SearchResult{}, nil)
+			},
+			expectError: "",
+			validate: func(t *testing.T, results []RAGResult) {
+				require.Empty(t, results)
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/telemetry/integration_test.go
+++ b/telemetry/integration_test.go
@@ -346,9 +346,11 @@ func TestParentChildSpanHierarchy(t *testing.T) {
 
 	if httpStub == nil {
 		t.Fatal("HTTP span not found")
+		return
 	}
 	if llmStub == nil {
 		t.Fatal("LLM span not found")
+		return
 	}
 
 	// Verify same trace

--- a/telemetry/log_processor_test.go
+++ b/telemetry/log_processor_test.go
@@ -144,6 +144,7 @@ func TestLogSpanProcessor_ParentSpanID(t *testing.T) {
 	}
 	if childEntry == nil {
 		t.Fatal("child entry not found")
+		return
 	}
 	if _, ok := kvLookup(childEntry.kvs, "parent_span_id"); !ok {
 		t.Error("child entry missing parent_span_id")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Stacked on top of #937. Addresses the direct-message half of the service-account access concern raised in review ([discussion_r3776322648](https://github.com/mattermost/mattermost-plugin-agents/pull/937#discussion_r3776322648), [discussion_r3864810924](https://github.com/mattermost/mattermost-plugin-agents/pull/937#discussion_r3864810924)).

**The problem.** In service-account mode, embedded Mattermost tool calls execute with a session belonging to the agent's *bot* user rather than the human who asked. Since anyone can DM an agent, one user's private conversation with the agent was reachable by any other user of that agent: `get_user_channels` lists the bot's DMs and GMs with their IDs, and `read_channel` on one of them succeeds because the bot is a participant. No misconfiguration is required — unlike the private-channel case, nobody has to add the bot anywhere.

**The rule.** When the Mattermost session executing a tool call belongs to a bot, direct message and group message channels are out of reach — content, identifiers, counts, and mutation. Human sessions are unaffected.

The bot signal needs no new plumbing: `createMCPToolContext` already resolved the authenticated `*model.User` and was discarding everything but `.Id`, so `user.IsBot` was already in hand. Deriving the rule from the session rather than from agent configuration keeps it inside `mcpserver/tools`, which matters because that package is shared with the HTTP and stdio servers and is deliberately decoupled from plugin internals.

#### How it's enforced

**Argument guard.** One check in the `registerDynamicTool` handler, before any resolver runs. Arguments are still a plain map there, so it scans by key name (`channel_id`, `channel_ids`, `post_id`, `post_ids`, `root_id`, `thread_id`, `reply_to_post_id`, `file_id`, `file_ids`), resolving each to a channel — posts and files via their post or channel — memoized per call. Keys are lowercased before matching, because `encoding/json` matches struct fields case-insensitively and the generated schemas don't forbid unknown properties, so `{"CHANNEL_ID": ...}` would otherwise have slipped past and still populated the args struct. Nested objects and arrays are traversed. `before`/`after` are guarded only when the value looks like a Mattermost ID, since they are post-ID cursors on `read_channel` but dates on `search_posts`; the same mechanism handles `in`.

There is deliberately **no exemption list**, so a tool added later is guarded by default.

**Output filters** for tools that can return DM/GM data without taking a guarded argument: `get_user_channels` and `search_channels` (the discovery paths), `get_channel_info` (reachable by display-name search), `get_threads`, `list_scheduled_posts`, `list_sidebar_categories`, `search_files`, `get_user_channel_memberships`, the automation tools, and `get_mentions` / `list_saved_posts` via `visiblePostList` at the call sites. Mutation-by-opaque-ID paths (`delete_scheduled_post`, `update_scheduled_post`, `delete_automation`, `update_automation`) resolve the target and verify its channel before mutating.

**Semantic search** is filtered at the source: `search.Options` gains `ExcludeDirectAndGroup`, threaded through the raw search API and into the pgvector query, which reuses the `Channels` join already there for the `DeleteAt` filter. It is opt-in and off by default, so a human searching their own DMs is unchanged. Results are also filtered locally, so a backend that ignores the option cannot widen the boundary.

**Keyword search** filters before applying offset and limit, so hidden matches don't consume page slots and produce short or falsely empty pages.

**Fail closed throughout.** Only channels explicitly typed Open or Private pass; `nil`, unknown types, and unresolvable references are rejected rather than allowed through unchecked. If the authenticated user cannot be resolved at all, the session is treated as a bot.

**Keeping it closed.** `TestEveryToolDeclaresDMandGMEnforcement` requires every tool registered by `mcpTools()` to be classified in `botSessionDMGMEnforcement` using a named `dmGMEnforcement` constant, and fails with a classify-this-tool message otherwise. Handler-level tests drive real tools through `CallTool` so the wiring itself is covered, not just the helper.

#### Deliberate decisions worth reviewing

- **Outbound DMs still work.** `dm` and `group_message` take usernames rather than channel IDs, so they are outside the guard and agents can still message people proactively. Blocking them would break notification workflows without preventing any disclosure. Automation `send_dm` actions follow the same reasoning. If you'd rather agents could not initiate DMs at all, that's a separate policy call.
- **Guard errors distinguish "this is a DM" from "could not resolve this reference."** That is technically an existence oracle, but only for someone already holding a valid 26-character ID, and enumeration paths are filtered. Collapsing them would mean reporting a hallucinated ID as a DM, which misleads the model on a much more common path. Happy to merge them if you disagree.
- **`get_unread_counts`, webhook listings, and `get_dm_common_teams`** are classified as unable to reach DM/GM data rather than filtered: unread counts are team aggregates, outgoing webhooks cannot exist on D/G, and `get_dm_common_teams` returns teams and takes a guarded `channel_id`.

#### Not addressed here

- Group messages containing an agent are still written to the semantic index while the equivalent DMs are skipped (`shouldIndexPost` relies on `GetBotForDMChannel`, and `mmapi.IsDMWith` matches only channel type `D`). Now that bot sessions cannot retrieve DM/GM content, this is data-minimisation hygiene rather than a disclosure path. Closing it needs a channel-member lookup per group message, because GM channel names are hashes rather than the participants' IDs, and `IsDMWith` is relied on for true-1-1-DM semantics in several conversation paths that must not change.
- Human personal-access-token sessions on the stdio server now resolve `/users/me` twice per tool call, once for the client and once for identity. Minor, stdio-only, worth folding into one lookup later.
- Private channels someone deliberately added the bot to remain governed by bot membership. That is the separate question still under discussion on #937 — this change closes the door that opens by itself.

#### QA

`make check-style`, `go build ./...`, `make check-i18n` and `make check-shards` are clean. The full Go suite passes, including a targeted `-race` run over `mcpserver/tools`, `mcpserver` and `search` for the two search goroutines and the per-call resolver. The pgvector allow-list is covered by an integration test against a real `pgvector/pgvector:pg17` container, including an unknown channel type that a block-list would have leaked.

Reviewed by three independent passes; the first two found real defects (case-sensitive key matching, five unguarded discovery tools, filtering after pagination, a personal-access-token regression, block-list instead of allow-list, the HTTP search path dropping the flag) which are fixed in the later commits.

One pre-existing failure is inherited from this branch's base: `webapp/src/components/system_console/avatar.test.tsx` asserts against a virtual `placeholder-icon.png` mock, which `master` has already replaced with the Jest asset stub. It is unrelated to this change and resolves when #937 picks up master.

#### Ticket Link

Follow-up to review feedback on #937.

#### Screenshots

No UI changes.

#### Release Note

```release-note
Agents using service account authentication can no longer read direct messages or group messages through Mattermost tools. Tool calls made with a bot account's session now reject channel, post, and file references that resolve to a direct or group message, omit direct and group messages from channel listings, thread lists, saved and pinned posts, sidebar categories, file search, and keyword and semantic search results, and refuse to modify scheduled posts or automations belonging to them. Agents can still send direct messages to users.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80be10ea-0620-4d56-adcd-954e3c986d24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80be10ea-0620-4d56-adcd-954e3c986d24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bot sessions now limit channel listings, searches, posts, threads, files, automations, scheduled posts, memberships, and sidebar categories to verified open or private channels.
  - Searches can omit direct and group conversations while retaining open and private channels.
  - Empty filtered results now display clear no-results messages.
  - Saved-post listings for bot sessions require a channel or team scope.
  - Raw semantic search supports excluding direct and group conversations.

- **Bug Fixes**
  - Prevented bot access to direct and group-message content through referenced identifiers and tool arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->