### PR TITLE
fix(abac): sanitize CEL test users (follow-up to #971)

### DIFF
--- a/api/api_access_control.go
+++ b/api/api_access_control.go
@@ -408,10 +408,49 @@ func (a *API) handleCELTest(c *gin.Context) {
 	}
 	// Plugin RPC (gob) turns an empty users slice into nil; JSON would then
 	// emit "users": null and crash the host TestResultsModal on spread.
-	if result != nil && result.Users == nil {
-		result.Users = []*model.User{}
+	if result != nil {
+		if result.Users == nil {
+			result.Users = []*model.User{}
+		}
+		a.sanitizeUsersForHTTPResponse(result.Users, userID)
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+// sanitizeUsersForHTTPResponse applies core's profile sanitization to users
+// returned over HTTP. Mirrors App.SanitizeProfile: options from
+// Config.GetSanitizeOptions, with email/fullname/authservice forced on for
+// PermissionManageSystem. auth_data is never opted in, so Sanitize blanks it
+// for everyone.
+func (a *API) sanitizeUsersForHTTPResponse(users []*model.User, actingUserID string) {
+	asAdmin := isSystemAdmin(a.pluginAPI, actingUserID)
+	options := a.userProfileSanitizeOptions(asAdmin)
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		user.SanitizeProfile(options, asAdmin)
+	}
+}
+
+// userProfileSanitizeOptions mirrors core App.GetSanitizeOptions: privacy
+// ShowEmailAddress/ShowFullName, plus email/fullname/authservice for sysadmins.
+func (a *API) userProfileSanitizeOptions(asAdmin bool) map[string]bool {
+	options := map[string]bool{
+		"email":    false,
+		"fullname": false,
+	}
+	if cfg := a.pluginAPI.Configuration.GetConfig(); cfg != nil &&
+		cfg.PrivacySettings.ShowEmailAddress != nil &&
+		cfg.PrivacySettings.ShowFullName != nil {
+		options = cfg.GetSanitizeOptions()
+	}
+	if asAdmin {
+		options["email"] = true
+		options["fullname"] = true
+		options["authservice"] = true
+	}
+	return options
 }
 
 func (a *API) handleCELAutocompleteFields(c *gin.Context) {

--- a/api/api_access_control_test.go
+++ b/api/api_access_control_test.go
@@ -602,6 +602,7 @@ func TestCELTestNormalizesNilUsers(t *testing.T) {
 	defer e.Cleanup(t)
 
 	e.mockAPI.On("HasPermissionTo", userID, model.PermissionManageOwnAgent).Return(true).Maybe()
+	e.mockAPI.On("HasPermissionTo", userID, model.PermissionManageSystem).Return(false).Maybe()
 	e.mockAPI.On("QueryUsersForAccessControlExpression", userID, accesscontrol.ResourceTypeService, mock.AnythingOfType("string"), "", "", 0).
 		Return(&model.AccessControlPolicyTestResponse{Users: nil, Total: 0}, nil).Once()
 
@@ -618,6 +619,121 @@ func TestCELTestNormalizesNilUsers(t *testing.T) {
 	var raw map[string]json.RawMessage
 	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&raw))
 	require.Equal(t, json.RawMessage("[]"), raw["users"])
+}
+
+func TestCELTestSanitizesReturnedUsers(t *testing.T) {
+	const (
+		sentinelEmail    = "sentinel-email@example.test"
+		sentinelAuthData = "uid=sentinel,dc=example,dc=com"
+		sentinelFirst    = "SentinelFirst"
+		sentinelLast     = "SentinelLast"
+		sentinelAuthSvc  = "sentinel-authservice"
+		keepUsername     = "keep-username"
+	)
+
+	tests := []struct {
+		name            string
+		isAdmin         bool
+		showEmail       bool
+		showFullName    bool
+		wantEmail       bool
+		wantNames       bool
+		wantAuthService bool
+	}{
+		{
+			name: "non-admin privacy off hides email names and auth",
+		},
+		{
+			name:         "non-admin privacy on keeps email and names not auth",
+			showEmail:    true,
+			showFullName: true,
+			wantEmail:    true,
+			wantNames:    true,
+		},
+		{
+			name:      "non-admin show email only",
+			showEmail: true,
+			wantEmail: true,
+		},
+		{
+			name:         "non-admin show full name only",
+			showFullName: true,
+			wantNames:    true,
+		},
+		{
+			name:            "system admin sees email names authservice despite privacy off",
+			isAdmin:         true,
+			wantEmail:       true,
+			wantNames:       true,
+			wantAuthService: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID := model.NewId()
+			matched := &model.User{
+				Id:          model.NewId(),
+				Username:    keepUsername,
+				Email:       sentinelEmail,
+				FirstName:   sentinelFirst,
+				LastName:    sentinelLast,
+				AuthService: sentinelAuthSvc,
+				AuthData:    model.NewPointer(sentinelAuthData),
+			}
+
+			e := setupAccessControlTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			e.OverrideConfig(&model.Config{
+				PrivacySettings: model.PrivacySettings{
+					ShowEmailAddress: model.NewPointer(tt.showEmail),
+					ShowFullName:     model.NewPointer(tt.showFullName),
+				},
+			})
+			e.mockAPI.On("HasPermissionTo", userID, model.PermissionManageOwnAgent).Return(!tt.isAdmin).Maybe()
+			e.mockAPI.On("HasPermissionTo", userID, model.PermissionManageOthersAgent).Return(false).Maybe()
+			e.mockAPI.On("HasPermissionTo", userID, model.PermissionManageSystem).Return(tt.isAdmin).Maybe()
+			e.mockAPI.On("QueryUsersForAccessControlExpression", userID, accesscontrol.ResourceTypeAgent, mock.AnythingOfType("string"), "", "", 0).
+				Return(&model.AccessControlPolicyTestResponse{
+					Users: []*model.User{matched},
+					Total: 1,
+				}, nil).Once()
+
+			body := map[string]any{
+				"resource_type": accesscontrol.ResourceTypeAgent,
+				"expression":    `user.attributes.department == "eng"`,
+				"term":          "",
+				"after":         "",
+				"limit":         0,
+			}
+			recorder := doRequest(e.api, http.MethodPost, "/access_control/cel/test", body, userID)
+			require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+
+			raw := recorder.Body.String()
+			assert.Contains(t, raw, matched.Id)
+			assert.Contains(t, raw, keepUsername)
+			assert.NotContains(t, raw, sentinelAuthData)
+
+			if tt.wantEmail {
+				assert.Contains(t, raw, sentinelEmail)
+			} else {
+				assert.NotContains(t, raw, sentinelEmail)
+			}
+			if tt.wantNames {
+				assert.Contains(t, raw, sentinelFirst)
+				assert.Contains(t, raw, sentinelLast)
+			} else {
+				assert.NotContains(t, raw, sentinelFirst)
+				assert.NotContains(t, raw, sentinelLast)
+			}
+			if tt.wantAuthService {
+				assert.Contains(t, raw, sentinelAuthSvc)
+			} else {
+				assert.NotContains(t, raw, sentinelAuthSvc)
+			}
+		})
+	}
 }
 
 // perIDDecisionClient denies specific resource IDs; everything else is no_policy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Follow-up to #971 addressing [Edgar's CEL test user sanitization comment](https://github.com/mattermost/mattermost-plugin-agents/pull/971#discussion_r3933496328).

`POST /access_control/cel/test` JSON-encoded `AccessControlPolicyTestResponse.Users` without profile sanitization. The plugin API is supposed to return unsanitized users, and `model.User.Sanitize(map[string]bool{})` does not clear email/names/`auth_data` when the options map is empty. The route is reachable by agent managers, not only sysadmins, so that leaked email, first/last name (against privacy settings), and LDAP DN / SAML/OAuth identifier via `auth_data`.

This change sanitizes each user with **core model functions** before `c.JSON`, matching core's CEL test handler (`App.SanitizeProfile`):

- Options from `pluginAPI.Configuration.GetConfig().GetSanitizeOptions()` (`PrivacySettings.ShowEmailAddress` / `ShowFullName`).
- If the caller has `PermissionManageSystem`, force `email` / `fullname` / `authservice` true (`asAdmin`).
- Call `user.SanitizeProfile(opts, asAdmin)`.
- `auth_data` is never opted in, so `Sanitize` blanks it for everyone.
- `id` / `username` are kept. The CEL test route is **not** locked to system admins.

Does **not** address Edgar comments #2–#6.

#### Ticket Link
Follow-up to https://github.com/mattermost/mattermost-plugin-agents/pull/971
Review comment: https://github.com/mattermost/mattermost-plugin-agents/pull/971#discussion_r3933496328

#### Screenshots
N/A (API sanitization only)

#### Release Note
```release-note
Sanitized user profiles returned by the access-policy CEL test API so email, names, and auth identifiers follow Mattermost privacy settings.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c54e18ad-b1e5-4096-8de8-87e0182e0c2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c54e18ad-b1e5-4096-8de8-87e0182e0c2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved privacy handling for users returned by CEL evaluations.
  - User IDs and usernames remain available, while email addresses, full names, and authentication-service details are filtered according to privacy settings.
  - System administrators retain access to permitted profile information.
  - Authentication data is consistently excluded from returned user profiles.
  - Improved handling of evaluations involving unavailable users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->