### PR TITLE
Cherry-pick #1016 to release-2.6

### DIFF
--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -116,6 +116,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
         editorComponent = (
             <AdvancedTextEditor
                 channelId={botChannelId}
+                rootId={''}
                 placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
                 isThreadView={true}
                 location={'RHS_COMMENT'}


### PR DESCRIPTION
#### Summary
Cherry pick of https://github.com/mattermost/mattermost-plugin-agents/pull/1016 — pass rootId to Agents RHS composer so Mattermost 11.11 draft sync does not infinite-re-render.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-agents/pull/1016

#### Release Note
```release-note
Fixed the Agents right-hand sidebar crashing with a React infinite re-render on Mattermost 11.11.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the advanced text editor could open without the required root context when launched in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->