### PR TITLE
Backport MM-69856

### DIFF
--- a/meetings/meeting_summarization.go
+++ b/meetings/meeting_summarization.go
@@ -157,6 +157,11 @@ func (s *Service) newCallTranscriptionSummaryThread(bot *bots.Bot, requestingUse
 				s.pluginAPI.Log.Error("Error in call recording post", "error", reterr)
 			}
 		}()
+		defer func() {
+			if r := recover(); r != nil {
+				reterr = fmt.Errorf("panic summarizing transcription: %v", r)
+			}
+		}()
 
 		transcriptionFileID, err := GetCaptionsFileIDFromProps(transcriptionPost)
 		if err != nil {
@@ -239,6 +244,11 @@ func (s *Service) summarizeCallRecording(bot *bots.Bot, rootID string, requestin
 					s.pluginAPI.Log.Error("Failed to update post in error handling handleCallRecordingPost", "error", err)
 				}
 				s.pluginAPI.Log.Error("Error in call recording post", "error", reterr)
+			}
+		}()
+		defer func() {
+			if r := recover(); r != nil {
+				reterr = fmt.Errorf("panic summarizing call recording: %v", r)
 			}
 		}()
 

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -23,6 +23,10 @@ func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 	scanner := bufio.NewScanner(chat)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// Zoom chat lines are "HH:MM:SS <text>". Continuation/short lines lack a timestamp.
+		if len(line) < 9 {
+			continue
+		}
 		text := line[9:]
 		item := &astisub.Item{}
 		startAt, err := time.Parse("15:04:05", line[:8])

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -19,28 +19,34 @@ type Subtitles struct {
 
 func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 	storage := astisub.NewSubtitles()
+	zeroTime, err := time.Parse("15:04:05", "00:00:00")
+	if err != nil {
+		return nil, err
+	}
 
 	scanner := bufio.NewScanner(chat)
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Zoom chat lines are "HH:MM:SS <text>". Continuation/short lines lack a timestamp.
-		if len(line) < 9 {
+		// Timestamped Zoom lines are "HH:MM:SS <text>" (space or tab separator).
+		if len(line) >= 9 && (line[8] == ' ' || line[8] == '\t') {
+			if startAt, parseErr := time.Parse("15:04:05", line[:8]); parseErr == nil {
+				item := &astisub.Item{
+					StartAt: startAt.Sub(zeroTime),
+					EndAt:   startAt.Add(5 * time.Second).Sub(zeroTime),
+					Lines:   []astisub.Line{{Items: []astisub.LineItem{{Text: line[9:]}}}},
+				}
+				storage.Items = append(storage.Items, item)
+				continue
+			}
+		}
+		if len(storage.Items) == 0 {
 			continue
 		}
-		text := line[9:]
-		item := &astisub.Item{}
-		startAt, err := time.Parse("15:04:05", line[:8])
-		if err != nil {
-			return nil, err
-		}
-		zeroTime, err := time.Parse("15:04:05", "00:00:00")
-		if err != nil {
-			return nil, err
-		}
-		item.StartAt = startAt.Sub(zeroTime)
-		item.EndAt = startAt.Add(5 * time.Second).Sub(zeroTime)
-		item.Lines = append(item.Lines, astisub.Line{Items: []astisub.LineItem{{Text: text}}})
-		storage.Items = append(storage.Items, item)
+		last := storage.Items[len(storage.Items)-1]
+		last.Lines = append(last.Lines, astisub.Line{Items: []astisub.LineItem{{Text: line}}})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
 	}
 	return storage, nil
 }

