### PR TITLE
fix(abac): resolve merge with durable-ids config reload

### DIFF
--- a/server/abac_id_migrations.go
+++ b/server/abac_id_migrations.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/store"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -17,8 +16,10 @@ import (
 // service IDs are rewritten to model.NewId() values, and MCP servers (external,
 // embedded, and plugin-registered) get stable IDs assigned. All run in a
 // single idempotent store transaction, guarded by one cluster mutex. Returns
-// whether the migration wrote to the DB.
-func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.Store, cfg *config.Container) (bool, error) {
+// whether the migration wrote to the DB. Callers must load config from the
+// store afterwards — Migrated=false means another node already wrote, not that
+// this process's memory is current.
+func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.Store) (bool, error) {
 	mtx, err := cluster.NewMutex(api, "ai_abac_id_migration")
 	if err != nil {
 		return false, fmt.Errorf("failed to create ABAC ID migration mutex: %w", err)
@@ -32,15 +33,6 @@ func runABACIDMigrations(api plugin.API, pluginAPI *pluginapi.Client, st *store.
 	}
 
 	if report.Migrated {
-		reloaded, reloadErr := st.GetConfig()
-		if reloadErr != nil {
-			return false, fmt.Errorf("failed to reload config after ID migrations: %w", reloadErr)
-		}
-		if reloaded != nil {
-			if storeErr := cfg.StorePersistedConfigWithoutNotify(reloaded); storeErr != nil {
-				return false, fmt.Errorf("failed to store config after ID migrations: %w", storeErr)
-			}
-		}
 		pluginAPI.Log.Info("ABAC ID migrations applied",
 			"services_remapped", report.ServicesRemapped,
 			"agent_rows_updated", report.AgentRowsUpdated,

--- a/server/main.go
+++ b/server/main.go
@@ -192,7 +192,14 @@ func (p *Plugin) OnActivate() error {
 	}
 	mtx2.Unlock()
 
-	// Load config from DB into memory and set migrated flag
+	// ID migration before in-memory load so a follower that waited on the
+	// cluster lock still sees the winner's remapped IDs (Migrated=false means
+	// the store already has them, not that this process loaded them).
+	idsMigrated, err := runABACIDMigrations(p.API, pluginAPI, p.store)
+	if err != nil {
+		return fmt.Errorf("failed to run ABAC ID migrations: %w", err)
+	}
+
 	dbConfig, err := p.store.GetConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config from database: %w", err)
@@ -202,13 +209,6 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.configMigrated = true
 
-	// ABAC ID migrations must run after the config.json->DB migration and
-	// before bots are ensured, so EnsureBots persists agents that already use
-	// already-remapped service IDs into Agents_UserAgents.
-	idsMigrated, err := runABACIDMigrations(p.API, pluginAPI, p.store, &p.configuration)
-	if err != nil {
-		return fmt.Errorf("failed to run ABAC ID migrations: %w", err)
-	}
 	if idsMigrated {
 		if pubErr := p.PublishConfigUpdate(); pubErr != nil {
 			pluginAPI.Log.Error("Failed to publish config update after ID migration", "error", pubErr.Error())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Resolves the merge conflict between `abac/pep-and-api` (PR 971) and its base `abac/durable-ids`.

`durable-ids` moved ABAC ID migration **before** the in-memory config load (`ef5936f5`) so a cluster lock-loser still sees remapped service IDs. This branch had a second `runABACIDMigrations` call after load (and still passed the old `*config.Container` argument). Keep the durable-ids ordering and drop the duplicate call. PEP wiring (`accessChecker` into bots/MCP/API) is unchanged.

After this lands on `abac/pep-and-api`, PR 971 should be mergeable into `abac/durable-ids`.

#### Ticket Link
Stacked on https://github.com/mattermost/mattermost-plugin-agents/pull/971

#### Screenshots
N/A (activation-path merge resolution, no UI).

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d664b2f6-33f7-4d12-ad8d-ff62a1147994?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d664b2f6-33f7-4d12-ad8d-ff62a1147994&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration migration sequencing to ensure access-control updates are applied before configuration is loaded.
  * Prevented stale in-memory configuration from being used after migrations.
  * Ensured migrated configuration is read from persistent storage at the appropriate stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->