### PR TITLE
Update admin configuration load and save handling

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -83,6 +83,7 @@ type MCPClientManager interface {
 type ConfigStore interface {
 	GetConfig() (*config.Config, error)
 	SaveConfig(cfg config.Config) error
+	UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error)
 }
 
 // AgentStore provides CRUD access to user-created agents in the database.

--- a/api/api_admin.go
+++ b/api/api_admin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/audit"
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost-plugin-agents/v2/indexer"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mmapi"
@@ -532,10 +533,24 @@ type UpdatePluginServerRequest struct {
 	ToolConfigs *[]mcp.ToolConfig `json:"tool_configs,omitempty"`
 }
 
+func mergePluginServerUpdate(live mcp.PluginServerConfig, persisted *mcp.PluginServerConfig, req UpdatePluginServerRequest) mcp.PluginServerConfig {
+	effective := live
+	if persisted != nil {
+		effective.Enabled = persisted.Enabled
+		effective.ToolConfigs = persisted.ToolConfigs
+	}
+	if req.Enabled != nil {
+		effective.Enabled = *req.Enabled
+	}
+	if req.ToolConfigs != nil {
+		effective.ToolConfigs = *req.ToolConfigs
+	}
+	return effective
+}
+
 // handleUpdatePluginServer updates admin-owned fields (Enabled, ToolConfigs) on
 // a registered plugin MCP server; PluginID, Name, Path, and ExposeExternal
-// remain owned by the source plugin. The full registry snapshot is captured
-// before configUpdater.Update to avoid re-entrant pluginServersMu locking.
+// remain owned by the source plugin.
 func (a *API) handleUpdatePluginServer(c *gin.Context) {
 	pluginID := c.Param("pluginID")
 	if pluginID == "" {
@@ -561,51 +576,49 @@ func (a *API) handleUpdatePluginServer(c *gin.Context) {
 		return
 	}
 
-	updated := live
-	if req.Enabled != nil {
-		updated.Enabled = *req.Enabled
-	}
-	if req.ToolConfigs != nil {
-		updated.ToolConfigs = *req.ToolConfigs
-	}
+	// Give failure records the requested result when persistence cannot run.
+	// A successful atomic merge replaces this with the exact saved value below.
+	audit.AddParam(auditRec(c), "enabled", mergePluginServerUpdate(live, nil, req).Enabled)
 
-	// Effective final value after partial-update merge, not the raw request.
-	audit.AddParam(auditRec(c), "enabled", updated.Enabled)
-
-	existing, getErr := a.configStore.GetConfig()
-	if getErr != nil {
-		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to load config for plugin-server save: %w", getErr))
-		return
-	}
-	if existing == nil {
-		c.AbortWithError(http.StatusInternalServerError, errors.New("no plugin configuration available"))
-		return
-	}
-	// Clone to avoid mutating the store's cached pointer.
-	cfg := existing.Clone()
-
-	// Merge by PluginID against the persisted list rather than overwriting
-	// with the in-memory snapshot, which would silently drop entries for
-	// plugins that are persisted but currently inactive in memory.
-	merged := append([]mcp.PluginServerConfig(nil), cfg.MCP.PluginServers...)
-	mergedIdx := -1
-	for i := range merged {
-		if merged[i].PluginID == updated.PluginID {
-			mergedIdx = i
-			break
+	var effective mcp.PluginServerConfig
+	saved, err := a.configStore.UpdateConfig(func(existing *config.Config) (config.Config, error) {
+		if existing == nil {
+			return config.Config{}, errors.New("no plugin configuration available")
 		}
-	}
-	if mergedIdx >= 0 {
-		merged[mergedIdx] = updated
-	} else {
-		merged = append(merged, updated)
-	}
-	cfg.MCP.PluginServers = merged
 
-	if err := a.configStore.SaveConfig(*cfg); err != nil {
+		// Clone to avoid mutating the store's cached pointer.
+		cfg := existing.Clone()
+
+		// Merge by PluginID against the persisted list rather than overwriting
+		// with the in-memory snapshot, which would silently drop entries for
+		// plugins that are persisted but currently inactive in memory.
+		merged := append([]mcp.PluginServerConfig(nil), cfg.MCP.PluginServers...)
+		mergedIdx := -1
+		for i := range merged {
+			if merged[i].PluginID == live.PluginID {
+				mergedIdx = i
+				break
+			}
+		}
+		if mergedIdx >= 0 {
+			effective = mergePluginServerUpdate(live, &merged[mergedIdx], req)
+			merged[mergedIdx] = effective
+		} else {
+			effective = mergePluginServerUpdate(live, nil, req)
+			merged = append(merged, effective)
+		}
+		cfg.MCP.PluginServers = merged
+
+		return *cfg, nil
+	})
+	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to save plugin-server config: %w", err))
 		return
 	}
+
+	// Effective final value after the atomic partial-update merge, not the raw
+	// request or the pre-lock live snapshot.
+	audit.AddParam(auditRec(c), "enabled", effective.Enabled)
 
 	// The mutation is persisted from here on; a later cluster-notify failure
 	// yields a fail record for a change that actually landed — say so.
@@ -616,16 +629,14 @@ func (a *API) handleUpdatePluginServer(c *gin.Context) {
 		return
 	}
 
-	a.mcpClientManager.UpdatePluginServer(updated)
-	a.configUpdater.Update(cfg)
+	a.mcpClientManager.UpdatePluginServer(effective)
+	a.configUpdater.Update(&saved)
 
-	// Rebuild when either old or new state was external so removed tools
-	// disappear from the aggregate server.
-	if updated.ExposeExternal || live.ExposeExternal {
+	if effective.ExposeExternal {
 		if rb := a.resolveExternalServerRebuilder(); rb != nil {
 			rb.RebuildExternalServer()
 		}
 	}
 
-	c.JSON(http.StatusOK, updated)
+	c.JSON(http.StatusOK, effective)
 }

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ func setupAdminTestEnvironment(t *testing.T) (*API, *plugintest.API, *adminTestS
 	gin.DefaultWriter = io.Discard
 
 	mockAPI := &plugintest.API{}
+	mockAPI.On("LogAuditRec", mock.Anything).Maybe()
 	client := pluginapi.NewClient(mockAPI, nil)
 
 	cfg := &testConfigImpl{}
@@ -839,6 +841,41 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "partial update combines live source fields with persisted admin fields",
+			preRegistered: []mcp.PluginServerConfig{
+				{
+					PluginID: "com.mattermost.demo", Name: "Current name", Path: "/current",
+					Enabled: false, ExposeExternal: true,
+				},
+			},
+			seededPersisted: []config.PluginServerConfig{
+				{
+					PluginID: "com.mattermost.demo", Name: "Old name", Path: "/old",
+					Enabled: true, ExposeExternal: false,
+					ToolConfigs: []config.MCPToolConfig{
+						{Name: "existing", Policy: config.MCPToolPolicyAsk, Enabled: true},
+					},
+				},
+			},
+			body:                  `{"tool_configs": [{"name": "replacement", "policy": "ask", "enabled": false}]}`,
+			expectStatus:          http.StatusOK,
+			expectSaveCalls:       1,
+			expectUpdateCalls:     1,
+			expectPublishCalls:    1,
+			expectRegistryCalls:   1,
+			expectUnregisterCalls: 0,
+			assertPersistedState: func(t *testing.T, savedCfg *config.Config) {
+				require.Len(t, savedCfg.MCP.PluginServers, 1)
+				updated := savedCfg.MCP.PluginServers[0]
+				assert.Equal(t, "Current name", updated.Name)
+				assert.Equal(t, "/current", updated.Path)
+				assert.True(t, updated.ExposeExternal)
+				assert.True(t, updated.Enabled)
+				require.Len(t, updated.ToolConfigs, 1)
+				assert.Equal(t, "replacement", updated.ToolConfigs[0].Name)
+			},
+		},
+		{
 			// Regression for MM-68980: admin updates one plugin while another
 			// plugin (with admin-customized config) is currently inactive in
 			// memory. The persisted entry for the inactive plugin must
@@ -896,7 +933,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "GetConfig failure returns 500 and skips Save/Update/Publish",
+			name: "active config read failure returns 500 and skips side effects",
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
@@ -910,7 +947,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectUnregisterCalls: 0,
 		},
 		{
-			name: "SaveConfig failure returns 500 and skips Update/Publish",
+			name: "config persistence failure returns 500 and skips side effects",
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
@@ -924,7 +961,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			expectUnregisterCalls: 0,
 		},
 		{
-			name: "PublishConfigUpdate failure returns 500 after Save and skips Update",
+			name: "cluster notification failure returns 500 after persistence",
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
@@ -941,7 +978,7 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			// A nil persisted config must not be silently replaced by a
 			// zero-value baseline; doing so would clobber unrelated settings
 			// (services, bots, MCP flags) on the next save.
-			name: "nil persisted config returns 500 and skips Save/Update/Publish/Register",
+			name: "nil persisted config returns 500 and skips side effects",
 			preRegistered: []mcp.PluginServerConfig{{
 				PluginID: "com.mattermost.demo", Name: "Demo", Path: "/mcp", Enabled: true,
 			}},
@@ -1001,6 +1038,9 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 
 			if tt.getErr != nil || tt.saveErr != nil {
 				require.Equal(t, tt.expectSaveCalls, failingStore.saveCallCount)
+				require.Equal(t, 1, failingStore.updateCallCount)
+			} else {
+				require.Equal(t, 1, stores.configStore.updateCallCount)
 			}
 			require.Equal(t, tt.expectUpdateCalls, stores.configUpdater.callCount)
 			require.Equal(t, tt.expectPublishCalls, stores.clusterNotifier.callCount)
@@ -1010,19 +1050,158 @@ func TestHandleUpdatePluginServer_PersistsToConfig(t *testing.T) {
 			require.Len(t, mgr.unregisterCalls, tt.expectUnregisterCalls, "live plugin registry must not be mutated on failure paths")
 
 			if tt.assertPersistedState != nil {
-				require.NotNil(t, stores.configStore.cfg, "SaveConfig must have been called and persisted cfg")
+				require.NotNil(t, stores.configStore.cfg, "UpdateConfig must have persisted cfg")
 				tt.assertPersistedState(t, stores.configStore.cfg)
+			}
+			if tt.expectStatus == http.StatusOK {
+				require.Equal(t, stores.configStore.cfg, stores.configUpdater.lastUpdate)
 			}
 		})
 	}
 }
 
-// failingConfigStore is a testConfigStore variant with configurable error injection on Get/Save.
+func TestHandleUpdatePluginServer_ConcurrentPartialUpdates(t *testing.T) {
+	api, mockAPI, _ := setupAdminTestEnvironment(t)
+	defer mockAPI.AssertExpectations(t)
+
+	mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return().Maybe()
+
+	initial := mcp.PluginServerConfig{
+		PluginID: "com.mattermost.demo",
+		Name:     "Demo",
+		Path:     "/mcp",
+		Enabled:  false,
+	}
+	mgr := api.mcpClientManager.(*mockMCPClientManager)
+	mgr.pluginServers = []mcp.PluginServerConfig{initial}
+
+	store := newControlledPluginServerConfigStore(config.Config{
+		MCP: config.MCPConfig{PluginServers: []config.PluginServerConfig{initial}},
+	})
+	api.configStore = store
+
+	type result struct {
+		status int
+		body   []byte
+	}
+	send := func(body string) <-chan result {
+		results := make(chan result, 1)
+		go func() {
+			req := httptest.NewRequest(http.MethodPut, "/admin/mcp/plugin-servers/com.mattermost.demo", strings.NewReader(body))
+			req.Header.Set("Mattermost-User-Id", "admin-user")
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			api.ServeHTTP(&plugin.Context{}, recorder, req)
+			results <- result{status: recorder.Code, body: recorder.Body.Bytes()}
+		}()
+		return results
+	}
+
+	enabledResult := send(`{"enabled": true}`)
+	store.waitEntered(t, 1)
+
+	toolResult := send(`{"tool_configs": [{"name": "echo", "policy": "ask", "enabled": false}]}`)
+	store.waitEntered(t, 2)
+
+	store.release(1)
+	first := <-enabledResult
+	require.Equal(t, http.StatusOK, first.status)
+
+	store.release(2)
+	second := <-toolResult
+	require.Equal(t, http.StatusOK, second.status)
+
+	var response mcp.PluginServerConfig
+	require.NoError(t, json.Unmarshal(second.body, &response))
+	assert.True(t, response.Enabled)
+	require.Len(t, response.ToolConfigs, 1)
+	assert.Equal(t, "echo", response.ToolConfigs[0].Name)
+
+	persisted := store.snapshot()
+	require.Len(t, persisted.MCP.PluginServers, 1)
+	assert.True(t, persisted.MCP.PluginServers[0].Enabled)
+	require.Len(t, persisted.MCP.PluginServers[0].ToolConfigs, 1)
+	assert.Equal(t, "echo", persisted.MCP.PluginServers[0].ToolConfigs[0].Name)
+
+	runtime, ok := mgr.GetPluginServer(initial.PluginID)
+	require.True(t, ok)
+	assert.Equal(t, persisted.MCP.PluginServers[0], runtime)
+}
+
+type controlledPluginServerConfigStore struct {
+	mu       sync.Mutex
+	cfg      config.Config
+	updates  int
+	entered  [2]chan struct{}
+	releases [2]chan struct{}
+}
+
+func newControlledPluginServerConfigStore(cfg config.Config) *controlledPluginServerConfigStore {
+	return &controlledPluginServerConfigStore{
+		cfg:      cfg,
+		entered:  [2]chan struct{}{make(chan struct{}, 1), make(chan struct{}, 1)},
+		releases: [2]chan struct{}{make(chan struct{}, 1), make(chan struct{}, 1)},
+	}
+}
+
+func (s *controlledPluginServerConfigStore) GetConfig() (*config.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg.Clone(), nil
+}
+
+func (s *controlledPluginServerConfigStore) SaveConfig(cfg config.Config) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg = *cfg.Clone()
+	return nil
+}
+
+func (s *controlledPluginServerConfigStore) UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error) {
+	s.mu.Lock()
+	stored := s.cfg.Clone()
+	saved, err := update(stored)
+	if err != nil {
+		s.mu.Unlock()
+		return config.Config{}, err
+	}
+	s.cfg = *saved.Clone()
+	s.updates++
+	call := s.updates
+	s.mu.Unlock()
+
+	s.entered[call-1] <- struct{}{}
+	<-s.releases[call-1]
+	return saved, nil
+}
+
+func (s *controlledPluginServerConfigStore) waitEntered(t *testing.T, call int) {
+	t.Helper()
+	select {
+	case <-s.entered[call-1]:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("UpdateConfig call %d did not start", call)
+	}
+}
+
+func (s *controlledPluginServerConfigStore) release(call int) {
+	s.releases[call-1] <- struct{}{}
+}
+
+func (s *controlledPluginServerConfigStore) snapshot() config.Config {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return *s.cfg.Clone()
+}
+
+// failingConfigStore supports active-read and persistence error injection.
 type failingConfigStore struct {
-	cfg           *config.Config
-	getErr        error
-	saveErr       error
-	saveCallCount int
+	cfg             *config.Config
+	getErr          error
+	saveErr         error
+	saveCallCount   int
+	updateCallCount int
 }
 
 func (s *failingConfigStore) GetConfig() (*config.Config, error) {
@@ -1037,6 +1216,21 @@ func (s *failingConfigStore) SaveConfig(cfg config.Config) error {
 	clone := cfg
 	s.cfg = &clone
 	return nil
+}
+
+func (s *failingConfigStore) UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error) {
+	s.updateCallCount++
+	if s.getErr != nil {
+		return config.Config{}, s.getErr
+	}
+	saved, err := update(s.cfg)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if err := s.SaveConfig(saved); err != nil {
+		return config.Config{}, err
+	}
+	return saved, nil
 }
 
 // setupAdminAuditTest wires the full-router environment with audit capture so