--- a/subtitles/subtitles_test.go
+++ b/subtitles/subtitles_test.go
@@ -4,6 +4,8 @@
 package subtitles
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -58,11 +60,10 @@ func TestNewSubtitlesFromZoomChat(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		input           string
-		wantLLM         string
-		wantEmpty       bool
-		wantErrContains string
+		name      string
+		input     string
+		wantLLM   string
+		wantEmpty bool
 	}{
 		{
 			name: "valid zoom chat lines",
@@ -71,22 +72,36 @@ func TestNewSubtitlesFromZoomChat(t *testing.T) {
 			wantLLM: "00:01 to 00:06 - Alice: Hello everyone\n00:05 to 00:10 - Bob: Hi Alice",
 		},
 		{
-			name: "short continuation lines are skipped",
+			name: "short continuation lines append to previous item",
 			input: `00:00:01 Alice: Hello
 x
 00:00:05 Bob: Hi
 ab`,
-			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+			wantLLM: "00:01 to 00:06 - Alice: Hello - x\n00:05 to 00:10 - Bob: Hi - ab",
 		},
 		{
-			name:      "only short lines yields empty subtitles",
-			input:     "x\nab\n",
+			name: "long continuation lines append instead of failing parse",
+			input: `00:00:01 Alice: Hello
+more of the message here
+00:00:05 Bob: Hi`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello - more of the message here\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name:      "only non-timestamp lines yields empty subtitles",
+			input:     "x\nnot-time More text here\n",
 			wantEmpty: true,
 		},
 		{
-			name:            "invalid timestamp returns error",
-			input:           "not-time More text here",
-			wantErrContains: "parsing time",
+			name: "tab-separated timestamp lines are accepted",
+			input: "00:00:01\tAlice: Hello\n" +
+				"00:00:05\tBob: Hi",
+			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name: "malformed timestamp separator appends as continuation",
+			input: `00:00:01 Alice: Hello
+00:00:05XBob: Hi`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello - 00:00:05XBob: Hi",
 		},
 	}
 
@@ -100,11 +115,6 @@ ab`,
 				subs, err = NewSubtitlesFromZoomChat(strings.NewReader(tc.input))
 			})
 
-			if tc.wantErrContains != "" {
-				require.ErrorContains(t, err, tc.wantErrContains)
-				return
-			}
-
 			require.NoError(t, err)
 			require.NotNil(t, subs)
 			if tc.wantEmpty {
@@ -114,4 +124,25 @@ ab`,
 			require.Equal(t, tc.wantLLM, subs.FormatForLLM())
 		})
 	}
+}
+
+func TestNewSubtitlesFromZoomChatScannerError(t *testing.T) {
+	t.Parallel()
+
+	reader := io.MultiReader(
+		strings.NewReader("00:00:01 Alice: Hello\n"),
+		errReader{err: errors.New("read failed")},
+	)
+
+	subs, err := NewSubtitlesFromZoomChat(reader)
+	require.ErrorContains(t, err, "read failed")
+	require.Nil(t, subs)
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
 }

--- a/subtitles/subtitles_test.go
+++ b/subtitles/subtitles_test.go
@@ -53,3 +53,65 @@ func TestFormatTextOnly(t *testing.T) {
 
 	require.Equal(t, expectedFormatTextOnly, subtitles.FormatTextOnly())
 }
+
+func TestNewSubtitlesFromZoomChat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		wantLLM         string
+		wantEmpty       bool
+		wantErrContains string
+	}{
+		{
+			name: "valid zoom chat lines",
+			input: `00:00:01 Alice: Hello everyone
+00:00:05 Bob: Hi Alice`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello everyone\n00:05 to 00:10 - Bob: Hi Alice",
+		},
+		{
+			name: "short continuation lines are skipped",
+			input: `00:00:01 Alice: Hello
+x
+00:00:05 Bob: Hi
+ab`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name:      "only short lines yields empty subtitles",
+			input:     "x\nab\n",
+			wantEmpty: true,
+		},
+		{
+			name:            "invalid timestamp returns error",
+			input:           "not-time More text here",
+			wantErrContains: "parsing time",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var subs *Subtitles
+			var err error
+			require.NotPanics(t, func() {
+				subs, err = NewSubtitlesFromZoomChat(strings.NewReader(tc.input))
+			})
+
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, err, tc.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, subs)
+			if tc.wantEmpty {
+				require.True(t, subs.IsEmpty())
+				return
+			}
+			require.Equal(t, tc.wantLLM, subs.FormatForLLM())
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Backport MM-69856

See: https://github.com/mattermost/mattermost-plugin-agents/pull/906
See: https://github.com/mattermost/mattermost-plugin-agents/pull/927

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-69856

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1e53a00-2e21-4f06-a250-bd51c5f5864f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1e53a00-2e21-4f06-a250-bd51c5f5864f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Zoom chat subtitle processing to recognize timestamps separated by spaces or tabs.
  - Continuation lines are now handled correctly, while unrelated or malformed lines are safely ignored.
  - Subtitle processing now continues reliably when chat content contains non-timestamped entries.
  - Asynchronous transcription-summary and call-recording workflows now recover from unexpected failures and report errors through existing status updates.

- **Tests**
  - Added coverage for valid timestamps, continuation lines, malformed input, empty results, and scanner errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->