### PR TITLE
Cherry-pick #939 to release-2.0: recover embedded MCP clients after session revocation

### DIFF
--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -89,25 +89,46 @@ func (c *UserClients) ConnectToRemoteServers(servers []ServerConfig) *Errors {
 	return mcpErrors
 }
 
-// ConnectToEmbeddedServerIfAvailable connects to the embedded server if session ID is provided
+// ConnectToEmbeddedServerIfAvailable connects to the embedded server if session ID is provided.
 func (c *UserClients) ConnectToEmbeddedServerIfAvailable(sessionID string, embeddedClient *EmbeddedServerClient, embeddedConfig EmbeddedServerConfig) error {
 	if !embeddedConfig.Enabled || embeddedClient == nil {
 		return nil
 	}
 
-	// Check if we already have an embedded server connection
-	if _, exists := c.clients[EmbeddedClientKey]; exists {
-		return nil // Already connected
+	if sessionID == "" {
+		return nil
 	}
 
-	// Connect if session ID is provided
-	if sessionID != "" {
-		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := c.connectToEmbeddedServerWithClient(ctxWithTimeout, c.userID, sessionID, embeddedClient); err != nil {
-			c.log.Error("Failed to connect to embedded MCP server", "userID", c.userID, "error", err)
-			return fmt.Errorf("failed to connect to embedded server: %w", err)
+	existingClient := c.clients[EmbeddedClientKey]
+	if existingClient != nil && existingClient.sessionID == sessionID {
+		return nil
+	}
+
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverClient, err := embeddedClient.CreateClient(ctxWithTimeout, c.userID, sessionID)
+	if err != nil {
+		c.log.Error("Failed to connect to embedded MCP server", "userID", c.userID, "error", err)
+		return fmt.Errorf("failed to connect to embedded server: %w", err)
+	}
+
+	existingClient = c.clients[EmbeddedClientKey]
+	if existingClient != nil && existingClient.sessionID == sessionID {
+		if err := serverClient.Close(); err != nil {
+			c.log.Error("Failed to close MCP client", "userID", c.userID, "serverID", EmbeddedClientKey, "error", err)
 		}
+		return nil
+	}
+
+	c.clients[EmbeddedClientKey] = serverClient
+
+	if existingClient != nil {
+		if err := existingClient.Close(); err != nil {
+			c.log.Error("Failed to close MCP client", "userID", c.userID, "serverID", EmbeddedClientKey, "error", err)
+		}
+		c.log.Debug("Reconnected to embedded MCP server with refreshed session", "userID", c.userID)
+	} else {
 		c.log.Debug("Successfully connected to embedded MCP server", "userID", c.userID)
 	}
 
@@ -121,16 +142,6 @@ func (c *UserClients) connectToServer(ctx context.Context, serverID string, serv
 		return err
 	}
 	c.clients[serverID] = serverClient
-	return nil
-}
-
-// connectToEmbeddedServerWithClient establishes a connection to the embedded server using the embedded client helper
-func (c *UserClients) connectToEmbeddedServerWithClient(ctx context.Context, userID, sessionID string, embeddedClient *EmbeddedServerClient) error {
-	serverClient, err := embeddedClient.CreateClient(ctx, userID, sessionID)
-	if err != nil {
-		return err
-	}
-	c.clients[EmbeddedClientKey] = serverClient
 	return nil
 }
 

--- a/mcp/user_clients_test.go
+++ b/mcp/user_clients_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+	plugintest "github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestLogger registers catch-all .Maybe() mocks for log methods.
+// plugintest mocks expand each variadic arg into a separate positional arg,
+// so we must register one expectation per arity.
+func setupTestLogger(mockAPI *plugintest.API) {
+	for _, method := range []string{"LogDebug", "LogError", "LogWarn", "LogInfo"} {
+		for arity := 1; arity <= 16; arity++ {
+			args := make([]interface{}, arity)
+			for i := range args {
+				args[i] = mock.Anything
+			}
+			mockAPI.On(method, args...).Return().Maybe()
+		}
+	}
+}
+
+type sessionLookupPluginAPI struct {
+	plugintest.API
+	sessionByID map[string]*model.Session
+}
+
+func (f *sessionLookupPluginAPI) LogDebug(string, ...interface{}) {}
+
+func (f *sessionLookupPluginAPI) LogInfo(string, ...interface{}) {}
+
+func (f *sessionLookupPluginAPI) LogWarn(string, ...interface{}) {}
+
+func (f *sessionLookupPluginAPI) LogError(string, ...interface{}) {}
+
+func (f *sessionLookupPluginAPI) GetSession(sessionID string) (*model.Session, *model.AppError) {
+	if f.sessionByID == nil {
+		return nil, nil
+	}
+	return f.sessionByID[sessionID], nil
+}
+
+func TestConnectToEmbeddedServerIfAvailable_ReconnectsWhenSessionChanges(t *testing.T) {
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+
+	fakeAPI := &sessionLookupPluginAPI{
+		sessionByID: map[string]*model.Session{
+			"old-session": {Id: "old-session", UserId: "alice", Token: "old-token"},
+			"new-session": {Id: "new-session", UserId: "alice", Token: "new-token"},
+		},
+	}
+	pluginAPI := pluginapi.NewClient(fakeAPI, nil)
+	embeddedClient := NewEmbeddedServerClient(&sessionEchoEmbeddedMCPServer{ctx: runCtx}, pluginAPI.Log, pluginAPI)
+	uc := NewUserClients("alice", pluginAPI.Log, nil, nil, nil)
+	cfg := EmbeddedServerConfig{Enabled: true}
+
+	require.NoError(t, uc.ConnectToEmbeddedServerIfAvailable("old-session", embeddedClient, cfg))
+	require.Equal(t, "old-session", callSessionIdentityTool(t, uc.GetTools()))
+
+	require.NoError(t, uc.ConnectToEmbeddedServerIfAvailable("new-session", embeddedClient, cfg))
+	require.Equal(t, "new-session", callSessionIdentityTool(t, uc.GetTools()))
+}
+
+func TestClientManagerGetToolsForUser_ReconnectsAfterStoredSessionRevoked(t *testing.T) {
+	const (
+		userID       = "alice"
+		oldSessionID = "old-session"
+		newSessionID = "new-session"
+	)
+
+	storedSessionID := oldSessionID
+	sessions := map[string]*model.Session{
+		oldSessionID: {Id: oldSessionID, UserId: userID, Token: "old-token"},
+	}
+	fakeAPI := &plugintest.API{}
+	setupTestLogger(fakeAPI)
+	fakeAPI.On("KVGet", mock.AnythingOfType("string")).Return(func(key string) []byte {
+		if key == buildEmbeddedSessionKey(userID) {
+			return []byte(storedSessionID)
+		}
+		return nil
+	}, (*model.AppError)(nil))
+	fakeAPI.On("KVDelete", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		if args.String(0) == buildEmbeddedSessionKey(userID) {
+			storedSessionID = ""
+		}
+	}).Return((*model.AppError)(nil))
+	fakeAPI.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.Anything, mock.AnythingOfType("model.PluginKVSetOptions")).Run(func(args mock.Arguments) {
+		if args.String(0) != buildEmbeddedSessionKey(userID) {
+			return
+		}
+		data, _ := args.Get(1).([]byte)
+		storedSessionID = string(data)
+	}).Return(true, (*model.AppError)(nil))
+	fakeAPI.On("GetUser", userID).Return(&model.User{Id: userID, Roles: "system_user"}, (*model.AppError)(nil))
+	fakeAPI.On("GetSession", mock.AnythingOfType("string")).Return(
+		func(sessionID string) *model.Session {
+			return sessions[sessionID]
+		},
+		func(sessionID string) *model.AppError {
+			if sessions[sessionID] == nil {
+				return model.NewAppError("GetSessionById", "api.context.session_expired.app_error", nil, "", http.StatusUnauthorized)
+			}
+			return nil
+		},
+	)
+	fakeAPI.On("CreateSession", mock.AnythingOfType("*model.Session")).Return(func(session *model.Session) *model.Session {
+		session.Id = newSessionID
+		session.Token = "new-token"
+		sessions[newSessionID] = session
+		return session
+	}, (*model.AppError)(nil))
+	defaultConfig := &model.Config{}
+	defaultConfig.SetDefaults()
+	fakeAPI.On("GetConfig").Return(defaultConfig)
+
+	pluginAPI := pluginapi.NewClient(fakeAPI, nil)
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+	manager := NewClientManager(
+		Config{
+			EmbeddedServer: EmbeddedServerConfig{
+				Enabled: true,
+				ToolConfigs: []ToolConfig{{
+					Name:    "session_identity",
+					Policy:  "auto_run_in_dm",
+					Enabled: true,
+				}},
+			},
+		},
+		pluginAPI.Log,
+		pluginAPI,
+		nil,
+		&sessionEchoEmbeddedMCPServer{ctx: runCtx},
+		http.DefaultClient,
+	)
+	t.Cleanup(manager.Close)
+
+	tools, mcpErrors := manager.GetToolsForUser(userID)
+	require.Nil(t, mcpErrors)
+	require.Equal(t, oldSessionID, callSessionIdentityTool(t, tools))
+
+	delete(sessions, oldSessionID)
+
+	tools, mcpErrors = manager.GetToolsForUser(userID)
+	require.Nil(t, mcpErrors)
+	require.Equal(t, newSessionID, storedSessionID)
+	require.Equal(t, newSessionID, callSessionIdentityTool(t, tools))
+}
+
+func callSessionIdentityTool(t *testing.T, tools []llm.Tool) string {
+	t.Helper()
+	require.Len(t, tools, 1)
+	require.Equal(t, "session_identity", tools[0].Name)
+	result, err := tools[0].Resolver(&llm.Context{}, func(args any) error {
+		*(args.(*map[string]any)) = map[string]any{}
+		return nil
+	})
+	require.NoError(t, err)
+	return strings.TrimSpace(result)
+}
+
+type sessionEchoEmbeddedMCPServer struct {
+	ctx context.Context
+}
+
+func (s *sessionEchoEmbeddedMCPServer) CreateClientTransport(_ string, sessionID string, _ *pluginapi.Client) (*gomcp.InMemoryTransport, error) {
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "session-echo", Version: "1.0"}, nil)
+	server.AddTool(&gomcp.Tool{
+		Name:        "session_identity",
+		Description: "Returns the session used by this connection",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(context.Context, *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: sessionID}},
+		}, nil
+	})
+	serverTransport, clientTransport := gomcp.NewInMemoryTransports()
+	go func() {
+		_ = server.Run(s.ctx, serverTransport)
+	}()
+	return clientTransport, nil
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Cherry-pick of #939 onto `release-2.0`.

