### PR TITLE
webapp: left-align MCP accordions and match Access policy to OAuth

### DIFF
--- a/webapp/src/components/access_control/console_policy_section.test.tsx
+++ b/webapp/src/components/access_control/console_policy_section.test.tsx
@@ -98,6 +98,14 @@ afterEach(() => {
 });
 
 describe('ConsolePolicySection', () => {
+    test('renders a collapsed accordion header matching other console sections', () => {
+        renderSection('serviceidaaaaaaaaaaaaaaaaa');
+
+        const header = screen.getByRole('button', {name: 'Access policy'});
+        expect(header.getAttribute('aria-expanded')).toBe('false');
+        expect(screen.queryByTestId('table-editor')).toBeNull();
+    });
+
     test('the editor mounts on first expand and stays mounted when collapsed', async () => {
         renderSection('serviceidaaaaaaaaaaaaaaaaa');
 

--- a/webapp/src/components/access_control/console_policy_section.tsx
+++ b/webapp/src/components/access_control/console_policy_section.tsx
@@ -4,10 +4,11 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
-import {ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/components';
 
 import {PolicyResourceType} from '@/types/access_control';
 import {isValidMattermostId, useABACSupport} from '@/utils/access_control';
+
+import Accordion from '../system_console/accordion';
 
 import PolicyEditor from './policy_editor';
 
@@ -58,93 +59,32 @@ const ConsolePolicySection = (props: Props) => {
     };
 
     return (
-        <SectionContainer $collapsed={hasOpened && !expanded}>
-            <SectionHeader
-                role='button'
-                tabIndex={0}
-                aria-expanded={expanded}
-                onClick={toggleExpanded}
-                onKeyDown={(e: React.KeyboardEvent) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        toggleExpanded();
-                    }
-                }}
-            >
-                {expanded ? <ChevronDownIcon size={16}/> : <ChevronRightIcon size={16}/>}
-                <SectionTitle>
-                    <FormattedMessage defaultMessage='Access policy'/>
-                </SectionTitle>
-            </SectionHeader>
-            {(expanded || hasOpened) && (
-                <SectionContent
-                    $collapsed={!expanded}
-                    {...collapsedInert(expanded)}
-                >
-                    {isValidMattermostId(resourceId) ? (
-                        <PolicyEditor
-                            resourceType={resourceType}
-                            resourceId={resourceId}
-                            resourceDisplayName={resourceDisplayName}
-                            allowSimplified={true}
-                            allowAdvanced={true}
-                        />
-                    ) : (
-                        <LegacyIDNote>{legacyIDNote(resourceType)}</LegacyIDNote>
-                    )}
-                </SectionContent>
+        <Accordion
+            title={<FormattedMessage defaultMessage='Access policy'/>}
+            expanded={expanded}
+            onToggle={toggleExpanded}
+            keepMounted={hasOpened}
+            contentCollapsed={!expanded}
+        >
+            {isValidMattermostId(resourceId) ? (
+                <PolicyEditor
+                    resourceType={resourceType}
+                    resourceId={resourceId}
+                    resourceDisplayName={resourceDisplayName}
+                    allowSimplified={true}
+                    allowAdvanced={true}
+                />
+            ) : (
+                <LegacyIDNote>{legacyIDNote(resourceType)}</LegacyIDNote>
             )}
-        </SectionContainer>
+        </Accordion>
     );
 };
-
-// Omit inert when expanded: React 18 serializes inert={false} as inert="false",
-// which browsers still treat as inert.
-function collapsedInert(expanded: boolean): {inert?: ''} {
-    return expanded ? {} : {inert: ''};
-}
-
-// --- Styled Components ---
-
-const SectionContainer = styled.div<{$collapsed: boolean}>`
-    margin-top: 16px;
-    border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-    padding-top: 12px;
-    ${({$collapsed}) => $collapsed && `
-        position: relative;
-        overflow: hidden;
-    `}
-`;
-
-const SectionHeader = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    cursor: pointer;
-    user-select: none;
-`;
-
-const SectionTitle = styled.div`
-    font-size: 14px;
-    font-weight: 600;
-`;
-
-const SectionContent = styled.div<{$collapsed: boolean; inert?: ''}>`
-    margin-top: 12px;
-    ${({$collapsed}) => $collapsed && `
-        visibility: hidden;
-        position: absolute;
-        left: 0;
-        right: 0;
-        overflow: hidden;
-        clip-path: inset(50%);
-        pointer-events: none;
-    `}
-`;
 
 const LegacyIDNote = styled.div`
     font-size: 12px;
     color: rgba(var(--center-channel-color-rgb), 0.72);
+    text-align: left;
 `;
 
 export default ConsolePolicySection;

--- a/webapp/src/components/system_console/accordion.tsx
+++ b/webapp/src/components/system_console/accordion.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+import {ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/components';
+
+export type AccordionVariant = 'nested' | 'card';
+
+type AccordionProps = {
+    title: React.ReactNode;
+    expanded: boolean;
+    onToggle: () => void;
+    children?: React.ReactNode;
+    badge?: React.ReactNode;
+    headerExtra?: React.ReactNode;
+    contentId?: string;
+    variant?: AccordionVariant;
+
+    // Keep children mounted while collapsed (visually hidden + inert).
+    keepMounted?: boolean;
+    contentCollapsed?: boolean;
+};
+
+const Accordion = ({
+    title,
+    expanded,
+    onToggle,
+    children,
+    badge,
+    headerExtra,
+    contentId,
+    variant = 'nested',
+    keepMounted = false,
+    contentCollapsed,
+}: AccordionProps) => {
+    const collapsed = contentCollapsed ?? !expanded;
+    const showContent = Boolean(children) && (expanded || keepMounted);
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+        }
+    };
+
+    return (
+        <Shell
+            $collapsed={keepMounted && collapsed}
+            $variant={variant}
+        >
+            <HeaderBar>
+                <Toggle
+                    role='button'
+                    tabIndex={0}
+                    aria-expanded={expanded}
+                    aria-controls={contentId}
+                    onClick={onToggle}
+                    onKeyDown={handleKeyDown}
+                >
+                    <HeaderLeft>
+                        {expanded ? <ChevronDownIcon size={16}/> : <ChevronRightIcon size={16}/>}
+                        <Title $variant={variant}>
+                            {title}
+                        </Title>
+                    </HeaderLeft>
+                    {badge}
+                </Toggle>
+                {headerExtra && (
+                    <HeaderExtra>
+                        {headerExtra}
+                    </HeaderExtra>
+                )}
+            </HeaderBar>
+            {showContent && (
+                <Content
+                    id={contentId}
+                    $collapsed={collapsed}
+                    $variant={variant}
+                    {...collapsedInert(!collapsed)}
+                >
+                    {children}
+                </Content>
+            )}
+        </Shell>
+    );
+};
+
+// Omit inert when expanded: React 18 serializes inert={false} as inert="false",
+// which browsers still treat as inert.
+function collapsedInert(expanded: boolean): {inert?: ''} {
+    return expanded ? {} : {inert: ''};
+}
+
+const Shell = styled.div<{$collapsed: boolean; $variant: AccordionVariant}>`
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+    border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+    border-radius: 4px;
+    overflow: hidden;
+    background-color: ${(props) => (props.$variant === 'card' ? 'var(--center-channel-bg)' : 'transparent')};
+    ${({$collapsed}) => $collapsed && `
+        position: relative;
+        overflow: hidden;
+    `}
+`;
+
+const HeaderBar = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    background-color: rgba(var(--center-channel-color-rgb), 0.02);
+    text-align: left;
+`;
+
+const Toggle = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex: 1;
+    min-width: 0;
+    padding: 10px 12px;
+    cursor: pointer;
+    text-align: left;
+
+    &:hover {
+        background-color: rgba(var(--center-channel-color-rgb), 0.04);
+    }
+`;
+
+const HeaderLeft = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    min-width: 0;
+    color: rgba(var(--center-channel-color-rgb), 0.56);
+    text-align: left;
+`;
+
+const Title = styled.div<{$variant: AccordionVariant}>`
+    font-weight: 600;
+    text-align: left;
+    ${(props) => (props.$variant === 'card' ? `
+        font-size: 16px;
+        color: var(--center-channel-color);
+    ` : `
+        font-size: 13px;
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+    `)}
+`;
+
+const HeaderExtra = styled.div`
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding-right: 8px;
+`;
+
+const Content = styled.div<{$collapsed: boolean; $variant: AccordionVariant; inert?: ''}>`
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+    gap: ${(props) => (props.$variant === 'card' ? '16px' : '12px')};
+    padding: ${(props) => (props.$variant === 'card' ? '16px' : '12px')};
+    border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+    ${({$collapsed}) => $collapsed && `
+        visibility: hidden;
+        position: absolute;
+        left: 0;
+        right: 0;
+        overflow: hidden;
+        clip-path: inset(50%);
+        pointer-events: none;
+    `}
+`;
+
+export default Accordion;

--- a/webapp/src/components/system_console/mcp_builtin_servers_section.test.tsx
+++ b/webapp/src/components/system_console/mcp_builtin_servers_section.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 jest.mock('react-intl', () => {
     const React = require('react'); // eslint-disable-line @typescript-eslint/no-shadow, no-shadow, global-require
@@ -98,5 +98,27 @@ describe('BuiltInPluginServersSection', () => {
         );
 
         expect(screen.queryByTestId('console-policy-section')).toBeNull();
+    });
+
+    it('collapses a server accordion and hides its details', () => {
+        render(
+            <IntlProvider locale='en'>
+                <BuiltInPluginServersSection
+                    embeddedServerId={EMBEDDED_ID}
+                    pluginServers={[makePluginServer()]}
+                />
+            </IntlProvider>,
+        );
+
+        expect(screen.getByText('Plugin ID: com.example.demo')).not.toBeNull();
+        expect(screen.getByText(EMBEDDED_ID)).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', {name: /Demo Plugin/}));
+        expect(screen.queryByText('Plugin ID: com.example.demo')).toBeNull();
+        expect(screen.getByText('Demo Plugin')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', {name: /Mattermost/}));
+        expect(screen.queryByText(EMBEDDED_ID)).toBeNull();
+        expect(screen.getByText('Mattermost')).not.toBeNull();
     });
 });

--- a/webapp/src/components/system_console/mcp_builtin_servers_section.tsx
+++ b/webapp/src/components/system_console/mcp_builtin_servers_section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -9,6 +9,7 @@ import {pluginIDFromServerOrigin} from '../../utils/tool_names';
 
 import ConsolePolicySection from '../access_control/console_policy_section';
 
+import Accordion from './accordion';
 import {MCPServerInfo} from './mcp_types';
 
 // Read-only card for the embedded Mattermost MCP server and live plugin servers.
@@ -25,24 +26,32 @@ const BuiltInServerCard = ({
     helpText?: React.ReactNode;
     policyId?: string;
 }) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+
     return (
-        <ReadOnlyServerContainer data-testid='built-in-server-card'>
-            <ServerHeader>
-                <ReadOnlyTitleRow>
-                    <ReadOnlyServerTitle>{title}</ReadOnlyServerTitle>
-                    {badge}
-                </ReadOnlyTitleRow>
-            </ServerHeader>
-            {subtitle && <ReadOnlySubtitle>{subtitle}</ReadOnlySubtitle>}
-            {helpText && <ReadOnlyHelpText>{helpText}</ReadOnlyHelpText>}
-            {policyId && (
-                <ConsolePolicySection
-                    resourceType='mcp'
-                    resourceId={policyId}
-                    resourceDisplayName={title}
-                />
-            )}
-        </ReadOnlyServerContainer>
+        <div data-testid='built-in-server-card'>
+            <Accordion
+                variant='card'
+                title={(
+                    <ReadOnlyTitleRow>
+                        <span>{title}</span>
+                        {badge}
+                    </ReadOnlyTitleRow>
+                )}
+                expanded={isExpanded}
+                onToggle={() => setIsExpanded(!isExpanded)}
+            >
+                {subtitle && <ReadOnlySubtitle>{subtitle}</ReadOnlySubtitle>}
+                {helpText && <ReadOnlyHelpText>{helpText}</ReadOnlyHelpText>}
+                {policyId && (
+                    <ConsolePolicySection
+                        resourceType='mcp'
+                        resourceId={policyId}
+                        resourceDisplayName={title}
+                    />
+                )}
+            </Accordion>
+        </div>
     );
 };
 
@@ -107,13 +116,16 @@ export const BuiltInPluginServersSection = ({
 const BuiltInSection = styled.div`
     margin-top: 8px;
     margin-bottom: 8px;
+    text-align: left;
 `;
 
 const BuiltInSectionHeader = styled.div`
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     gap: 4px;
     margin-top: 16px;
+    text-align: left;
 `;
 
 const BuiltInSectionTitle = styled.div`
@@ -133,50 +145,29 @@ const ServersList = styled.div`
     gap: 16px;
     margin-top: 16px;
     margin-bottom: 16px;
-`;
-
-const ServerContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-    border-radius: 4px;
-    padding: 16px;
-    background-color: var(--center-channel-bg);
-`;
-
-const ReadOnlyServerContainer = styled(ServerContainer)`
-    background-color: rgba(var(--center-channel-color-rgb), 0.02);
-`;
-
-const ServerHeader = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    text-align: left;
 `;
 
 const ReadOnlyTitleRow = styled.div`
     display: flex;
     align-items: center;
+    justify-content: flex-start;
     gap: 8px;
     flex-wrap: wrap;
-`;
-
-const ReadOnlyServerTitle = styled.div`
-    font-weight: 600;
-    font-size: 16px;
-    color: var(--center-channel-color);
+    text-align: left;
 `;
 
 const ReadOnlySubtitle = styled.div`
     font-size: 12px;
     color: rgba(var(--center-channel-color-rgb), 0.64);
+    text-align: left;
 `;
 
 const ReadOnlyHelpText = styled.div`
     font-size: 12px;
     color: rgba(var(--center-channel-color-rgb), 0.64);
     line-height: 1.5;
+    text-align: left;
 `;
 
 const TypeBadge = styled.span`

--- a/webapp/src/components/system_console/mcp_servers.test.tsx
+++ b/webapp/src/components/system_console/mcp_servers.test.tsx
@@ -253,6 +253,46 @@ describe('MCPServers service account headers', () => {
     });
 });
 
+describe('MCPServers accordions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseIsBasicsLicensed.mockReturnValue(true);
+        mockGetMCPTools.mockReturnValue(new Promise(() => null));
+    });
+
+    test('remote servers start expanded and collapse to a header', () => {
+        renderServers(makeMCPConfig([makeRemoteServer()]));
+
+        expect(screen.getByText('Enable Server')).not.toBeNull();
+        expect(screen.getByText('OAuth Credentials (Optional)')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', {name: /Jira/}));
+
+        expect(screen.queryByText('Enable Server')).toBeNull();
+        expect(screen.queryByText('OAuth Credentials (Optional)')).toBeNull();
+        expect(screen.getByText('Jira')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', {name: /Jira/}));
+        expect(screen.getByText('Enable Server')).not.toBeNull();
+        expect(screen.getByText('OAuth Credentials (Optional)')).not.toBeNull();
+    });
+
+    test('Access policy sits beside OAuth as its own accordion on persisted servers', () => {
+        renderServers(makeMCPConfig([existingServer]));
+
+        expect(screen.getByText('OAuth Credentials (Optional)')).not.toBeNull();
+        expect(screen.getByTestId('console-policy-section').textContent).toBe(STABLE_ID);
+    });
+
+    test('OAuth credentials stay collapsed until opened', () => {
+        renderServers(makeMCPConfig([makeRemoteServer()]));
+
+        expect(screen.queryByText('Client ID')).toBeNull();
+        fireEvent.click(screen.getByRole('button', {name: /OAuth Credentials/}));
+        expect(screen.getByText('Client ID')).not.toBeNull();
+    });
+});
+
 describe('MCPServers license gating', () => {
     beforeEach(() => {
         jest.clearAllMocks();

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -345,7 +345,7 @@ const MCPServer = ({
                     <OAuthConfiguredBadge>
                         <FormattedMessage defaultMessage='Configured'/>
                     </OAuthConfiguredBadge>
-                ) : undefined}
+                ) : null}
             >
                 <SectionHelpText>
                     {intl.formatMessage({defaultMessage: 'For MCP servers that require a pre-registered OAuth application (e.g. GitHub). Leave empty if the server supports automatic registration.'})}

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -3,7 +3,7 @@
 
 import React, {useEffect, useRef, useState} from 'react';
 import styled from 'styled-components';
-import {PlusIcon, TrashCanOutlineIcon, ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/components';
+import {PlusIcon, TrashCanOutlineIcon} from '@mattermost/compass-icons/components';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 import {GlobalState} from '@mattermost/types/store';
@@ -17,6 +17,7 @@ import {useIsBasicsLicensed} from '@/license';
 
 import ConsolePolicySection from '../access_control/console_policy_section';
 
+import Accordion from './accordion';
 import {CopyableTextItem} from './copyable_text_item';
 import {BuiltInPluginServersSection} from './mcp_builtin_servers_section';
 import MCPToolsViewer from './mcp_tools_viewer';
@@ -155,6 +156,7 @@ const MCPServer = ({
     const intl = useIntl();
     const [isEditingName, setIsEditingName] = useState(false);
     const [serverName, setServerName] = useState(serverConfig.name);
+    const [isExpanded, setIsExpanded] = useState(true);
     const [isOAuthExpanded, setIsOAuthExpanded] = useState(Boolean(serverConfig.clientID));
     const unnamedServerLabel = intl.formatMessage(
         {defaultMessage: 'Server {number}'},
@@ -251,31 +253,48 @@ const MCPServer = ({
         }
     };
 
+    const displayName = config.name || unnamedServerLabel;
+
     return (
-        <ServerContainer>
-            <ServerHeader>
-                {isEditingName ? (
-                    <ServerNameEditContainer>
-                        <ServerNameInput
-                            value={serverName}
-                            onChange={(e) => setServerName(e.target.value)}
-                            onBlur={handleRename}
-                            onKeyDown={handleKeyDown}
-                            autoFocus={true}
-                            placeholder={intl.formatMessage({defaultMessage: 'Server name'})}
-                        />
-                    </ServerNameEditContainer>
-                ) : (
-                    <ServerTitle onClick={() => setIsEditingName(true)}>
-                        {config.name || unnamedServerLabel}
-                    </ServerTitle>
-                )}
-                <DeleteButton onClick={onDelete}>
+        <Accordion
+            variant='card'
+            title={isEditingName ? (
+                <ServerNameInput
+                    value={serverName}
+                    onChange={(e) => setServerName(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onBlur={handleRename}
+                    onKeyDown={handleKeyDown}
+                    autoFocus={true}
+                    placeholder={intl.formatMessage({defaultMessage: 'Server name'})}
+                />
+            ) : (
+                <ServerTitle
+                    onClick={(e) => {
+                        if (!isExpanded) {
+                            return;
+                        }
+                        e.stopPropagation();
+                        setIsEditingName(true);
+                    }}
+                >
+                    {displayName}
+                </ServerTitle>
+            )}
+            expanded={isExpanded}
+            onToggle={() => setIsExpanded(!isExpanded)}
+            headerExtra={(
+                <DeleteButton
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete();
+                    }}
+                >
                     <TrashCanOutlineIcon size={16}/>
                     <FormattedMessage defaultMessage='Delete Server'/>
                 </DeleteButton>
-            </ServerHeader>
-
+            )}
+        >
             <BooleanItem
                 label={intl.formatMessage({defaultMessage: 'Enable Server'})}
                 value={config.enabled}
@@ -317,59 +336,40 @@ const MCPServer = ({
                 />
             </HeadersSection>
 
-            <OAuthSection>
-                <OAuthSectionHeader
-                    role='button'
-                    tabIndex={0}
-                    aria-expanded={isOAuthExpanded}
-                    aria-controls={`oauth-section-content-${serverIndex}`}
-                    onClick={() => setIsOAuthExpanded(!isOAuthExpanded)}
-                    onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            setIsOAuthExpanded(!isOAuthExpanded);
-                        }
-                    }}
-                >
-                    <OAuthSectionHeaderLeft>
-                        {isOAuthExpanded ? <ChevronDownIcon size={16}/> : <ChevronRightIcon size={16}/>}
-                        <OAuthSectionTitle>
-                            {intl.formatMessage({defaultMessage: 'OAuth Credentials (Optional)'})}
-                        </OAuthSectionTitle>
-                    </OAuthSectionHeaderLeft>
-                    {!isOAuthExpanded && config.clientID && (
-                        <OAuthConfiguredBadge>
-                            <FormattedMessage defaultMessage='Configured'/>
-                        </OAuthConfiguredBadge>
-                    )}
-                </OAuthSectionHeader>
-                {isOAuthExpanded && (
-                    <OAuthSectionContent id={`oauth-section-content-${serverIndex}`}>
-                        <SectionHelpText>
-                            {intl.formatMessage({defaultMessage: 'For MCP servers that require a pre-registered OAuth application (e.g. GitHub). Leave empty if the server supports automatic registration.'})}
-                        </SectionHelpText>
-                        <TextItem
-                            label={intl.formatMessage({defaultMessage: 'Client ID'})}
-                            value={config.clientID}
-                            onChange={(e) => onChange(serverIndex, {
-                                ...config,
-                                clientID: e.target.value,
-                            })}
-                            helptext={intl.formatMessage({defaultMessage: 'The OAuth application client ID.'})}
-                        />
-                        <TextItem
-                            label={intl.formatMessage({defaultMessage: 'Client Secret'})}
-                            value={config.clientSecret}
-                            type='password'
-                            onChange={(e) => onChange(serverIndex, {
-                                ...config,
-                                clientSecret: e.target.value,
-                            })}
-                            helptext={intl.formatMessage({defaultMessage: 'The OAuth application client secret.'})}
-                        />
-                    </OAuthSectionContent>
-                )}
-            </OAuthSection>
+            <Accordion
+                title={intl.formatMessage({defaultMessage: 'OAuth Credentials (Optional)'})}
+                expanded={isOAuthExpanded}
+                onToggle={() => setIsOAuthExpanded(!isOAuthExpanded)}
+                contentId={`oauth-section-content-${serverIndex}`}
+                badge={!isOAuthExpanded && config.clientID ? (
+                    <OAuthConfiguredBadge>
+                        <FormattedMessage defaultMessage='Configured'/>
+                    </OAuthConfiguredBadge>
+                ) : undefined}
+            >
+                <SectionHelpText>
+                    {intl.formatMessage({defaultMessage: 'For MCP servers that require a pre-registered OAuth application (e.g. GitHub). Leave empty if the server supports automatic registration.'})}
+                </SectionHelpText>
+                <TextItem
+                    label={intl.formatMessage({defaultMessage: 'Client ID'})}
+                    value={config.clientID}
+                    onChange={(e) => onChange(serverIndex, {
+                        ...config,
+                        clientID: e.target.value,
+                    })}
+                    helptext={intl.formatMessage({defaultMessage: 'The OAuth application client ID.'})}
+                />
+                <TextItem
+                    label={intl.formatMessage({defaultMessage: 'Client Secret'})}
+                    value={config.clientSecret}
+                    type='password'
+                    onChange={(e) => onChange(serverIndex, {
+                        ...config,
+                        clientSecret: e.target.value,
+                    })}
+                    helptext={intl.formatMessage({defaultMessage: 'The OAuth application client secret.'})}
+                />
+            </Accordion>
 
             {/* IDs are minted server-side on save, so any id-bearing entry is
                 persisted and policy authoring is safe. */}
@@ -377,10 +377,10 @@ const MCPServer = ({
                 <ConsolePolicySection
                     resourceType='mcp'
                     resourceId={config.id}
-                    resourceDisplayName={config.name || unnamedServerLabel}
+                    resourceDisplayName={displayName}
                 />
             )}
-        </ServerContainer>
+        </Accordion>
     );
 };
 
@@ -663,31 +663,14 @@ const MCPServers = ({mcpConfig, onChange}: Props) => {
 const ServersList = styled.div`
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 16px;
     margin-top: 16px;
     margin-bottom: 16px;
+    text-align: left;
 `;
 
-const ServerContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-    border-radius: 4px;
-    padding: 16px;
-    background-color: var(--center-channel-bg);
-`;
-
-const ServerHeader = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-`;
-
-const ServerTitle = styled.div`
-    font-weight: 600;
-    font-size: 16px;
-    color: var(--center-channel-color);
+const ServerTitle = styled.span`
     cursor: pointer;
     padding: 4px 8px;
     border-radius: 4px;
@@ -730,7 +713,9 @@ const DeleteButton = styled.button`
 const HeadersSection = styled.div`
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 12px;
+    text-align: left;
 `;
 
 const HeadersSectionTitle = styled.div`
@@ -740,40 +725,6 @@ const HeadersSectionTitle = styled.div`
     margin-bottom: 4px;
 `;
 
-const OAuthSection = styled.div`
-    display: flex;
-    flex-direction: column;
-    border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-    border-radius: 4px;
-    overflow: hidden;
-`;
-
-const OAuthSectionHeader = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 12px;
-    cursor: pointer;
-    background-color: rgba(var(--center-channel-color-rgb), 0.02);
-
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-    }
-`;
-
-const OAuthSectionHeaderLeft = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: rgba(var(--center-channel-color-rgb), 0.56);
-`;
-
-const OAuthSectionTitle = styled.div`
-    font-weight: 600;
-    font-size: 13px;
-    color: rgba(var(--center-channel-color-rgb), 0.72);
-`;
-
 const OAuthConfiguredBadge = styled.div`
     font-size: 11px;
     font-weight: 600;
@@ -781,14 +732,6 @@ const OAuthConfiguredBadge = styled.div`
     padding: 2px 8px;
     background-color: rgba(var(--online-indicator-rgb), 0.08);
     border-radius: 10px;
-`;
-
-const OAuthSectionContent = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    padding: 12px;
-    border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
 `;
 
 const SectionHelpText = styled.div`
@@ -876,7 +819,7 @@ const PlusServerIcon = styled(PlusIcon)`
 
 const EmptyState = styled.div`
     padding: 24px;
-    text-align: center;
+    text-align: left;
     color: rgba(var(--center-channel-color-rgb), 0.64);
     background-color: rgba(var(--center-channel-color-rgb), 0.04);
     border-radius: 4px;
@@ -904,13 +847,6 @@ const ServerNameInput = styled.input`
         border-color: var(--button-bg);
         outline: none;
     }
-`;
-
-const ServerNameEditContainer = styled.div`
-    display: flex;
-    align-items: center;
-    width: 100%;
-    max-width: 300px;
 `;
 
 const TabsContainer = styled.div`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Styles the System Console MCP server list so Access policy, OAuth credentials, and each MCP server share the same left-aligned accordion treatment.

- **Access policy** uses the same boxed accordion chrome as **OAuth Credentials (Optional)** (gray header, border, left-aligned chevron + title).
- **Each remote and built-in/plugin MCP server** is a collapsible accordion. Nested OAuth and Access policy sections stay independent accordions inside the server body.
- Console content in these sections is left-aligned.

This builds on the ABAC host UI in #973.

#### Ticket Link
Follow-up UI polish for the MCP / Access policy console on `abac/enforcement-and-hosts`.

#### Screenshots
Verified with unit tests (no running Mattermost System Console in this environment):

- Remote MCP servers start expanded and collapse to a header
- OAuth credentials remain a nested accordion
- Access policy uses the same accordion header as OAuth
- Built-in/plugin MCP servers collapse independently

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4070dd05-4a0c-4d40-ad7a-f5c4a6b56f10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4070dd05-4a0c-4d40-ad7a-f5c4a6b56f10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent collapsible accordion sections throughout MCP server settings.
  - MCP server cards now open by default and can be collapsed to show a compact header.
  - OAuth credentials remain collapsed until selected, with configuration status displayed in the header.
  - Access policies are presented as collapsible sections alongside OAuth settings.
  - Built-in server details can be expanded or collapsed while keeping server names visible.

- **Bug Fixes**
  - Improved alignment and consistency across system console server and policy sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->