--- a/api/api_agents_test.go
+++ b/api/api_agents_test.go
@@ -63,7 +63,20 @@ func (m *mockConfigStore) GetConfig() (*config.Config, error) {
 }
 
 func (m *mockConfigStore) SaveConfig(cfg config.Config) error {
+	saved := cfg
+	m.cfg = &saved
 	return nil
+}
+
+func (m *mockConfigStore) UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error) {
+	saved, err := update(m.cfg)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if err := m.SaveConfig(saved); err != nil {
+		return config.Config{}, err
+	}
+	return saved, nil
 }
 
 // overrideLicenseMocks replaces any GetConfig/GetLicense expectations already

--- a/api/api_config.go
+++ b/api/api_config.go
@@ -15,6 +15,10 @@ import (
 )
 
 func normalizeAdminConfig(cfg config.Config) config.Config {
+	if cfg.Services != nil {
+		cfg.Services = append([]llm.ServiceConfig{}, cfg.Services...)
+	}
+
 	cfg.MCP.Enabled = true
 	cfg.MCP.EmbeddedServer.Enabled = true
 
@@ -37,7 +41,7 @@ func (a *API) handleGetConfig(c *gin.Context) {
 	}
 
 	if cfg == nil {
-		c.JSON(http.StatusOK, normalizeAdminConfig(config.Config{
+		normalized := normalizeAdminConfig(config.Config{
 			Services: []llm.ServiceConfig{},
 			Bots:     []llm.BotConfig{},
 			MCP: mcp.Config{
@@ -50,13 +54,13 @@ func (a *API) handleGetConfig(c *gin.Context) {
 			WebSearch: config.WebSearchConfig{
 				DomainDenylist: []string{},
 			},
-		}))
+		})
+		c.JSON(http.StatusOK, config.RedactSecrets(normalized))
 		return
 	}
 
-	// Clone before normalizeAdminConfig: it mutates Services (e.g. UseResponsesAPI); the store
-	// pointer may alias the in-memory cached config, and GET must not mutate shared state.
-	c.JSON(http.StatusOK, normalizeAdminConfig(*cfg.Clone()))
+	normalized := normalizeAdminConfig(*cfg)
+	c.JSON(http.StatusOK, config.RedactSecrets(normalized))
 }
 
 // handleSaveConfig saves a new plugin configuration to the database,
@@ -79,20 +83,21 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 		return
 	}
 
-	// Audit which top-level config sections change — never their values,
-	// since services/webSearch/mcp carry credentials. Best effort: a failed
-	// read of the prior config must not block the save, so the record then
-	// simply omits changed_keys.
-	if rec := auditRec(c); rec != nil {
-		if prev, err := a.configStore.GetConfig(); err == nil {
-			audit.AddParam(rec, "changed_keys", audit.ChangedJSONKeys(prev, cfg))
+	var storedForAudit *config.Config
+	saved, err := a.configStore.UpdateConfig(func(stored *config.Config) (config.Config, error) {
+		storedForAudit = stored
+		if stored == nil {
+			return config.RestoreSecrets(cfg, config.Config{}), nil
 		}
-	}
-
-	if err := a.configStore.SaveConfig(cfg); err != nil {
+		return config.RestoreSecrets(cfg, *stored), nil
+	})
+	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to save config: %w", err))
 		return
 	}
+
+	// Audit which top-level config sections changed, never their values.
+	audit.AddParam(auditRec(c), "changed_keys", audit.ChangedJSONKeys(storedForAudit, saved))
 
 	// From here on the config HAS changed in the database. If a later step
 	// fails (cluster notify), the audit record's fail status would otherwise
@@ -100,7 +105,7 @@ func (a *API) handleSaveConfig(c *gin.Context) {
 	audit.AddParam(auditRec(c), "persisted", true)
 
 	// Update in-memory config on this node
-	a.configUpdater.Update(&cfg)
+	a.configUpdater.Update(&saved)
 
 	// Notify other cluster nodes to reload config from DB
 	if err := a.clusterNotifier.PublishConfigUpdate(); err != nil {

--- a/api/api_config_secrets_test.go
+++ b/api/api_config_secrets_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost-plugin-agents/v2/embeddings"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGetConfigWithInvalidEmbeddingParameters(t *testing.T) {
+	stored := &config.Config{
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{
+				Parameters: json.RawMessage(`{"apiKey":"stored-value`),
+			},
+		},
+	}
+	store := &testConfigStore{cfg: stored}
+	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/config", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "stored-value")
+
+	var out config.Config
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.JSONEq(t, "null", string(out.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+	assert.Equal(t, `{"apiKey":"stored-value`, string(store.cfg.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+}
+
+func TestHandleSaveConfigRestoresRedactedValues(t *testing.T) {
+	store := &testConfigStore{}
+	router := setupTestRouter(store, &testConfigUpdater{}, &testClusterNotifier{})
+
+	putConfig := func(cfg config.Config) {
+		t.Helper()
+		body, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPut, "/admin/config", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+	getConfig := func() config.Config {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/admin/config", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var cfg config.Config
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cfg))
+		return cfg
+	}
+
+	putConfig(config.Config{
+		Services: []llm.ServiceConfig{{
+			ID:     "service-1",
+			Type:   llm.ServiceTypeOpenAI,
+			APIKey: "initial-service-value",
+		}},
+	})
+
+	redacted := getConfig()
+	require.Len(t, redacted.Services, 1)
+	require.Equal(t, config.FakeSetting, redacted.Services[0].APIKey)
+
+	putConfig(redacted)
+	require.NotNil(t, store.cfg)
+	require.Equal(t, "initial-service-value", store.cfg.Services[0].APIKey)
+
+	redacted.Services[0].APIKey = ""
+	putConfig(redacted)
+	require.Empty(t, store.cfg.Services[0].APIKey)
+
+	redacted.Services[0].APIKey = "replacement-service-value"
+	putConfig(redacted)
+	require.Equal(t, "replacement-service-value", store.cfg.Services[0].APIKey)
+}

--- a/api/api_config_test.go
+++ b/api/api_config_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
+	"github.com/mattermost/mattermost-plugin-agents/v2/embeddings"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
 	"github.com/stretchr/testify/assert"
@@ -21,9 +22,12 @@ import (
 
 // testConfigStore is a simple in-memory implementation of ConfigStore for testing.
 type testConfigStore struct {
-	cfg     *config.Config
-	getErr  error
-	saveErr error
+	cfg             *config.Config
+	getErr          error
+	saveErr         error
+	updateErr       error
+	saveCallCount   int
+	updateCallCount int
 }
 
 func (s *testConfigStore) GetConfig() (*config.Config, error) {
@@ -34,12 +38,35 @@ func (s *testConfigStore) GetConfig() (*config.Config, error) {
 }
 
 func (s *testConfigStore) SaveConfig(cfg config.Config) error {
+	s.saveCallCount++
 	if s.saveErr != nil {
 		return s.saveErr
 	}
 	clone := cfg
 	s.cfg = &clone
 	return nil
+}
+
+func (s *testConfigStore) UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error) {
+	s.updateCallCount++
+	if s.getErr != nil {
+		return config.Config{}, s.getErr
+	}
+
+	saved, err := update(s.cfg)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if s.updateErr != nil {
+		return config.Config{}, s.updateErr
+	}
+	if s.saveErr != nil {
+		return config.Config{}, s.saveErr
+	}
+
+	clone := saved
+	s.cfg = &clone
+	return saved, nil
 }
 
 // testConfigUpdater tracks whether Update was called and with what config.
@@ -137,9 +164,10 @@ func TestHandleGetConfig(t *testing.T) {
 				DefaultBotName: "ai",
 				Services: []llm.ServiceConfig{
 					{
-						ID:   "svc-1",
-						Name: "OpenAI",
-						Type: "openai",
+						ID:     "svc-1",
+						Name:   "OpenAI",
+						Type:   "openai",
+						APIKey: "stored-service-value",
 					},
 				},
 				Bots: []llm.BotConfig{
@@ -159,6 +187,8 @@ func TestHandleGetConfig(t *testing.T) {
 				require.Len(t, cfg.Services, 1)
 				assert.Equal(t, "svc-1", cfg.Services[0].ID)
 				assert.Equal(t, "openai", cfg.Services[0].Type)
+				assert.Equal(t, config.FakeSetting, cfg.Services[0].APIKey)
+				assert.NotContains(t, string(body), "stored-service-value")
 				require.Len(t, cfg.Bots, 1)
 				assert.Equal(t, "bot-1", cfg.Bots[0].ID)
 				assert.Equal(t, "svc-1", cfg.Bots[0].ServiceID)
@@ -191,7 +221,7 @@ func TestHandleGetConfigDoesNotMutateStoredServices(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	stored := &config.Config{
 		Services: []llm.ServiceConfig{
-			{ID: "svc-1", Type: llm.ServiceTypeOpenAI, UseResponsesAPI: false},
+			{ID: "svc-1", Type: llm.ServiceTypeOpenAI, APIKey: "stored-service-value", UseResponsesAPI: false},
 		},
 	}
 	store := &testConfigStore{cfg: stored}
@@ -203,23 +233,64 @@ func TestHandleGetConfigDoesNotMutateStoredServices(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.False(t, store.cfg.Services[0].UseResponsesAPI, "GET must not mutate stored config backing array")
+	assert.Equal(t, "stored-service-value", store.cfg.Services[0].APIKey)
 
 	var out config.Config
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
 	require.Len(t, out.Services, 1)
 	assert.True(t, out.Services[0].UseResponsesAPI)
+	assert.Equal(t, config.FakeSetting, out.Services[0].APIKey)
+}
+
+func TestNormalizeAdminConfigCopiesMutatedServices(t *testing.T) {
+	input := config.Config{
+		Services: []llm.ServiceConfig{{ID: "service-1", Type: llm.ServiceTypeOpenAI}},
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{
+				Parameters: json.RawMessage(`{"apiKey":"stored-value`),
+			},
+		},
+	}
+
+	normalized := normalizeAdminConfig(input)
+	normalized.Services[0].ID = "changed"
+
+	assert.Equal(t, "service-1", input.Services[0].ID)
+	assert.False(t, input.Services[0].UseResponsesAPI)
+	assert.False(t, input.MCP.Enabled)
+	assert.False(t, input.MCP.EmbeddedServer.Enabled)
+	assert.True(t, normalized.MCP.Enabled)
+	assert.True(t, normalized.MCP.EmbeddedServer.Enabled)
+	assert.Equal(t, `{"apiKey":"stored-value`, string(normalized.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+	assert.Equal(t, `{"apiKey":"stored-value`, string(input.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
 }
 
 func TestHandleSaveConfig(t *testing.T) {
 	tests := []struct {
 		name                  string
 		requestBody           any
+		storeUpdateErr        error
 		clusterErr            error
 		expectedStatus        int
 		validateStore         func(t *testing.T, store *testConfigStore)
 		validateUpdater       func(t *testing.T, updater *testConfigUpdater)
 		validateClusterNotify func(t *testing.T, notifier *testClusterNotifier)
 	}{
+		{
+			name:           "returns error when config update fails",
+			requestBody:    config.Config{},
+			storeUpdateErr: errors.New("update unavailable"),
+			expectedStatus: http.StatusInternalServerError,
+			validateStore: func(t *testing.T, store *testConfigStore) {
+				assert.Nil(t, store.cfg)
+			},
+			validateUpdater: func(t *testing.T, updater *testConfigUpdater) {
+				assert.Zero(t, updater.callCount)
+			},
+			validateClusterNotify: func(t *testing.T, notifier *testClusterNotifier) {
+				assert.Zero(t, notifier.callCount)
+			},
+		},
 		{
 			name: "returns error when cluster notify fails after successful save",
 			requestBody: config.Config{
@@ -390,7 +461,7 @@ func TestHandleSaveConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := &testConfigStore{}
+			store := &testConfigStore{updateErr: tt.storeUpdateErr}
 			updater := &testConfigUpdater{}
 			notifier := &testClusterNotifier{err: tt.clusterErr}
 
@@ -484,15 +555,17 @@ func TestSaveAndGetConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ai", loadedCfg.DefaultBotName)
 	require.Len(t, loadedCfg.Services, 1)
-	assert.Equal(t, "sk-test", loadedCfg.Services[0].APIKey)
+	assert.Equal(t, config.FakeSetting, loadedCfg.Services[0].APIKey)
+	assert.NotContains(t, w.Body.String(), "sk-test")
+	assert.Equal(t, "sk-test", store.cfg.Services[0].APIKey)
 	assert.True(t, loadedCfg.Services[0].UseResponsesAPI)
 	require.Len(t, loadedCfg.Bots, 1)
 	assert.Equal(t, "bot-1", loadedCfg.Bots[0].ID)
 	assert.True(t, loadedCfg.MCP.Enabled)
 	assert.True(t, loadedCfg.MCP.EmbeddedServer.Enabled)
 	require.Len(t, loadedCfg.MCP.Servers, 1)
-	assert.Equal(t, map[string]string{"X-Trace": "on"}, loadedCfg.MCP.Servers[0].Headers)
-	assert.Equal(t, map[string]string{"Authorization": "Bearer service-pat"}, loadedCfg.MCP.Servers[0].ServiceAccountHeaders)
+	assert.Equal(t, map[string]string{"X-Trace": config.FakeSetting}, loadedCfg.MCP.Servers[0].Headers)
+	assert.Equal(t, map[string]string{"Authorization": config.FakeSetting}, loadedCfg.MCP.Servers[0].ServiceAccountHeaders)
 
 	// Step 4: Verify side effects
 	assert.Equal(t, 1, updater.callCount)

--- a/api/audit_middleware_test.go
+++ b/api/audit_middleware_test.go
@@ -129,17 +129,17 @@ func TestAuditMiddlewareSaveConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "prior-config read failure still saves and audits, omitting changed_keys",
+			name:           "prior-config read failure aborts without persistence",
 			userID:         "userid",
 			isAdmin:        true,
 			body:           requestBody,
 			getErr:         errors.New("kv read exploded"),
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusInternalServerError,
 			validateRecord: func(t *testing.T, rec *model.AuditRecord) {
-				assert.Equal(t, model.AuditStatusSuccess, rec.Status)
-				assert.NotContains(t, rec.EventData.Parameters, "changed_keys",
-					"best-effort diff must be omitted, not fabricated, when the prior config is unreadable")
-				assert.Equal(t, true, rec.EventData.Parameters["persisted"])
+				assert.Equal(t, model.AuditStatusFail, rec.Status)
+				assert.Equal(t, http.StatusInternalServerError, rec.Error.Code)
+				assert.NotContains(t, rec.EventData.Parameters, "changed_keys")
+				assert.NotContains(t, rec.EventData.Parameters, "persisted")
 			},
 		},
 		{

--- a/config/secrets.go
+++ b/config/secrets.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// FakeSetting is returned in place of a configured credential.
+const FakeSetting = model.FakeSetting
+
+var embeddingCredentialFields = []string{
+	"apiKey",
+	"awsSecretAccessKey",
+	"vertexAuthCredentials",
+}
+
+// RedactSecrets returns a copy of cfg with configured credentials replaced by
+// FakeSetting. Empty credential fields remain empty.
+func RedactSecrets(cfg Config) Config {
+	// A malformed raw provider configuration cannot be deep-copied through JSON.
+	// Replace it before cloning so callers still receive a valid, closed response.
+	if !validJSON(cfg.EmbeddingSearchConfig.EmbeddingProvider.Parameters) {
+		cfg.EmbeddingSearchConfig.EmbeddingProvider.Parameters = nil
+	}
+
+	out := *cfg.Clone()
+
+	for i := range out.Services {
+		redactServiceSecrets(&out.Services[i])
+	}
+	for i := range out.Bots {
+		if out.Bots[i].Service != nil {
+			redactServiceSecrets(out.Bots[i].Service)
+		}
+	}
+
+	out.WebSearch.Google.APIKey = redactSecret(out.WebSearch.Google.APIKey)
+	out.WebSearch.Brave.APIKey = redactSecret(out.WebSearch.Brave.APIKey)
+
+	for i := range out.MCP.Servers {
+		server := &out.MCP.Servers[i]
+		server.ClientSecret = redactSecret(server.ClientSecret)
+		redactHeaderSecrets(server.Headers)
+		redactHeaderSecrets(server.ServiceAccountHeaders)
+	}
+
+	out.EmbeddingSearchConfig.EmbeddingProvider.Parameters = redactEmbeddingSecrets(
+		out.EmbeddingSearchConfig.EmbeddingProvider.Parameters,
+	)
+
+	return out
+}
+
+// RestoreSecrets returns a copy of incoming with exact FakeSetting values
+// replaced by their stored counterparts. Other values, including empty values,
+// are preserved.
+func RestoreSecrets(incoming, stored Config) Config {
+	out := *incoming.Clone()
+
+	for i := range out.Services {
+		restoreServiceSecrets(&out.Services[i], findServiceByID(stored.Services, out.Services[i].ID))
+	}
+	for i := range out.Bots {
+		if out.Bots[i].Service == nil {
+			continue
+		}
+
+		var storedService *llm.ServiceConfig
+		if storedBot := findBotByID(stored.Bots, out.Bots[i].ID); storedBot != nil {
+			storedService = storedBot.Service
+		}
+		restoreServiceSecrets(out.Bots[i].Service, storedService)
+	}
+
+	out.WebSearch.Google.APIKey = restoreSecret(out.WebSearch.Google.APIKey, stored.WebSearch.Google.APIKey)
+	out.WebSearch.Brave.APIKey = restoreSecret(out.WebSearch.Brave.APIKey, stored.WebSearch.Brave.APIKey)
+
+	for i := range out.MCP.Servers {
+		server := &out.MCP.Servers[i]
+		storedServer := findMCPServer(stored.MCP.Servers, *server)
+		if storedServer == nil {
+			server.ClientSecret = restoreSecret(server.ClientSecret, "")
+			restoreHeaderSecrets(server.Headers, nil)
+			restoreHeaderSecrets(server.ServiceAccountHeaders, nil)
+			continue
+		}
+
+		server.ClientSecret = restoreSecret(server.ClientSecret, storedServer.ClientSecret)
+		restoreHeaderSecrets(server.Headers, storedServer.Headers)
+		restoreHeaderSecrets(server.ServiceAccountHeaders, storedServer.ServiceAccountHeaders)
+	}
+
+	out.EmbeddingSearchConfig.EmbeddingProvider.Parameters = restoreEmbeddingSecrets(
+		out.EmbeddingSearchConfig.EmbeddingProvider.Parameters,
+		stored.EmbeddingSearchConfig.EmbeddingProvider.Parameters,
+	)
+
+	return out
+}
+
+func redactSecret(value string) string {
+	if value == "" {
+		return ""
+	}
+	return FakeSetting
+}
+
+func restoreSecret(incoming, stored string) string {
+	if incoming != FakeSetting {
+		return incoming
+	}
+	return stored
+}
+
+func redactServiceSecrets(service *llm.ServiceConfig) {
+	service.APIKey = redactSecret(service.APIKey)
+	service.AWSSecretAccessKey = redactSecret(service.AWSSecretAccessKey)
+	service.VertexAuthCredentials = redactSecret(service.VertexAuthCredentials)
+}
+
+func restoreServiceSecrets(service *llm.ServiceConfig, stored *llm.ServiceConfig) {
+	if stored == nil {
+		stored = &llm.ServiceConfig{}
+	}
+	service.APIKey = restoreSecret(service.APIKey, stored.APIKey)
+	service.AWSSecretAccessKey = restoreSecret(service.AWSSecretAccessKey, stored.AWSSecretAccessKey)
+	service.VertexAuthCredentials = restoreSecret(service.VertexAuthCredentials, stored.VertexAuthCredentials)
+}
+
+func findServiceByID(services []llm.ServiceConfig, id string) *llm.ServiceConfig {
+	if id == "" {
+		return nil
+	}
+	for i := range services {
+		if services[i].ID == id {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+func findBotByID(bots []llm.BotConfig, id string) *llm.BotConfig {
+	if id == "" {
+		return nil
+	}
+	for i := range bots {
+		if bots[i].ID == id {
+			return &bots[i]
+		}
+	}
+	return nil
+}
+
+func findMCPServer(servers []MCPServerConfig, incoming MCPServerConfig) *MCPServerConfig {
+	incomingEndpoint := CanonicalMCPEndpointURL(incoming.BaseURL)
+	for i := range servers {
+		if servers[i].Name == incoming.Name && CanonicalMCPEndpointURL(servers[i].BaseURL) == incomingEndpoint {
+			return &servers[i]
+		}
+	}
+
+	if incomingEndpoint == "" {
+		return nil
+	}
+
+	var matched *MCPServerConfig
+	for i := range servers {
+		if CanonicalMCPEndpointURL(servers[i].BaseURL) == incomingEndpoint {
+			if matched != nil {
+				return nil
+			}
+			matched = &servers[i]
+		}
+	}
+	return matched
+}
+
+func redactHeaderSecrets(headers map[string]string) {
+	for key, value := range headers {
+		headers[key] = redactSecret(value)
+	}
+}
+
+func restoreHeaderSecrets(incoming, stored map[string]string) {
+	for key, value := range incoming {
+		incoming[key] = restoreSecret(value, stored[key])
+	}
+}
+
+func validJSON(raw json.RawMessage) bool {
+	return len(raw) == 0 || json.Valid(raw)
+}
+
+func redactEmbeddingSecrets(raw json.RawMessage) json.RawMessage {
+	params, ok := decodeParameters(raw)
+	if !ok {
+		return nil
+	}
+
+	for _, field := range embeddingCredentialFields {
+		value, present := params[field]
+		if !present || isExplicitEmptyString(value) {
+			continue
+		}
+		params[field] = mustMarshalString(FakeSetting)
+	}
+
+	return encodeParameters(params)
+}
+
+func restoreEmbeddingSecrets(incoming, stored json.RawMessage) json.RawMessage {
+	params, ok := decodeParameters(incoming)
+	if !ok {
+		return nil
+	}
+	storedParams, _ := decodeParameters(stored)
+
+	changed := false
+	for _, field := range embeddingCredentialFields {
+		value, ok := parameterString(params, field)
+		if !ok || value != FakeSetting {
+			continue
+		}
+
+		storedValue, ok := storedParams[field]
+		if !ok {
+			storedValue = mustMarshalString("")
+		}
+		params[field] = storedValue
+		changed = true
+	}
+	if !changed {
+		return incoming
+	}
+
+	return encodeParameters(params)
+}
+
+func decodeParameters(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, true
+	}
+
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, false
+	}
+	return params, true
+}
+
+func parameterString(params map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := params[key]
+	if !ok {
+		return "", false
+	}
+
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func isExplicitEmptyString(raw json.RawMessage) bool {
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return false
+	}
+	stringValue, ok := value.(string)
+	return ok && stringValue == ""
+}
+
+func mustMarshalString(value string) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func encodeParameters(params map[string]json.RawMessage) json.RawMessage {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+	return raw
+}

--- a/config/secrets_test.go
+++ b/config/secrets_test.go
@@ -1,0 +1,431 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/embeddings"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSecrets(t *testing.T) {
+	stored := Config{
+		Services: []llm.ServiceConfig{{
+			ID:                    "service-1",
+			Name:                  "provider",
+			APIKey:                "service-api-key",
+			AWSAccessKeyID:        "access-key-id",
+			AWSSecretAccessKey:    "service-aws-secret",
+			VertexAuthCredentials: "service-vertex-credentials",
+		}},
+		Bots: []llm.BotConfig{{
+			ID: "bot-1",
+			Service: &llm.ServiceConfig{
+				ID:                    "embedded-service",
+				APIKey:                "embedded-api-key",
+				AWSSecretAccessKey:    "embedded-aws-secret",
+				VertexAuthCredentials: "embedded-vertex-credentials",
+			},
+		}},
+		WebSearch: WebSearchConfig{
+			Google: WebSearchGoogleConfig{APIKey: "google-api-key", SearchEngineID: "engine-1"},
+			Brave:  WebSearchBraveConfig{APIKey: "brave-api-key"},
+		},
+		MCP: MCPConfig{Servers: []MCPServerConfig{{
+			Name:                  "server-1",
+			BaseURL:               "https://mcp.example.com",
+			ClientID:              "client-id",
+			ClientSecret:          "client-secret",
+			Headers:               map[string]string{"Authorization": "header-secret", "Empty": ""},
+			ServiceAccountHeaders: map[string]string{"X-Service-Key": "service-header-secret"},
+		}}},
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{
+				Parameters: json.RawMessage(`{
+					"apiKey":"embedding-api-key",
+					"awsSecretAccessKey":"embedding-aws-secret",
+					"vertexAuthCredentials":"embedding-vertex-credentials",
+					"embeddingModel":"model-1",
+					"options":{"dimensions":1536}
+				}`),
+			},
+		},
+		DefaultBotName: "bot-1",
+	}
+
+	redacted := RedactSecrets(stored)
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "service api key", got: redacted.Services[0].APIKey, want: FakeSetting},
+		{name: "service aws secret", got: redacted.Services[0].AWSSecretAccessKey, want: FakeSetting},
+		{name: "service vertex credentials", got: redacted.Services[0].VertexAuthCredentials, want: FakeSetting},
+		{name: "embedded service api key", got: redacted.Bots[0].Service.APIKey, want: FakeSetting},
+		{name: "embedded service aws secret", got: redacted.Bots[0].Service.AWSSecretAccessKey, want: FakeSetting},
+		{name: "embedded service vertex credentials", got: redacted.Bots[0].Service.VertexAuthCredentials, want: FakeSetting},
+		{name: "google api key", got: redacted.WebSearch.Google.APIKey, want: FakeSetting},
+		{name: "brave api key", got: redacted.WebSearch.Brave.APIKey, want: FakeSetting},
+		{name: "mcp client secret", got: redacted.MCP.Servers[0].ClientSecret, want: FakeSetting},
+		{name: "mcp header", got: redacted.MCP.Servers[0].Headers["Authorization"], want: FakeSetting},
+		{name: "empty mcp header", got: redacted.MCP.Servers[0].Headers["Empty"], want: ""},
+		{name: "mcp service account header", got: redacted.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"], want: FakeSetting},
+		{name: "aws access key id is unchanged", got: redacted.Services[0].AWSAccessKeyID, want: "access-key-id"},
+		{name: "mcp client id is unchanged", got: redacted.MCP.Servers[0].ClientID, want: "client-id"},
+		{name: "non-secret field is unchanged", got: redacted.DefaultBotName, want: "bot-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+
+	var params map[string]any
+	require.NoError(t, json.Unmarshal(redacted.EmbeddingSearchConfig.EmbeddingProvider.Parameters, &params))
+	assert.Equal(t, FakeSetting, params["apiKey"])
+	assert.Equal(t, FakeSetting, params["awsSecretAccessKey"])
+	assert.Equal(t, FakeSetting, params["vertexAuthCredentials"])
+	assert.Equal(t, "model-1", params["embeddingModel"])
+	assert.Equal(t, map[string]any{"dimensions": float64(1536)}, params["options"])
+
+	t.Run("does not mutate or alias input", func(t *testing.T) {
+		redacted.Services[0].Name = "changed"
+		redacted.Bots[0].Service.ID = "changed"
+		redacted.MCP.Servers[0].Headers["Authorization"] = "changed"
+		redacted.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"] = "changed"
+
+		assert.Equal(t, "provider", stored.Services[0].Name)
+		assert.Equal(t, "embedded-service", stored.Bots[0].Service.ID)
+		assert.Equal(t, "header-secret", stored.MCP.Servers[0].Headers["Authorization"])
+		assert.Equal(t, "service-header-secret", stored.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"])
+		assert.Contains(t, string(stored.EmbeddingSearchConfig.EmbeddingProvider.Parameters), "embedding-api-key")
+	})
+}
+
+func TestRedactSecretsInvalidEmbeddingParameters(t *testing.T) {
+	cfg := Config{
+		DefaultBotName: "bot-1",
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{
+				Parameters: json.RawMessage(`{"apiKey":"stored-value`),
+			},
+		},
+	}
+
+	redacted := RedactSecrets(cfg)
+	assert.Equal(t, "bot-1", redacted.DefaultBotName)
+	assert.JSONEq(t, "null", string(redacted.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+}
+
+func TestEmbeddingNonStringCredentials(t *testing.T) {
+	parameters := json.RawMessage(`{
+		"apiKey":{"privateObject":"value"},
+		"awsSecretAccessKey":{"privateObject":"value"},
+		"vertexAuthCredentials":{"privateObject":"value"},
+		"embeddingModel":"model-visible"
+	}`)
+	stored := Config{
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{Parameters: parameters},
+		},
+	}
+
+	redacted := RedactSecrets(stored)
+	var params map[string]any
+	require.NoError(t, json.Unmarshal(redacted.EmbeddingSearchConfig.EmbeddingProvider.Parameters, &params))
+	for _, field := range embeddingCredentialFields {
+		assert.Equal(t, FakeSetting, params[field])
+	}
+	assert.Equal(t, "model-visible", params["embeddingModel"])
+	assert.NotContains(t, string(redacted.EmbeddingSearchConfig.EmbeddingProvider.Parameters), "privateObject")
+
+	restored := RestoreSecrets(redacted, stored)
+	assert.JSONEq(t, string(parameters), string(restored.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+	assert.JSONEq(t, string(parameters), string(stored.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+
+	t.Run("explicit empty strings remain empty", func(t *testing.T) {
+		emptyParameters := json.RawMessage(`{"apiKey":"","awsSecretAccessKey":"","vertexAuthCredentials":""}`)
+		emptyStored := Config{
+			EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+				EmbeddingProvider: embeddings.UpstreamConfig{Parameters: emptyParameters},
+			},
+		}
+
+		assert.JSONEq(t, string(emptyParameters), string(RedactSecrets(emptyStored).EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+	})
+
+	t.Run("incoming non-placeholder remains incoming", func(t *testing.T) {
+		incomingParameters := json.RawMessage(`{"apiKey":{"incoming":"value"}}`)
+		incoming := Config{
+			EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+				EmbeddingProvider: embeddings.UpstreamConfig{Parameters: incomingParameters},
+			},
+		}
+
+		restoredIncoming := RestoreSecrets(incoming, stored)
+		assert.JSONEq(t, string(incomingParameters), string(restoredIncoming.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+	})
+}
+
+func TestRestoreSecrets(t *testing.T) {
+	storedConfig := func() Config {
+		return Config{
+			Services: []llm.ServiceConfig{{
+				ID:                    "service-1",
+				APIKey:                "stored-api-key",
+				AWSSecretAccessKey:    "stored-aws-secret",
+				VertexAuthCredentials: "stored-vertex-credentials",
+			}},
+			Bots: []llm.BotConfig{{
+				ID: "bot-1",
+				Service: &llm.ServiceConfig{
+					APIKey:                "stored-embedded-api-key",
+					AWSSecretAccessKey:    "stored-embedded-aws-secret",
+					VertexAuthCredentials: "stored-embedded-vertex-credentials",
+				},
+			}},
+			WebSearch: WebSearchConfig{
+				Google: WebSearchGoogleConfig{APIKey: "stored-google-key"},
+				Brave:  WebSearchBraveConfig{APIKey: "stored-brave-key"},
+			},
+			MCP: MCPConfig{Servers: []MCPServerConfig{{
+				Name:                  "server-1",
+				ClientSecret:          "stored-client-secret",
+				Headers:               map[string]string{"Authorization": "stored-header", "Removed": "removed-header"},
+				ServiceAccountHeaders: map[string]string{"X-Service-Key": "stored-service-header", "Removed-Service": "removed-service-header"},
+			}}},
+		}
+	}
+
+	t.Run("placeholders restore the secret inventory", func(t *testing.T) {
+		stored := storedConfig()
+		incoming := *stored.Clone()
+		incoming.Services[0].APIKey = FakeSetting
+		incoming.Services[0].AWSSecretAccessKey = FakeSetting
+		incoming.Services[0].VertexAuthCredentials = FakeSetting
+		incoming.Bots[0].Service.APIKey = FakeSetting
+		incoming.Bots[0].Service.AWSSecretAccessKey = FakeSetting
+		incoming.Bots[0].Service.VertexAuthCredentials = FakeSetting
+		incoming.WebSearch.Google.APIKey = FakeSetting
+		incoming.WebSearch.Brave.APIKey = FakeSetting
+		incoming.MCP.Servers[0].ClientSecret = FakeSetting
+		incoming.MCP.Servers[0].Headers["Authorization"] = FakeSetting
+		incoming.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"] = FakeSetting
+
+		restored := RestoreSecrets(incoming, stored)
+
+		assert.Equal(t, stored.Services[0].APIKey, restored.Services[0].APIKey)
+		assert.Equal(t, stored.Services[0].AWSSecretAccessKey, restored.Services[0].AWSSecretAccessKey)
+		assert.Equal(t, stored.Services[0].VertexAuthCredentials, restored.Services[0].VertexAuthCredentials)
+		assert.Equal(t, stored.Bots[0].Service.APIKey, restored.Bots[0].Service.APIKey)
+		assert.Equal(t, stored.Bots[0].Service.AWSSecretAccessKey, restored.Bots[0].Service.AWSSecretAccessKey)
+		assert.Equal(t, stored.Bots[0].Service.VertexAuthCredentials, restored.Bots[0].Service.VertexAuthCredentials)
+		assert.Equal(t, stored.WebSearch.Google.APIKey, restored.WebSearch.Google.APIKey)
+		assert.Equal(t, stored.WebSearch.Brave.APIKey, restored.WebSearch.Brave.APIKey)
+		assert.Equal(t, stored.MCP.Servers[0].ClientSecret, restored.MCP.Servers[0].ClientSecret)
+		assert.Equal(t, stored.MCP.Servers[0].Headers["Authorization"], restored.MCP.Servers[0].Headers["Authorization"])
+		assert.Equal(t, stored.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"], restored.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"])
+	})
+
+	cases := []struct {
+		name     string
+		incoming string
+		want     string
+	}{
+		{name: "placeholder restores", incoming: FakeSetting, want: "stored-api-key"},
+		{name: "empty clears", incoming: "", want: ""},
+		{name: "new value replaces", incoming: "replacement", want: "replacement"},
+		{name: "other asterisks replace", incoming: "********", want: "********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stored := storedConfig()
+			incoming := *stored.Clone()
+			incoming.Services[0].APIKey = tc.incoming
+
+			restored := RestoreSecrets(incoming, stored)
+
+			assert.Equal(t, tc.want, restored.Services[0].APIKey)
+			assert.Equal(t, tc.incoming, incoming.Services[0].APIKey, "incoming must remain unchanged")
+		})
+	}
+
+	t.Run("new objects cannot inherit stored values", func(t *testing.T) {
+		stored := storedConfig()
+		incoming := Config{
+			Services: []llm.ServiceConfig{{ID: "service-new", APIKey: FakeSetting}},
+			Bots:     []llm.BotConfig{{ID: "bot-new", Service: &llm.ServiceConfig{APIKey: FakeSetting}}},
+			MCP: MCPConfig{Servers: []MCPServerConfig{{
+				Name:                  "server-new",
+				ClientSecret:          FakeSetting,
+				Headers:               map[string]string{"Authorization": FakeSetting},
+				ServiceAccountHeaders: map[string]string{"X-Service-Key": FakeSetting},
+			}}},
+		}
+
+		restored := RestoreSecrets(incoming, stored)
+
+		assert.Empty(t, restored.Services[0].APIKey)
+		assert.Empty(t, restored.Bots[0].Service.APIKey)
+		assert.Empty(t, restored.MCP.Servers[0].ClientSecret)
+		assert.Empty(t, restored.MCP.Servers[0].Headers["Authorization"])
+		assert.Empty(t, restored.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"])
+	})
+
+	t.Run("header maps restore by key", func(t *testing.T) {
+		stored := storedConfig()
+		incoming := *stored.Clone()
+		incoming.MCP.Servers[0].Headers = map[string]string{
+			"Authorization": FakeSetting,
+			"New":           "new-header",
+		}
+		incoming.MCP.Servers[0].ServiceAccountHeaders = map[string]string{
+			"X-Service-Key": FakeSetting,
+			"New-Service":   "new-service-header",
+		}
+
+		restored := RestoreSecrets(incoming, stored)
+
+		assert.Equal(t, map[string]string{
+			"Authorization": "stored-header",
+			"New":           "new-header",
+		}, restored.MCP.Servers[0].Headers)
+		assert.NotContains(t, restored.MCP.Servers[0].Headers, "Removed")
+		assert.Equal(t, map[string]string{
+			"X-Service-Key": "stored-service-header",
+			"New-Service":   "new-service-header",
+		}, restored.MCP.Servers[0].ServiceAccountHeaders)
+		assert.NotContains(t, restored.MCP.Servers[0].ServiceAccountHeaders, "Removed-Service")
+	})
+
+	t.Run("mcp server match follows endpoint", func(t *testing.T) {
+		stored := storedConfig()
+		stored.MCP.Servers[0].BaseURL = "https://mcp.example.com"
+
+		placeholderServer := func(name, baseURL string) MCPServerConfig {
+			return MCPServerConfig{
+				Name:                  name,
+				BaseURL:               baseURL,
+				ClientSecret:          FakeSetting,
+				Headers:               map[string]string{"Authorization": FakeSetting},
+				ServiceAccountHeaders: map[string]string{"X-Service-Key": FakeSetting},
+			}
+		}
+
+		tests := []struct {
+			name   string
+			server MCPServerConfig
+			secret string
+			header string
+			svcHdr string
+		}{
+			{name: "same server", server: placeholderServer("server-1", "https://mcp.example.com"), secret: "stored-client-secret", header: "stored-header", svcHdr: "stored-service-header"},
+			{name: "renamed server at equivalent endpoint", server: placeholderServer("server-renamed", " HTTPS://MCP.EXAMPLE.COM:443/ "), secret: "stored-client-secret", header: "stored-header", svcHdr: "stored-service-header"},
+			{name: "same name at new endpoint", server: placeholderServer("server-1", "https://other.example.com")},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				incoming := Config{MCP: MCPConfig{Servers: []MCPServerConfig{tt.server}}}
+				restored := RestoreSecrets(incoming, stored)
+				assert.Equal(t, tt.secret, restored.MCP.Servers[0].ClientSecret)
+				assert.Equal(t, tt.header, restored.MCP.Servers[0].Headers["Authorization"])
+				assert.Equal(t, tt.svcHdr, restored.MCP.Servers[0].ServiceAccountHeaders["X-Service-Key"])
+			})
+		}
+
+		t.Run("same name takes priority over ambiguous canonical fallback", func(t *testing.T) {
+			stored.MCP.Servers = append(stored.MCP.Servers, MCPServerConfig{
+				Name:         "server-2",
+				BaseURL:      "https://MCP.EXAMPLE.COM:443/",
+				ClientSecret: "other-client-secret",
+			})
+
+			incoming := Config{MCP: MCPConfig{Servers: []MCPServerConfig{{
+				Name:         "server-1",
+				BaseURL:      "https://MCP.EXAMPLE.COM:443/",
+				ClientSecret: FakeSetting,
+			}}}}
+			restored := RestoreSecrets(incoming, stored)
+			assert.Equal(t, "stored-client-secret", restored.MCP.Servers[0].ClientSecret)
+
+			incoming.MCP.Servers[0].Name = "server-renamed"
+			restored = RestoreSecrets(incoming, stored)
+			assert.Empty(t, restored.MCP.Servers[0].ClientSecret)
+		})
+	})
+}
+
+func TestRestoreEmbeddingSecrets(t *testing.T) {
+	stored := Config{
+		EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+			EmbeddingProvider: embeddings.UpstreamConfig{
+				Parameters: json.RawMessage(`{
+					"apiKey":"stored-api-key",
+					"awsSecretAccessKey":"stored-aws-secret",
+					"vertexAuthCredentials":"stored-vertex-credentials",
+					"embeddingModel":"model-1"
+				}`),
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		incoming    string
+		want        string
+		emptyStored bool
+	}{
+		{
+			name: "mixed restore clear replace and keep options",
+			incoming: `{
+				"apiKey":"********************************",
+				"awsSecretAccessKey":"",
+				"vertexAuthCredentials":"replacement-vertex",
+				"embeddingModel":"model-2",
+				"options":{"dimensions":3072},
+				"unknown":"kept"
+			}`,
+			want: `{
+				"apiKey":"stored-api-key",
+				"awsSecretAccessKey":"",
+				"vertexAuthCredentials":"replacement-vertex",
+				"embeddingModel":"model-2",
+				"options":{"dimensions":3072},
+				"unknown":"kept"
+			}`,
+		},
+		{
+			name:        "new config placeholder becomes empty",
+			incoming:    `{"apiKey":"********************************","embeddingModel":"model-2"}`,
+			want:        `{"apiKey":"","embeddingModel":"model-2"}`,
+			emptyStored: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storedForCase := stored
+			if tt.emptyStored {
+				storedForCase = Config{}
+			}
+			incoming := Config{
+				EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{
+					EmbeddingProvider: embeddings.UpstreamConfig{Parameters: json.RawMessage(tt.incoming)},
+				},
+			}
+
+			restored := RestoreSecrets(incoming, storedForCase)
+
+			assert.JSONEq(t, tt.want, string(restored.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+			assert.JSONEq(t, tt.incoming, string(incoming.EmbeddingSearchConfig.EmbeddingProvider.Parameters))
+		})
+	}
+}

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -33,6 +33,8 @@ Install the plugin through the System Console by navigating to **System Console 
 
 Navigate to **System Console > Plugins > Agents** to configure plugin-wide settings such as AI services, the default bot, web search, embedding search, and MCP settings.
 
+Current plugin-wide configuration is stored in the plugin database and is read and updated through `GET` and `PUT /plugins/mattermost-ai/admin/config`. For configured credentials, `GET` returns the standard credential placeholder. In a subsequent `PUT`, the placeholder preserves the stored value, an empty string clears it, and any other value replaces it. An upgraded server may retain a legacy `PluginSettings` configuration blob in the Mattermost configuration file for compatibility. That blob is not the live configuration, and the Mattermost configuration API masks the plugin's `Config` value.
+
 Create and manage agents from the top-level **Agents** product page. If an agent selector dropdown is available in the Agents experience, use its **Manage** link to open the same page. The **AI Bots** section in the System Console links to the Agents page instead of hosting the full agent editor.
 
 ### Enable the plugin
@@ -509,47 +511,45 @@ There is no plugin-side toggle: records are always handed to the server, and per
 
 ### Backup and restore
 
-The plugin stores agent data across both plugin configuration and plugin database tables. To backup:
+The plugin stores current plugin-wide configuration and agent data in plugin-owned database tables. To back up:
 
-1. Ensure your regular Mattermost backup includes plugin configuration data.
-2. Include plugin database tables in your normal backup and restore process. In particular:
+1. Include plugin database tables in your normal backup and restore process. In particular:
+   - `Agents_ConfigHistory` for plugin-wide configuration
    - `Agents_UserAgents` for agents created or managed from the **Agents** page
    - `LLM_CustomPrompts` and `LLM_CustomPromptPins` for custom prompt templates and prompt pins
-3. For larger deployments, consider backing up indexed vector data separately.
+2. For larger deployments, consider backing up indexed vector data separately.
 
-Restoring only plugin configuration isn't sufficient to restore agents managed from the **Agents** page.
+Restoring only the legacy Mattermost `PluginSettings` data isn't sufficient to restore current plugin configuration or agents managed from the **Agents** page.
 
 ### Configuration format
 
 The plugin uses a service-based architecture:
 
-- `PluginSettings.Plugins["mattermost-ai"]["config"]` stores plugin-wide settings and AI service configurations, including `defaultBotName`
+- The active `Agents_ConfigHistory` record stores plugin-wide settings and AI service configurations, including `defaultBotName`; authorized administrators read and update it through `GET` and `PUT /plugins/mattermost-ai/admin/config`
 - Agents are stored separately in the `Agents_UserAgents` table
 
 This separation allows multiple agents to share the same LLM service configuration while keeping agent lifecycle and access data out of `config.bots`.
 
-**Configuration structure:**
+**Configuration API structure:**
 ```json
 {
-  "config": {
-    "services": [
-      {
-        "id": "550e8400-e29b-41d4-a716-446655440000",
-        "name": "OpenAI Service",
-        "type": "openai",
-        "apiKey": "sk-...",
-        "defaultModel": "gpt-4o",
-        "fallbackServiceID": "550e8400-e29b-41d4-a716-446655440001"
-      }
-    ],
-    "defaultBotName": "ai"
-  }
+  "services": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "OpenAI Service",
+      "type": "openai",
+      "apiKey": "sk-...",
+      "defaultModel": "gpt-4o",
+      "fallbackServiceID": "550e8400-e29b-41d4-a716-446655440001"
+    }
+  ],
+  "defaultBotName": "ai"
 }
 ```
 
 **Supported service types:** `openai`, `anthropic`, `azure`, `openaicompatible`, `asage`, `cohere`, `mistral`, `scale`
 
-**Legacy format:** Older configurations that stored bots in `config.bots`, or embedded service objects within bots, are migrated on plugin startup. After legacy bot migration completes, stored `config.bots` entries are removed to avoid duplicate bot registration.
+**Legacy format:** Older configurations that stored bots in `config.bots`, or embedded service objects within bots, are migrated on plugin startup. After migration completes, `config.bots` is cleared from the database-backed configuration to avoid duplicate bot registration. A legacy Mattermost `PluginSettings` blob may remain on disk for compatibility and may still contain the prior value; it is not the current configuration.
 
 ## Troubleshooting
 

--- a/docs/features/managing_agents.md
+++ b/docs/features/managing_agents.md
@@ -192,7 +192,7 @@ Existing posts that mention or were authored by the agent remain in channels wit
 
 ## Legacy bot migration
 
-Mattermost Agents V1 stored bot definitions inline in the plugin's `config.bots` array in `config.json`. V2 moves agents into the database. To make this transition automatic, the plugin runs a one-time migration on startup.
+Mattermost Agents V1 stored bot definitions inline in the plugin's `config.bots` array. V2 stores current plugin-wide configuration in `Agents_ConfigHistory`, managed through `GET` and `PUT /plugins/mattermost-ai/admin/config`, and stores agents in `Agents_UserAgents`. To make this transition automatic, the plugin runs a one-time migration on startup.
 
 ### What happens on upgrade
 
@@ -202,7 +202,9 @@ When the v2 plugin first activates against a server that previously used v1:
 2. It reads the stored config and, for each entry in `config.bots` that is not already represented in `Agents_UserAgents`, creates a new agent record. The existing Mattermost bot user account is reused; only the agent record is new.
 3. Each migrated agent is created with `AutoEnableNewMCPTools = true` so it preserves the legacy "all tools allowed" behavior. The MCP tool allowlist is not carried over from any prior gate because v1 bots had access to every MCP tool by default.
 4. Each migrated agent has an **empty `CreatorID`** and an **empty admin list**. This is what marks them as legacy. Any system administrator (`manage_system`) can edit or delete migrated agents from the Agents page.
-5. The plugin clears `config.bots` from the stored configuration to prevent duplicate bot registration on the next run, and writes `legacy_config_bots_migrated = true` to the system table so the migration does not run again.
+5. The plugin clears `config.bots` from the active `Agents_ConfigHistory` configuration to prevent duplicate bot registration on the next run, and writes `legacy_config_bots_migrated = true` to the system table so the migration does not run again.
+
+An upgraded server may retain a legacy `PluginSettings` blob in the Mattermost configuration file for compatibility, and that blob may still contain the prior `config.bots` value. It is not the live configuration. The Mattermost configuration API masks the plugin's `Config` value.
 
 ### Soft-deferred migration
 
@@ -221,10 +223,7 @@ After upgrading:
 
 1. Open the **Agents** page. Each pre-existing v1 bot should now appear as an agent row.
 2. Open **System Console > AI Bots**. You should see the **AI bot configuration has moved** notice with a link to the Agents page.
-3. Confirm in the database that `Agents_UserAgents` contains the expected number of rows and that `config.bots` is empty in the stored plugin configuration. Use:
-   ```bash
-   mmctl config get PluginSettings.Plugins.mattermost-ai.bots
-   ```
+3. Confirm that `Agents_UserAgents` contains the expected number of rows and that the current configuration returned by `GET /plugins/mattermost-ai/admin/config` no longer contains migrated `config.bots` entries. Use:
    ```sql
    SELECT COUNT(*) FROM Agents_UserAgents WHERE DeleteAt = 0;
    ```
@@ -237,7 +236,7 @@ If migration was not performed (because no `config.bots` entries existed) the fl
 
 ### Backups
 
-`Agents_UserAgents` is a plugin-owned table and is included in standard Mattermost database backups. Plain `mattermost-config.json` snapshots are no longer sufficient to restore agents — they contain only services and the default-bot setting, not agent definitions. See [Backup and restore](../admin_guide.md#backup-and-restore) for details.
+`Agents_ConfigHistory` and `Agents_UserAgents` are plugin-owned tables and are included in standard Mattermost database backups. Plain `mattermost-config.json` snapshots are not sufficient to restore current plugin-wide configuration or agents; they may contain only the legacy compatibility blob. See [Backup and restore](../admin_guide.md#backup-and-restore) for details.
 
 ## HA cluster behavior
 

--- a/docs/upgrading_to_2.0.md
+++ b/docs/upgrading_to_2.0.md
@@ -21,7 +21,7 @@ Complete every item before starting the upgrade. Do not skip the database backup
 1. **Confirm your current plugin version.** Go to **System Console > Plugin Management** and note the installed version of Mattermost AI / Mattermost Agents.
 2. **Confirm your Mattermost server version.** v2.0.0 requires Mattermost Server v10.0 or later. The optional external MCP HTTP server requires Mattermost Server v11.2 or later.
 3. **Back up the Mattermost database.** v2.0.0 runs schema migrations on first start (see [Section 4](#4-what-gets-migrated-automatically)). Some migrations are not safely reversible (see [Section 8](#8-rollback-considerations)). In particular, migration 000007 drops the legacy `LLM_PostMeta` table without migrating its contents into the new conversation-entities tables — v1.x conversation titles cannot be recovered after the upgrade except from this backup. See [Section 5](#5-breaking-changes) for the full list of v1.x data that does not survive the upgrade.
-4. **Back up `config.json`.** The legacy bot migration removes entries from stored plugin configuration after copying them into the database. Keeping a pre-upgrade copy of `config.json` is the simplest way to recover original bot definitions if you need to roll back.
+4. **Back up `config.json`.** Keep a pre-upgrade copy for rollback. The upgrade clears migrated `config.bots` entries from the database-backed configuration, but the Mattermost configuration file may retain its legacy `PluginSettings` blob for compatibility.
 5. **Verify your license is current.** Multi-agent configurations, fine-grained access controls, MCP support (remote and external MCP servers; the embedded Mattermost MCP server does not require a license), and embedding search require an Entry, Enterprise, or Enterprise Advanced license. See [License requirements](admin_guide.md#license-requirements).
 6. **Capture a list of currently configured bots.** From your existing System Console > Plugins > Agents (or AI Bots) page, note the username, display name, service binding, and access rules of each bot. After the upgrade, you can compare this list against the migrated agents on the new **Agents** product page.
 7. **Identify any external integrations that read the `LLM_PostMeta` table directly.** That table is dropped by migration 000007. To our knowledge, no documented integration depends on this table.
@@ -59,8 +59,10 @@ After the schema migrations run, the plugin performs a one-time migration of leg
     - `AdminUserIDs` cleared. Migrated agents are managed by system admins.
     - `AutoEnableNewMCPTools = true` so migrated agents preserve the v1.x behavior of having access to every MCP tool, including ones added later.
     - `MCPDynamicToolLoading = true` when the legacy bot did not explicitly store a value, so MCP tool schemas are loaded dynamically by default. Disable **Dynamic tool loading** on the agent's **MCPs** tab to expose the full MCP tool list up front.
-5. The plugin clears `config.bots` from stored configuration to prevent duplicate bot registration on subsequent restarts.
+5. The plugin clears `config.bots` from the active `Agents_ConfigHistory` configuration to prevent duplicate bot registration on subsequent restarts.
 6. The plugin sets `legacy_config_bots_migrated = true`.
+
+In v2, the active plugin-wide configuration is stored in the plugin database and is managed through `GET` and `PUT /plugins/mattermost-ai/admin/config`. An upgraded server may retain a legacy `PluginSettings` blob in the Mattermost configuration file. That blob is not the live configuration, and the Mattermost configuration API masks the plugin's `Config` value.
 
 ### 4.3 What changes in the System Console
 
@@ -80,7 +82,7 @@ The upgrade removes some v1.x data without migrating it forward. Confirm your da
 
 ### 5.1 `config.bots` is no longer the source of truth for agent definitions
 
-After the legacy bot migration runs, `config.bots` is cleared from stored plugin configuration. Editing `config.json` to add or modify agents will not have an effect — agent CRUD is now performed against `Agents_UserAgents` via the **Agents** page. Any tooling that drives agent definitions by writing to `config.bots` must be updated to call the agent API or use the **Agents** page.
+After the legacy bot migration runs, `config.bots` is cleared from the active database-backed configuration. A legacy Mattermost `PluginSettings` blob may still contain the previous value, but it is not current configuration. Editing `config.json` to add or modify agents will not have an effect — agent CRUD is now performed against `Agents_UserAgents` via the **Agents** page. Any tooling that drives agent definitions by writing to `config.bots` must be updated to call the agent API or use the **Agents** page.
 
 ### 5.2 The `LLM_PostMeta` table is dropped
 
@@ -173,7 +175,7 @@ Some v2.0.0 migrations cannot be cleanly reversed in production. Plan accordingl
 | Migration 000005 (`Agents_UserAgents` table) | Yes (drops table) | Down migration drops the table and supporting indexes. Any agents created or edited from the v2 UI between upgrade and rollback are lost. |
 | Migration 000006 (bot fields on `Agents_UserAgents`) | Yes (drops columns) | Down migration drops the added columns. |
 | Migration 000007 (`LLM_Conversations`, `LLM_Turns`, drop `LLM_PostMeta`) | **Partial** | Down migration drops `LLM_Conversations` and `LLM_Turns` and recreates an empty `LLM_PostMeta`. `LLM_PostMeta` content (v1.x conversation titles) cannot be recovered after migration 000007 drops the table — restore from backup if you need that data. |
-| Legacy bot migration (`config.bots` cleared) | **Manual** | The v2 plugin clears `config.bots` after migration. To roll back, restore the pre-upgrade `config.json` from your pre-flight backup. |
+| Legacy bot migration (`config.bots` cleared) | **Manual** | The v2 plugin clears `config.bots` from the active `Agents_ConfigHistory` configuration after migration. A legacy Mattermost `PluginSettings` blob may remain on disk. To roll back, restore the pre-upgrade database and `config.json` from your pre-flight backups. |
 
 The supported rollback path is therefore:
 

--- a/plugin.json
+++ b/plugin.json
@@ -25,7 +25,8 @@
     "settings": [
       {
         "key": "Config",
-        "type": "custom"
+        "type": "custom",
+        "secret": true
       }
     ]
   }

--- a/store/config.go
+++ b/store/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/mattermost/mattermost-plugin-agents/v2/config"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -42,34 +43,85 @@ func (s *Store) GetConfig() (*config.Config, error) {
 // The previous active config is deactivated and a new active row is inserted.
 // All prior configs are preserved with Active = false.
 func (s *Store) SaveConfig(cfg config.Config) error {
+	_, err := s.withConfigSaveLock(func(tx *sqlx.Tx) (config.Config, error) {
+		return cfg, replaceConfig(tx, cfg)
+	})
+	return err
+}
+
+// UpdateConfig atomically loads and replaces the active configuration.
+// The callback runs while the config save advisory lock is held.
+func (s *Store) UpdateConfig(update func(stored *config.Config) (config.Config, error)) (config.Config, error) {
+	return s.withConfigSaveLock(func(tx *sqlx.Tx) (config.Config, error) {
+		stored, err := getConfig(tx)
+		if err != nil {
+			return config.Config{}, err
+		}
+
+		saved, err := update(stored)
+		if err != nil {
+			return config.Config{}, fmt.Errorf("failed to update config: %w", err)
+		}
+
+		return saved, replaceConfig(tx, saved)
+	})
+}
+
+func (s *Store) withConfigSaveLock(save func(tx *sqlx.Tx) (config.Config, error)) (config.Config, error) {
+	tx, err := s.db.Beginx()
+	if err != nil {
+		return config.Config{}, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err = tx.Exec("SELECT pg_advisory_xact_lock($1, $2)", configSaveLockNamespace, configSaveLockKey); err != nil {
+		return config.Config{}, fmt.Errorf("failed to lock config save transaction: %w", err)
+	}
+
+	saved, err := save(tx)
+	if err != nil {
+		return config.Config{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return config.Config{}, fmt.Errorf("failed to commit config save: %w", err)
+	}
+
+	return saved, nil
+}
+
+func getConfig(tx *sqlx.Tx) (*config.Config, error) {
+	var stored *config.Config
+	var configJSON string
+	err := tx.Get(&configJSON, "SELECT Config FROM Agents_ConfigHistory WHERE Active = true LIMIT 1")
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+	case err != nil:
+		return nil, fmt.Errorf("failed to get active config: %w", err)
+	default:
+		var cfg config.Config
+		if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+		stored = &cfg
+	}
+
+	return stored, nil
+}
+
+func replaceConfig(tx *sqlx.Tx, cfg config.Config) error {
 	configBytes, err := json.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tx, err := s.db.Beginx()
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			_ = tx.Rollback()
-		}
-	}()
-
-	// Serialize SaveConfig across nodes/processes to avoid races on the partial
-	// unique index for the active row.
-	if _, err = tx.Exec("SELECT pg_advisory_xact_lock($1, $2)", configSaveLockNamespace, configSaveLockKey); err != nil {
-		return fmt.Errorf("failed to lock config save transaction: %w", err)
-	}
-
 	// Deactivate current active config (at most one row, indexed on Active)
-	if _, err = tx.Exec("UPDATE Agents_ConfigHistory SET Active = false WHERE Active = true"); err != nil {
+	if _, err := tx.Exec("UPDATE Agents_ConfigHistory SET Active = false WHERE Active = true"); err != nil {
 		return fmt.Errorf("failed to deactivate current config: %w", err)
 	}
 
 	// Insert new active config
-	if _, err = tx.Exec(
+	if _, err := tx.Exec(
 		"INSERT INTO Agents_ConfigHistory (ID, Config, CreateAt, Active) VALUES ($1, $2, $3, $4)",
 		model.NewId(),
 		string(configBytes),
@@ -77,10 +129,6 @@ func (s *Store) SaveConfig(cfg config.Config) error {
 		true,
 	); err != nil {
 		return fmt.Errorf("failed to insert new config: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit config save: %w", err)
 	}
 
 	return nil

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -427,4 +428,125 @@ func TestSaveConfigWaitsForConfigLock(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "bot-after-lock", cfg.DefaultBotName)
+}
+
+func TestUpdateConfigRollsBackCallbackError(t *testing.T) {
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+	require.NoError(t, s.SaveConfig(config.Config{DefaultBotName: "before"}))
+
+	expectedErr := errors.New("update rejected")
+	_, err := s.UpdateConfig(func(stored *config.Config) (config.Config, error) {
+		require.NotNil(t, stored)
+		return config.Config{DefaultBotName: "after"}, expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+
+	cfg, err := s.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "before", cfg.DefaultBotName)
+
+	var totalCount int
+	require.NoError(t, s.db.Get(&totalCount, "SELECT COUNT(*) FROM Agents_ConfigHistory"))
+	assert.Equal(t, 1, totalCount)
+}
+
+func TestMalformedActiveConfigReplacement(t *testing.T) {
+	const malformedConfig = `{"defaultBotName":`
+
+	s := setupTestStore(t)
+	require.NoError(t, s.RunMigrations())
+	_, err := s.db.Exec(
+		"INSERT INTO Agents_ConfigHistory (ID, Config, CreateAt, Active) VALUES ($1, $2, $3, $4)",
+		"malformed-config",
+		malformedConfig,
+		time.Now().UnixMilli(),
+		true,
+	)
+	require.NoError(t, err)
+
+	callbackCalled := false
+	_, err = s.UpdateConfig(func(*config.Config) (config.Config, error) {
+		callbackCalled = true
+		return config.Config{DefaultBotName: "replacement"}, nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal config")
+	assert.False(t, callbackCalled)
+
+	var activeConfig string
+	require.NoError(t, s.db.Get(&activeConfig, "SELECT Config FROM Agents_ConfigHistory WHERE Active = true"))
+	assert.Equal(t, malformedConfig, activeConfig)
+
+	replacement := config.Config{DefaultBotName: "replacement"}
+	require.NoError(t, s.SaveConfig(replacement))
+
+	cfg, err := s.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, replacement.DefaultBotName, cfg.DefaultBotName)
+}
+
+func TestUpdateConfigRestoresAgainstLatestConfig(t *testing.T) {
+	baseStore := setupTestStore(t)
+	require.NoError(t, baseStore.RunMigrations())
+	require.NoError(t, baseStore.SaveConfig(config.Config{
+		Services: []llm.ServiceConfig{{ID: "service-1", APIKey: "initial-value"}},
+	}))
+
+	var schemaName string
+	require.NoError(t, baseStore.db.Get(&schemaName, "SELECT current_schema()"))
+	rotateStore := setupSchemaBoundStore(t, schemaName)
+	restoreStore := setupSchemaBoundStore(t, schemaName)
+
+	rotateEntered := make(chan struct{})
+	releaseRotate := make(chan struct{})
+	rotateDone := make(chan error, 1)
+	go func() {
+		_, updateErr := rotateStore.UpdateConfig(func(stored *config.Config) (config.Config, error) {
+			if stored == nil {
+				return config.Config{}, errors.New("stored config is missing")
+			}
+			rotated := *stored.Clone()
+			rotated.Services[0].APIKey = "rotated-value"
+			close(rotateEntered)
+			<-releaseRotate
+			return rotated, nil
+		})
+		rotateDone <- updateErr
+	}()
+
+	select {
+	case <-rotateEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rotation update did not acquire the config lock")
+	}
+
+	seenStoredKey := make(chan string, 1)
+	restoreDone := make(chan error, 1)
+	go func() {
+		incoming := config.Config{
+			Services: []llm.ServiceConfig{{ID: "service-1", APIKey: config.FakeSetting}},
+		}
+		_, updateErr := restoreStore.UpdateConfig(func(stored *config.Config) (config.Config, error) {
+			if stored == nil {
+				return config.Config{}, errors.New("stored config is missing")
+			}
+			seenStoredKey <- stored.Services[0].APIKey
+			return config.RestoreSecrets(incoming, *stored), nil
+		})
+		restoreDone <- updateErr
+	}()
+
+	close(releaseRotate)
+	require.NoError(t, <-rotateDone)
+	require.NoError(t, <-restoreDone)
+	assert.Equal(t, "rotated-value", <-seenStoredKey)
+
+	cfg, err := baseStore.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Services, 1)
+	assert.Equal(t, "rotated-value", cfg.Services[0].APIKey)
 }

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -736,21 +736,24 @@ export type FetchModelsOptions = {
     vertexAuthCredentials?: string;
 }
 
-export async function fetchModels(serviceType: string, apiKey: string, apiURL: string, orgID: string, options: FetchModelsOptions = {}) {
+export async function fetchModels(serviceType: string, apiKey: string, apiURL: string, orgID: string, options: FetchModelsOptions = {}, signal?: AbortSignal) {
     const url = `${baseRoute()}/admin/models/fetch`;
-    const response = await fetch(url, Client4.getOptions({
-        method: 'POST',
-        body: JSON.stringify({
-            serviceType,
-            apiKey,
-            apiURL,
-            orgID,
-            region: options.region || '',
-            vertexProjectID: options.vertexProjectID || '',
-            vertexProjectNumber: options.vertexProjectNumber || '',
-            vertexAuthCredentials: options.vertexAuthCredentials || '',
+    const response = await fetch(url, {
+        ...Client4.getOptions({
+            method: 'POST',
+            body: JSON.stringify({
+                serviceType,
+                apiKey,
+                apiURL,
+                orgID,
+                region: options.region || '',
+                vertexProjectID: options.vertexProjectID || '',
+                vertexProjectNumber: options.vertexProjectNumber || '',
+                vertexAuthCredentials: options.vertexAuthCredentials || '',
+            }),
         }),
-    }));
+        signal,
+    });
 
     if (response.ok) {
         return response.json();

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -12,12 +12,11 @@ import {DangerPill} from '../pill';
 
 import {ButtonIcon} from '../assets/buttons';
 
-import {fetchModels} from '../../client';
-
 import {BooleanItem, FormRow, FieldControlRow, InlineCheckbox, ItemList, SelectionItem, SelectionItemOption, TextItem, ItemLabel, HelpText, ComboboxItem} from './item';
 import AvatarItem from './avatar';
 import {ChannelAccessLevelItem, UserAccessLevelItem} from './llm_access';
 import {LLMService} from './service';
+import {fetchModelsForService, type ModelInfo, supportsModelFetching as serviceSupportsModelFetching} from './model_fetch';
 import ReasoningConfigItem from './reasoning_config';
 
 export enum ChannelAccessLevel {
@@ -185,14 +184,14 @@ export const NativeToolsItem = (props: NativeToolsItemProps) => {
 type Props = {
     bot: LLMBotConfig
     services: LLMService[]
+
+    // IDs of services already saved on the server. Services whose credentials are
+    // redacted placeholders can only list models through the server-side
+    // credential endpoint, which requires the service to be persisted.
+    persistedServiceIDs?: ReadonlySet<string>
     onChange: (bot: LLMBotConfig) => void
     onDelete: () => void
     changedAvatar: (image: File) => void
-}
-
-type ModelInfo = {
-    id: string
-    displayName: string
 }
 
 const Bot = (props: Props) => {
@@ -201,6 +200,7 @@ const Bot = (props: Props) => {
     const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
     const [loadingModels, setLoadingModels] = useState(false);
     const [modelsFetchError, setModelsFetchError] = useState<string>('');
+    const modelsRequestGeneration = useRef(0);
 
     const missingUsername = !props.bot.name || props.bot.name.trim() === '';
     const invalidUsername = props.bot.name !== '' && (!(/^[a-z0-9.\-_]+$/).test(props.bot.name) || !(/[a-z]/).test(props.bot.name.charAt(0)));
@@ -208,72 +208,54 @@ const Bot = (props: Props) => {
 
     // Find the selected service
     const selectedService = props.services.find((s) => s.id === props.bot.serviceID);
-    const supportsModelFetching = selectedService &&
-        (selectedService.type === 'anthropic' ||
-         selectedService.type === 'openai' ||
-         selectedService.type === 'azure' ||
-         selectedService.type === 'openaicompatible' ||
-         selectedService.type === 'gemini' ||
-         selectedService.type === 'vertex');
+    const supportsModelFetching = Boolean(selectedService && serviceSupportsModelFetching(selectedService.type));
+    const isServicePersisted = Boolean(selectedService && props.persistedServiceIDs?.has(selectedService.id));
 
     // Fetch models when the service changes
     useEffect(() => {
-        if (!supportsModelFetching || !selectedService) {
-            setAvailableModels([]);
-            setModelsFetchError('');
-            return;
-        }
-
-        // Providers have different credential shapes for model listing:
-        // - openaicompatible: API key OR API URL
-        // - vertex: GCP project ID + region
-        // - others: API key
-        let hasRequiredCredentials: string | boolean = false;
-        switch (selectedService.type) {
-        case 'openaicompatible':
-            hasRequiredCredentials = selectedService.apiKey || selectedService.apiURL;
-            break;
-        case 'vertex':
-            hasRequiredCredentials = Boolean(selectedService.vertexProjectID && selectedService.region);
-            break;
-        default:
-            hasRequiredCredentials = selectedService.apiKey;
-        }
-
-        if (!hasRequiredCredentials) {
-            setAvailableModels([]);
-            setModelsFetchError('');
-            return;
-        }
+        const abortController = new AbortController();
+        const generation = ++modelsRequestGeneration.current;
+        const isCurrentRequest = () => !abortController.signal.aborted && generation === modelsRequestGeneration.current;
 
         const loadModels = async () => {
+            if (!selectedService) {
+                setAvailableModels((models) => (models.length === 0 ? models : []));
+                setModelsFetchError('');
+                return;
+            }
+
             setLoadingModels(true);
             setModelsFetchError('');
 
             try {
-                const data: ModelInfo[] = await fetchModels(
-                    selectedService.type,
-                    selectedService.apiKey,
-                    selectedService.apiURL || '',
-                    selectedService.orgId || '',
-                    {
-                        region: selectedService.region || '',
-                        vertexProjectID: selectedService.vertexProjectID || '',
-                        vertexProjectNumber: selectedService.vertexProjectNumber || '',
-                        vertexAuthCredentials: selectedService.vertexAuthCredentials || '',
-                    },
-                );
+                const data = await fetchModelsForService(selectedService, isServicePersisted, abortController.signal);
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                if (data === null) {
+                    setAvailableModels((models) => (models.length === 0 ? models : []));
+                    return;
+                }
                 setAvailableModels(data);
             } catch (error) {
+                if (!isCurrentRequest()) {
+                    return;
+                }
                 setModelsFetchError(intl.formatMessage({defaultMessage: 'Failed to fetch models. Please check the service configuration.'}));
                 setAvailableModels([]);
             } finally {
-                setLoadingModels(false);
+                if (isCurrentRequest()) {
+                    setLoadingModels(false);
+                }
             }
         };
 
         loadModels();
-    }, [selectedService?.id, selectedService?.type, selectedService?.apiKey, selectedService?.apiURL, selectedService?.orgId, selectedService?.region, selectedService?.vertexProjectID, selectedService?.vertexProjectNumber, selectedService?.vertexAuthCredentials, supportsModelFetching, intl]);
+
+        return () => {
+            abortController.abort();
+        };
+    }, [selectedService?.id, selectedService?.type, selectedService?.apiKey, selectedService?.apiURL, selectedService?.orgId, selectedService?.region, selectedService?.vertexProjectID, selectedService?.vertexProjectNumber, selectedService?.vertexAuthCredentials, isServicePersisted, intl]);
 
     return (
         <BotContainer>

--- a/webapp/src/components/system_console/bots.tsx
+++ b/webapp/src/components/system_console/bots.tsx
@@ -44,6 +44,7 @@ export const firstNewBot = {
 type Props = {
     bots: LLMBotConfig[]
     services: LLMService[]
+    persistedServiceIDs?: ReadonlySet<string>
     onChange: (bots: LLMBotConfig[]) => void
     botChangedAvatar: (bot: LLMBotConfig, image: File) => void
 }
@@ -85,6 +86,7 @@ const Bots = (props: Props) => {
                         key={bot.id}
                         bot={bot}
                         services={props.services}
+                        persistedServiceIDs={props.persistedServiceIDs}
                         onChange={onChange}
                         onDelete={() => onDelete(bot.id)}
                         changedAvatar={(image: File) => props.botChangedAvatar(bot, image)}

--- a/webapp/src/components/system_console/config.test.tsx
+++ b/webapp/src/components/system_console/config.test.tsx
@@ -1,0 +1,177 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import {getAIBots, getPluginConfig, savePluginConfig} from '@/client';
+import {FakeSetting} from '@/constants';
+
+import Config from './config';
+import type {LLMService} from './service';
+
+type MockServicesProps = {
+    services: LLMService[]
+    persistedServiceIDs: ReadonlySet<string>
+    onChange: (services: LLMService[]) => void
+}
+
+function mockServices(props: MockServicesProps) {
+    const newService = testService({
+        id: 'generated-id',
+        name: 'New service',
+        defaultModel: '',
+    });
+
+    return (
+        <>
+            <div data-testid='service-persistence'>
+                {props.services.map((service) => `${service.id}:${props.persistedServiceIDs.has(service.id) ? 'persisted' : 'unsaved'}`).join(',')}
+            </div>
+            <button onClick={() => props.onChange([...props.services, newService])}>
+                {'Add mock service'}
+            </button>
+        </>
+    );
+}
+
+jest.mock('react-intl', () => {
+    const actual = jest.requireActual('react-intl');
+    const intl = {
+        formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+    return {
+        ...actual,
+        useIntl: () => intl,
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('@/client', () => ({
+    getAIBots: jest.fn().mockResolvedValue({bots: []}),
+    getPluginConfig: jest.fn(),
+    savePluginConfig: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('./services', () => ({
+    __esModule: true,
+    default: mockServices,
+    firstNewService: {},
+}));
+
+jest.mock('./embedding_search/embedding_search_panel', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./web_search/web_search_panel', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./mcp_servers', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+const mockGetAIBots = getAIBots as jest.MockedFunction<typeof getAIBots>;
+const mockGetPluginConfig = getPluginConfig as jest.MockedFunction<typeof getPluginConfig>;
+const mockSavePluginConfig = savePluginConfig as jest.MockedFunction<typeof savePluginConfig>;
+
+function testService(overrides: Partial<LLMService> = {}): LLMService {
+    return {
+        id: 'existing-id',
+        name: 'Existing service',
+        type: 'anthropic',
+        apiURL: '',
+        apiKey: FakeSetting,
+        orgId: '',
+        defaultModel: 'model',
+        tokenLimit: 0,
+        streamingTimeoutSeconds: 0,
+        outputTokenLimit: 0,
+        useResponsesAPI: false,
+        region: '',
+        awsAccessKeyID: '',
+        awsSecretAccessKey: '',
+        vertexProjectID: '',
+        vertexProjectNumber: '',
+        vertexAuthCredentials: '',
+        ...overrides,
+    };
+}
+
+async function renderConfig() {
+    const registeredActions: Array<() => Promise<{error?: {message?: string}}>> = [];
+    render(
+        <IntlProvider locale='en'>
+            <Config
+                id='config'
+                label='Config'
+                helpText={null}
+                value={{} as never}
+                disabled={false}
+                config={{}}
+                currentState={{}}
+                license={{}}
+                setByEnv={false}
+                onChange={jest.fn()}
+                setSaveNeeded={jest.fn()}
+                registerSaveAction={(action) => registeredActions.push(action)}
+                unRegisterSaveAction={jest.fn()}
+            />
+        </IntlProvider>,
+    );
+    await screen.findByText('AI Services');
+    return registeredActions;
+}
+
+describe('Config saving', () => {
+    it('preserves placeholders on save and only persists newly added services after success', async () => {
+        mockGetAIBots.mockResolvedValue({bots: []});
+        mockGetPluginConfig.mockResolvedValue({
+            services: [testService({
+                awsSecretAccessKey: FakeSetting,
+                vertexAuthCredentials: FakeSetting,
+            })],
+        } as Awaited<ReturnType<typeof getPluginConfig>>);
+        mockSavePluginConfig.mockImplementation(() => Promise.resolve());
+
+        const registeredActions = await renderConfig();
+        await waitFor(() => expect(registeredActions.length).toBeGreaterThan(1));
+        expect(screen.getByTestId('service-persistence').textContent).toBe('existing-id:persisted');
+
+        const save = registeredActions[registeredActions.length - 1];
+        await act(async () => {
+            await save();
+        });
+        expect(mockSavePluginConfig).toHaveBeenCalledWith(expect.objectContaining({
+            services: [expect.objectContaining({
+                apiKey: FakeSetting,
+                awsSecretAccessKey: FakeSetting,
+                vertexAuthCredentials: FakeSetting,
+            })],
+        }));
+
+        const actionCountBeforeAdd = registeredActions.length;
+        fireEvent.click(screen.getByText('Add mock service'));
+        await waitFor(() => expect(screen.getByTestId('service-persistence').textContent).toContain('generated-id:unsaved'));
+        await waitFor(() => expect(registeredActions.length).toBeGreaterThan(actionCountBeforeAdd));
+
+        const saveAfterAdd = registeredActions[registeredActions.length - 1];
+        mockSavePluginConfig.mockRejectedValueOnce(new Error('save failed'));
+        let result: {error?: {message?: string}} = {};
+        await act(async () => {
+            result = await saveAfterAdd();
+        });
+        expect(result.error?.message).toBe('Failed to save configuration.');
+        expect(screen.getByTestId('service-persistence').textContent).toBe('existing-id:persisted,generated-id:unsaved');
+
+        mockSavePluginConfig.mockImplementation(() => Promise.resolve());
+        await act(async () => {
+            await saveAfterAdd();
+        });
+        await waitFor(() => expect(screen.getByTestId('service-persistence').textContent).toContain('generated-id:persisted'));
+    });
+});

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -188,6 +188,7 @@ const Config = (props: Props) => {
     const [loadError, setLoadError] = useState<string | null>(null);
     const [runtimeBots, setRuntimeBots] = useState<RuntimeBotOption[]>([]);
     const [runtimeBotsError, setRuntimeBotsError] = useState<string | null>(null);
+    const [persistedServiceIDs, setPersistedServiceIDs] = useState<Set<string>>(() => new Set());
     const intl = useIntl();
 
     // Load config from plugin API on mount
@@ -196,6 +197,7 @@ const Config = (props: Props) => {
             try {
                 const cfg = await getPluginConfig();
                 setLocalConfig({...defaultConfig, ...cfg});
+                setPersistedServiceIDs(new Set((cfg.services ?? []).map((service) => service.id)));
                 setLoadError(null);
             } catch (e: any) {
                 setLoadError(intl.formatMessage({defaultMessage: 'Failed to load configuration.'}));
@@ -227,6 +229,7 @@ const Config = (props: Props) => {
         const save = async () => {
             try {
                 await savePluginConfig(localConfig);
+                setPersistedServiceIDs(new Set((localConfig.services ?? []).map((service) => service.id)));
                 return {};
             } catch (e: any) {
                 return {error: {message: intl.formatMessage({defaultMessage: 'Failed to save configuration.'})}};
@@ -297,6 +300,7 @@ const Config = (props: Props) => {
                 <Services
                     services={value.services ?? []}
                     bots={value.bots ?? []}
+                    persistedServiceIDs={persistedServiceIDs}
                     onChange={(services: LLMService[]) => {
                         updateConfig({services});
                     }}

--- a/webapp/src/components/system_console/mcp_servers.test.tsx
+++ b/webapp/src/components/system_console/mcp_servers.test.tsx
@@ -198,4 +198,16 @@ describe('MCPServers service account headers', () => {
         expect(screen.getByPlaceholderText('Header value (e.g. Bearer token)')).not.toBeNull();
         expect(screen.getByText(/Do not repeat the header name in the value/)).not.toBeNull();
     });
+
+    test('renders header names as text and header values as passwords', async () => {
+        await renderOneServer(makeRemoteServer({
+            headers: {'X-Base': 'base-value'},
+            serviceAccountHeaders: {Authorization: 'Bearer pat'},
+        }));
+
+        expect((screen.getByPlaceholderText('Header name') as HTMLInputElement).type).toBe('text');
+        expect((baseHeaderValueInput() as HTMLInputElement).type).toBe('password');
+        expect((screen.getByPlaceholderText('Header name (e.g. Authorization)') as HTMLInputElement).type).toBe('text');
+        expect((serviceAccountHeaderValueInput() as HTMLInputElement).type).toBe('password');
+    });
 });

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -129,6 +129,7 @@ const HeaderMapEditor = ({
                             onChange={(e) => updateHeader(key, e.target.value, value)}
                         />
                         <HeaderInput
+                            type='password'
                             placeholder={headerValuePlaceholder}
                             value={value}
                             onChange={(e) => updateHeader(key, key, e.target.value)}

--- a/webapp/src/components/system_console/model_fetch.test.ts
+++ b/webapp/src/components/system_console/model_fetch.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fetchModels, fetchModelsForAgentService} from '@/client';
+import {FakeSetting} from '@/constants';
+
+import {fetchModelsForService, supportsModelFetching} from './model_fetch';
+
+jest.mock('@/client', () => ({
+    fetchModels: jest.fn(),
+    fetchModelsForAgentService: jest.fn(),
+}));
+
+const mockFetchModels = fetchModels as jest.MockedFunction<typeof fetchModels>;
+const mockFetchModelsForAgentService = fetchModelsForAgentService as jest.MockedFunction<typeof fetchModelsForAgentService>;
+
+const signal = new AbortController().signal;
+
+const baseService = {
+    id: 'svc-1',
+    type: 'anthropic',
+    apiKey: 'test-key',
+    apiURL: '',
+    orgId: '',
+    region: '',
+    vertexProjectID: '',
+    vertexProjectNumber: '',
+    vertexAuthCredentials: '',
+};
+
+beforeEach(() => {
+    mockFetchModels.mockReset();
+    mockFetchModelsForAgentService.mockReset();
+    mockFetchModels.mockResolvedValue([]);
+    mockFetchModelsForAgentService.mockResolvedValue([]);
+});
+
+describe('supportsModelFetching', () => {
+    it.each([
+        ['anthropic', true],
+        ['openai', true],
+        ['vertex', true],
+        ['bedrock', false],
+    ] as const)('%s → %s', (type, expected) => {
+        expect(supportsModelFetching(type)).toBe(expected);
+    });
+});
+
+describe('fetchModelsForService', () => {
+    it('uses stored credentials for a persisted placeholder', async () => {
+        const models = await fetchModelsForService({...baseService, apiKey: FakeSetting}, true, signal);
+
+        expect(models).toEqual([]);
+        expect(mockFetchModelsForAgentService).toHaveBeenCalledWith(baseService.id, signal);
+        expect(mockFetchModels).not.toHaveBeenCalled();
+    });
+
+    it('uses stored credentials for persisted Vertex auth represented by the placeholder', async () => {
+        const service = {
+            ...baseService,
+            type: 'vertex',
+            apiKey: '',
+            region: 'us-central1',
+            vertexProjectID: 'project-id',
+            vertexAuthCredentials: FakeSetting,
+        };
+
+        await fetchModelsForService(service, true, signal);
+
+        expect(mockFetchModelsForAgentService).toHaveBeenCalledWith(service.id, signal);
+        expect(mockFetchModels).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch for an unsaved placeholder', async () => {
+        const models = await fetchModelsForService({...baseService, apiKey: FakeSetting}, false, signal);
+
+        expect(models).toBeNull();
+        expect(mockFetchModelsForAgentService).not.toHaveBeenCalled();
+        expect(mockFetchModels).not.toHaveBeenCalled();
+    });
+
+    it('fetches directly when the service has a real credential', async () => {
+        await fetchModelsForService(baseService, false, signal);
+
+        expect(mockFetchModels).toHaveBeenCalledWith(
+            baseService.type,
+            baseService.apiKey,
+            baseService.apiURL,
+            baseService.orgId,
+            expect.objectContaining({
+                region: '',
+                vertexProjectID: '',
+                vertexProjectNumber: '',
+                vertexAuthCredentials: '',
+            }),
+            signal,
+        );
+        expect(mockFetchModelsForAgentService).not.toHaveBeenCalled();
+    });
+});

--- a/webapp/src/components/system_console/model_fetch.ts
+++ b/webapp/src/components/system_console/model_fetch.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fetchModels, fetchModelsForAgentService} from '@/client';
+import {FakeSetting} from '@/constants';
+
+export type ModelInfo = {
+    id: string
+    displayName: string
+    inputTokenLimit?: number
+    outputTokenLimit?: number
+    contextLength?: number
+}
+
+type ModelFetchService = {
+    id: string
+    type: string
+    apiKey: string
+    apiURL: string
+    orgId: string
+    region: string
+    vertexProjectID: string
+    vertexProjectNumber: string
+    vertexAuthCredentials: string
+}
+
+const modelFetchingProviders = new Set(['anthropic', 'openai', 'azure', 'openaicompatible', 'gemini', 'vertex']);
+
+export function supportsModelFetching(serviceType: string): boolean {
+    return modelFetchingProviders.has(serviceType);
+}
+
+function hasRequiredCredentials(service: ModelFetchService): boolean {
+    switch (service.type) {
+    case 'openaicompatible':
+        return Boolean(service.apiKey || service.apiURL);
+    case 'vertex':
+        return Boolean(service.vertexProjectID && service.region);
+    default:
+        return Boolean(service.apiKey);
+    }
+}
+
+function hasCredentialPlaceholder(service: ModelFetchService): boolean {
+    return service.apiKey === FakeSetting ||
+        (service.type === 'vertex' && service.vertexAuthCredentials === FakeSetting);
+}
+
+async function fetchModelsDirectly(service: ModelFetchService, signal: AbortSignal): Promise<ModelInfo[]> {
+    const models: ModelInfo[] = await fetchModels(
+        service.type,
+        service.apiKey,
+        service.apiURL || '',
+        service.orgId || '',
+        {
+            region: service.region || '',
+            vertexProjectID: service.vertexProjectID || '',
+            vertexProjectNumber: service.vertexProjectNumber || '',
+            vertexAuthCredentials: service.type === 'vertex' ? (service.vertexAuthCredentials || '') : '',
+        },
+        signal,
+    );
+    return models;
+}
+
+export async function fetchModelsForService(service: ModelFetchService, isPersisted: boolean, signal: AbortSignal): Promise<ModelInfo[] | null> {
+    if (!supportsModelFetching(service.type) || !hasRequiredCredentials(service)) {
+        return null;
+    }
+
+    if (hasCredentialPlaceholder(service)) {
+        if (!isPersisted) {
+            return null;
+        }
+        return fetchModelsForAgentService(service.id, signal);
+    }
+
+    return fetchModelsDirectly(service, signal);
+}

--- a/webapp/src/components/system_console/service.test.tsx
+++ b/webapp/src/components/system_console/service.test.tsx
@@ -2,28 +2,31 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {IntlProvider} from 'react-intl';
 
 import {ServiceFields, type LLMService} from './service';
 
 jest.mock('react-intl', () => {
     const actual = jest.requireActual('react-intl');
+    const intl = {
+        formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
     return {
         ...actual,
-        useIntl: () => ({
-            formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
-        }),
+        useIntl: () => intl,
         FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
     };
 });
 
 jest.mock('../../client', () => ({
     fetchModels: jest.fn(),
+    fetchModelsForAgentService: jest.fn(),
 }));
 
-const {fetchModels} = jest.requireMock('../../client') as {
+const {fetchModels, fetchModelsForAgentService} = jest.requireMock('../../client') as {
     fetchModels: jest.Mock;
+    fetchModelsForAgentService: jest.Mock;
 };
 
 const baseService: LLMService = {
@@ -60,8 +63,66 @@ function renderFields(service: LLMService = baseService) {
     return {...result, onChange};
 }
 
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return {promise, resolve};
+}
+
 beforeEach(() => {
     fetchModels.mockReset();
+    fetchModelsForAgentService.mockReset();
+    fetchModelsForAgentService.mockResolvedValue([]);
+});
+
+describe('ServiceFields model fetching', () => {
+    it('ignores an earlier response after credentials change', async () => {
+        const firstResponse = deferred<unknown[]>();
+        const secondResponse = deferred<unknown[]>();
+        fetchModels.
+            mockReturnValueOnce(firstResponse.promise).
+            mockReturnValueOnce(secondResponse.promise);
+
+        const firstService = {...baseService, apiKey: 'first-key'};
+        const {rerender} = renderFields(firstService);
+
+        await waitFor(() => expect(fetchModels).toHaveBeenCalledTimes(1));
+        const firstSignal = fetchModels.mock.calls[0][5] as AbortSignal;
+
+        rerender(
+            <IntlProvider locale='en'>
+                <ServiceFields
+                    service={{...firstService, apiKey: 'second-key'}}
+                    onChange={jest.fn()}
+                />
+            </IntlProvider>,
+        );
+
+        await waitFor(() => expect(fetchModels).toHaveBeenCalledTimes(2));
+        expect(firstSignal.aborted).toBe(true);
+
+        await act(async () => {
+            secondResponse.resolve([{
+                id: baseService.defaultModel,
+                displayName: 'New response',
+                inputTokenLimit: 222,
+            }]);
+        });
+        await waitFor(() => expect(screen.getByDisplayValue('222')).toBeTruthy());
+
+        await act(async () => {
+            firstResponse.resolve([{
+                id: baseService.defaultModel,
+                displayName: 'Stale response',
+                inputTokenLimit: 111,
+            }]);
+        });
+
+        expect(screen.queryByDisplayValue('111')).toBeNull();
+        expect(screen.getByDisplayValue('222')).toBeTruthy();
+    });
 });
 
 describe('ServiceFields token-limit inputs', () => {

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -11,9 +11,8 @@ import IconAI from '../assets/icon_ai';
 
 import {ButtonIcon} from '../assets/buttons';
 
-import {fetchModels} from '../../client';
-
 import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem, ComboboxItem} from './item';
+import {fetchModelsForService, type ModelInfo, supportsModelFetching} from './model_fetch';
 
 export type LLMService = {
     id: string
@@ -65,17 +64,10 @@ function serviceTypeToDisplayName(intl: IntlShape, serviceType: string): string 
     return mapServiceTypeToDisplayName.get(serviceType) || serviceType;
 }
 
-type ModelInfo = {
-    id: string
-    displayName: string
-    inputTokenLimit?: number
-    outputTokenLimit?: number
-    contextLength?: number
-}
-
 type ServiceFieldsProps = {
     service: LLMService
     services?: LLMService[]
+    isPersisted?: boolean
     onChange: (service: LLMService) => void
 }
 
@@ -87,10 +79,12 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
     const isCohere = type === 'cohere';
     const isMistral = type === 'mistral';
     const isScale = type === 'scale';
+    const isPersisted = props.isPersisted ?? false;
 
     const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
     const [loadingModels, setLoadingModels] = useState(false);
     const [modelsFetchError, setModelsFetchError] = useState<string>('');
+    const modelsRequestGeneration = useRef(0);
 
     // Cached admin entries so toggling to a Bifrost-known model and back
     // restores the prior manual values instead of the auto-detected ones.
@@ -123,7 +117,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
         }
     }, [props.service.tokenLimit, props.service.outputTokenLimit]);
 
-    const supportsModelFetching = type === 'anthropic' || type === 'openai' || type === 'azure' || type === 'openaicompatible' || type === 'gemini' || type === 'vertex';
+    const canFetchModels = supportsModelFetching(type);
 
     useEffect(() => {
         if (type === 'openai' && !props.service.useResponsesAPI) {
@@ -132,56 +126,43 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
     }, [type, props.onChange, props.service]);
 
     useEffect(() => {
-        // Providers have different credential shapes for model listing:
-        // - openaicompatible: API key OR API URL
-        // - vertex: GCP project ID + region (service-account JSON optional)
-        // - others: API key
-        let hasRequiredCredentials = false;
-        switch (type) {
-        case 'openaicompatible':
-            hasRequiredCredentials = Boolean(props.service.apiKey || props.service.apiURL);
-            break;
-        case 'vertex':
-            hasRequiredCredentials = Boolean(props.service.vertexProjectID && props.service.region);
-            break;
-        default:
-            hasRequiredCredentials = Boolean(props.service.apiKey);
-        }
-
-        if (!supportsModelFetching || !hasRequiredCredentials) {
-            setAvailableModels([]);
-            setModelsFetchError('');
-            return;
-        }
+        const abortController = new AbortController();
+        const generation = ++modelsRequestGeneration.current;
+        const isCurrentRequest = () => !abortController.signal.aborted && generation === modelsRequestGeneration.current;
 
         const loadModels = async () => {
             setLoadingModels(true);
             setModelsFetchError('');
 
             try {
-                const data: ModelInfo[] = await fetchModels(
-                    type,
-                    props.service.apiKey,
-                    props.service.apiURL || '',
-                    props.service.orgId || '',
-                    {
-                        region: props.service.region || '',
-                        vertexProjectID: props.service.vertexProjectID || '',
-                        vertexProjectNumber: props.service.vertexProjectNumber || '',
-                        vertexAuthCredentials: props.service.vertexAuthCredentials || '',
-                    },
-                );
+                const data = await fetchModelsForService(props.service, isPersisted, abortController.signal);
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                if (data === null) {
+                    setAvailableModels((models) => (models.length === 0 ? models : []));
+                    return;
+                }
                 setAvailableModels(data);
             } catch (error) {
-                setModelsFetchError(intl.formatMessage({defaultMessage: 'Failed to fetch models. Please check your API key and API URL.'}));
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                setModelsFetchError(intl.formatMessage({defaultMessage: 'Failed to fetch models. Please check the service configuration.'}));
                 setAvailableModels([]);
             } finally {
-                setLoadingModels(false);
+                if (isCurrentRequest()) {
+                    setLoadingModels(false);
+                }
             }
         };
 
         loadModels();
-    }, [type, props.service.apiKey, props.service.apiURL, props.service.orgId, props.service.region, props.service.vertexProjectID, props.service.vertexProjectNumber, props.service.vertexAuthCredentials, supportsModelFetching, intl]);
+
+        return () => {
+            abortController.abort();
+        };
+    }, [type, props.service.id, props.service.apiKey, props.service.apiURL, props.service.orgId, props.service.region, props.service.vertexProjectID, props.service.vertexProjectNumber, props.service.vertexAuthCredentials, isPersisted, intl]);
 
     const getDefaultOutputTokenLimit = () => {
         switch (type) {
@@ -195,7 +176,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
     };
 
     let loadModelsHelpText = '';
-    if (supportsModelFetching) {
+    if (canFetchModels) {
         if (loadingModels) {
             loadModelsHelpText = intl.formatMessage({defaultMessage: 'Loading models...'});
         } else if (modelsFetchError) {
@@ -359,7 +340,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
                     )}
                 </>
             )}
-            {supportsModelFetching && availableModels.length > 0 && (
+            {canFetchModels && availableModels.length > 0 && (
                 <ComboboxItem
                     label={intl.formatMessage({defaultMessage: 'Default model'})}
                     value={props.service.defaultModel}
@@ -370,7 +351,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
                     isClearable={false}
                 />
             )}
-            {!(supportsModelFetching && availableModels.length > 0) && (
+            {!(canFetchModels && availableModels.length > 0) && (
                 <TextItem
                     label={intl.formatMessage({defaultMessage: 'Default model'})}
                     value={props.service.defaultModel}
@@ -443,6 +424,7 @@ export const ServiceFields = (props: ServiceFieldsProps) => {
 type Props = {
     service: LLMService
     services: LLMService[]
+    isPersisted: boolean
     onChange: (service: LLMService) => void
     onDelete: () => void
 }
@@ -485,6 +467,7 @@ const Service = (props: Props) => {
                         <ServiceFields
                             service={props.service}
                             services={props.services}
+                            isPersisted={props.isPersisted}
                             onChange={props.onChange}
                         />
                     </ItemList>

--- a/webapp/src/components/system_console/services.tsx
+++ b/webapp/src/components/system_console/services.tsx
@@ -41,6 +41,7 @@ export const firstNewService = {
 type Props = {
     services: LLMService[]
     bots: LLMBotConfig[]
+    persistedServiceIDs: ReadonlySet<string>
     onChange: (services: LLMService[]) => void
 }
 
@@ -100,6 +101,7 @@ const Services = (props: Props) => {
                         key={service.id}
                         service={service}
                         services={props.services}
+                        isPersisted={props.persistedServiceIDs.has(service.id)}
                         onChange={onChange}
                         onDelete={() => onDelete(service.id)}
                     />

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const FakeSetting = '********************************';

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -16,7 +16,6 @@
   "/6XfA0os": "GCP Project Number (Optional)",
   "/80OC6Vw": "Minimum score multiplier for old messages (0-1). Higher values preserve old but highly relevant results; 1 disables the recency effect.",
   "/GrzAbOb": "Auto Run (Everywhere)",
-  "/Jlt6H7I": "Failed to fetch models. Please check your API key and API URL.",
   "/L9yICAK": "Failed to save configuration.",
   "/ZGMpdmH": "Failed to reindex posts: {error}",
   "/cP+FWmj": "Use multiple AI bots on qualifying Mattermost plans",


### PR DESCRIPTION
#### Summary
- Load and save plugin-wide configuration through `GET`/`PUT /plugins/mattermost-ai/admin/config` so existing service settings remain in place when an admin saves from System Console without changing them.
- System Console keeps unchanged service fields as-is and loads available models from the persisted service for existing configurations.
- Configuration updates apply against the latest stored record under the config lock.
- Docs describe the database-backed configuration and admin API as the live source, rather than the Mattermost `PluginSettings` blob.

**Test plan**
- Open **System Console > Plugins > Agents**, save without changing existing services, and confirm those services still work.
- Change a service setting, save, and confirm the new value is stored.
- Add a new service, save, and confirm it persists after a successful save and remains unsaved if the save fails.
- Open an existing service and confirm the model list loads.

#### Release Note
```release-note
Updated how Agents configuration is loaded and saved from the System Console. Live plugin configuration is stored in Agents_ConfigHistory and managed through GET/PUT /plugins/mattermost-ai/admin/config.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration updates are now saved atomically, preserving credentials and preventing partial changes.
  - Sensitive configuration values are masked in responses and protected during edits.
  - Model loading supports more services, persisted credentials, request cancellation, and stale-response protection.
  - MCP header values are now masked as password fields.

- **Bug Fixes**
  - Prevented concurrent configuration updates from overwriting each other.
  - Improved handling of failed saves, malformed settings, and unavailable model results.

- **Documentation**
  - Updated administration, migration, backup, and upgrade guidance for database-backed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->