### PR TITLE
webapp: pass rootId to the Agents RHS composer

### DIFF
--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -116,6 +116,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
         editorComponent = (
             <AdvancedTextEditor
                 channelId={botChannelId}
+                rootId=""
                 placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
                 isThreadView={true}
                 location={'RHS_COMMENT'}

--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -116,7 +116,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
         editorComponent = (
             <AdvancedTextEditor
                 channelId={botChannelId}
-                rootId=""
+                rootId={''}
                 placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
                 isThreadView={true}
                 location={'RHS_COMMENT'}


### PR DESCRIPTION
#### Summary
- Pass `rootId=""` to `AdvancedTextEditor` in the Agents RHS new-chat composer so Mattermost 11.11's render-time draft sync can settle.
- Opening the RHS on 11.11 otherwise hits React error #301 (too many re-renders) because the host compares `draft.rootId` (`''`) to an omitted prop (`undefined`) and never stops calling `setDraft`.

#### Release Note
```release-note
Fixed the Agents right-hand sidebar crashing with a React infinite re-render on Mattermost 11.11.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the RHS new-tab editor configuration without changing its behaviour or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->