Embedded MCP tools failed permanently after the KV-stored Mattermost session expired or was revoked (for example via `maxSessionsLimit` or admin revocation). The cached embedded client was reused even when `ensureEmbeddedSessionID` minted a replacement session.

This backport reconnects the cached embedded MCP client when the session ID changes, instead of returning a hard error until the plugin is cycled.

Conflict / adaptation notes for this backport:

- `release-2.0` `ConnectToEmbeddedServerIfAvailable` has no `context.Context` parameter and no `clientsMu`; the session-ID comparison and reconnect/close behavior is preserved without changing those APIs.
- `mcp/user_clients_test.go` does not exist on this branch, so the #939 tests are added as a new file and adapted to 2.0 signatures: no context on `GetTools` / `GetToolsForUser` / `ToolResolver`, 6-arg `NewClientManager`, non-`/v2` module path, and the bare embedded tool name `session_identity`.

QA steps:
1. Configure an agent with the embedded Mattermost MCP server and enable `get_channel_info` (or another embedded tool).
2. Invoke the tool once and confirm it succeeds.
3. As a system administrator, revoke all sessions for the test user, then sign the user back in.
4. Invoke the embedded tool again and confirm it succeeds automatically without cycling the Agents plugin.

#### Ticket Link

Cherry-pick of https://github.com/mattermost/mattermost-plugin-agents/pull/939
Jira https://mattermost.atlassian.net/browse/MM-70019

#### Screenshots

N/A

#### Release Note

```release-note
Fixed embedded MCP tools failing permanently after their stored Mattermost session expired or was revoked.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71685645-ed7b-4d1e-8823-8796710b346b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71685645-ed7b-4d1e-8823-8796710b346b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved embedded server connection handling when session IDs change or become invalid.
  - Automatically replaces stale connections and closes duplicate or previous clients.
  - Requires a valid session ID before establishing an embedded server connection.
  - Restores client connectivity after a stored session is revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->